### PR TITLE
Add pretty-print table output for UDS workflows

### DIFF
--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -835,6 +835,36 @@ def format_j1939_table(result: CommandResult) -> list[str]:
     return lines
 
 
+def format_uds_table(result: CommandResult) -> list[str]:
+    lines = [f"command: {result.command}", f"interface: {result.data.get('interface', 'unknown')}"]
+    events = result.data.get("events", [])
+    if result.command == "uds scan":
+        lines.append(f"responders: {result.data.get('responder_count', 0)}")
+    else:
+        lines.append(f"transactions: {result.data.get('transaction_count', 0)}")
+
+    lines.append("transactions:")
+    if not events:
+        lines.append("- no uds transactions")
+        return lines
+
+    for event in events:
+        payload = event["payload"]
+        ecu = payload["ecu_address"]
+        ecu_text = f"0x{ecu:02X}" if ecu is not None else "unknown"
+        lines.append(
+            "- "
+            f"service=0x{payload['service']:02X} "
+            f"name={payload['service_name']} "
+            f"ecu={ecu_text} "
+            f"req_id=0x{payload['request_id']:03X} "
+            f"resp_id=0x{payload['response_id']:03X} "
+            f"req={payload['request_data']} "
+            f"resp={payload['response_data']}"
+        )
+    return lines
+
+
 def format_candump_lines(result: CommandResult) -> list[str]:
     lines: list[str] = []
     for event in result.data.get("events", []):
@@ -902,6 +932,13 @@ def emit_result(result: CommandResult, output_format: str) -> None:
 
     if output_format == "table" and result.ok and result.command in J1939_COMMANDS:
         for line in format_j1939_table(result):
+            print(line)
+        for warning in payload["warnings"]:
+            print(f"warning: {warning}")
+        return
+
+    if output_format == "table" and result.ok and result.command in UDS_COMMANDS:
+        for line in format_uds_table(result):
             print(line)
         for warning in payload["warnings"]:
             print(f"warning: {warning}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -286,6 +286,27 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["data"]["events"][1]["payload"]["service"], 0x27)
         self.assertEqual(payload["data"]["events"][1]["payload"]["service_name"], "SecurityAccess")
 
+    def test_uds_scan_table_output_is_pretty_printed(self) -> None:
+        exit_code, stdout, stderr = run_cli("uds", "scan", "can0", "--table")
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertIn("command: uds scan", stdout)
+        self.assertIn("interface: can0", stdout)
+        self.assertIn("responders:", stdout)
+        self.assertIn("transactions:", stdout)
+        self.assertIn("service=0x10", stdout)
+        self.assertIn("name=DiagnosticSessionControl", stdout)
+        self.assertIn("req_id=0x7DF", stdout)
+        self.assertIn("resp_id=0x7E8", stdout)
+
+    def test_uds_trace_table_output_is_pretty_printed(self) -> None:
+        exit_code, stdout, stderr = run_cli("uds", "trace", "can0", "--table")
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertIn("command: uds trace", stdout)
+        self.assertIn("interface: can0", stdout)
+        self.assertIn("transactions:", stdout)
+        self.assertIn("service=0x27", stdout)
+        self.assertIn("name=SecurityAccess", stdout)
+
     def test_uds_transport_error_returns_backend_exit_code(self) -> None:
         exit_code, stdout, stderr = run_cli("uds", "scan", "offline0", "--json")
         self.assertEqual(exit_code, EXIT_TRANSPORT_ERROR)


### PR DESCRIPTION
## Summary
- Adds `format_uds_table()` to render `uds scan` and `uds trace` results in human-readable table format
- Wires UDS table output into `emit_result()` alongside existing JSON/JSONL paths
- Each transaction line includes service code, service name, ECU address, request/response IDs, and payload bytes

## Test plan
- [x] `uds scan can0 --table` renders service, ECU, req/resp IDs and payloads
- [x] `uds trace can0 --table` renders correctly
- [x] `uds scan can0 --json` and `--jsonl` output unchanged
- [x] All 72 tests pass

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)