### PR TITLE
feat: add opendbc as optional DBC provider

### DIFF
--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -41,13 +41,14 @@ EXIT_DECODE_ERROR = 3
 EXIT_PARTIAL_SUCCESS = 4
 TRANSPORT_COMMANDS = {"capture", "send", "filter", "stats", "generate"}
 DBC_COMMANDS = {"decode", "encode", "dbc inspect"}
+DBC_PROVIDER_COMMANDS = {"dbc provider list", "dbc search", "dbc fetch", "dbc cache list", "dbc cache prune", "dbc cache refresh"}
 J1939_COMMANDS = {"j1939 monitor", "j1939 decode", "j1939 pgn", "j1939 spn", "j1939 tp", "j1939 dm1"}
 SESSION_COMMANDS = {"session save", "session load", "session show"}
 UDS_COMMANDS = {"uds scan", "uds trace", "uds services"}
 CONFIG_COMMANDS = {"config show"}
 RE_COMMANDS = {"re counters", "re entropy"}
 ACTIVE_TRANSMIT_COMMANDS = {"send", "generate", "gateway", "uds scan"}
-IMPLEMENTED_COMMANDS = TRANSPORT_COMMANDS | DBC_COMMANDS | J1939_COMMANDS | SESSION_COMMANDS | UDS_COMMANDS | CONFIG_COMMANDS | RE_COMMANDS | {"mcp serve", "replay", "gateway", "shell", "export"}
+IMPLEMENTED_COMMANDS = TRANSPORT_COMMANDS | DBC_COMMANDS | DBC_PROVIDER_COMMANDS | J1939_COMMANDS | SESSION_COMMANDS | UDS_COMMANDS | CONFIG_COMMANDS | RE_COMMANDS | {"mcp serve", "replay", "gateway", "shell", "export"}
 
 
 class CliUsageError(Exception):
@@ -241,6 +242,42 @@ def build_parser() -> CanarchyArgumentParser:
     )
     add_output_arguments(dbc_inspect)
     dbc_inspect.set_defaults(command="dbc inspect")
+
+    dbc_provider = dbc_subparsers.add_parser("provider", help="manage DBC providers")
+    dbc_provider_subparsers = dbc_provider.add_subparsers(dest="dbc_provider_action", required=True)
+
+    dbc_provider_list = dbc_provider_subparsers.add_parser("list", help="list registered providers")
+    add_output_arguments(dbc_provider_list)
+    dbc_provider_list.set_defaults(command="dbc provider list")
+
+    dbc_search = dbc_subparsers.add_parser("search", help="search for DBC files across providers")
+    dbc_search.add_argument("query", help="search query (name, make, or keyword)")
+    dbc_search.add_argument("--provider", help="restrict search to a specific provider")
+    dbc_search.add_argument("--limit", type=int, default=20, help="maximum results (default: 20)")
+    add_output_arguments(dbc_search)
+    dbc_search.set_defaults(command="dbc search")
+
+    dbc_fetch = dbc_subparsers.add_parser("fetch", help="fetch and cache a DBC file")
+    dbc_fetch.add_argument("ref", help="DBC ref (e.g. opendbc:toyota_tnga_k_pt_generated)")
+    add_output_arguments(dbc_fetch)
+    dbc_fetch.set_defaults(command="dbc fetch")
+
+    dbc_cache = dbc_subparsers.add_parser("cache", help="manage the local DBC cache")
+    dbc_cache_subparsers = dbc_cache.add_subparsers(dest="dbc_cache_action", required=True)
+
+    dbc_cache_list = dbc_cache_subparsers.add_parser("list", help="list cached providers")
+    add_output_arguments(dbc_cache_list)
+    dbc_cache_list.set_defaults(command="dbc cache list")
+
+    dbc_cache_prune = dbc_cache_subparsers.add_parser("prune", help="remove stale cached commits")
+    dbc_cache_prune.add_argument("--provider", help="restrict to a specific provider")
+    add_output_arguments(dbc_cache_prune)
+    dbc_cache_prune.set_defaults(command="dbc cache prune")
+
+    dbc_cache_refresh = dbc_cache_subparsers.add_parser("refresh", help="refresh catalog from upstream")
+    dbc_cache_refresh.add_argument("--provider", default="opendbc", help="provider to refresh (default: opendbc)")
+    add_output_arguments(dbc_cache_refresh)
+    dbc_cache_refresh.set_defaults(command="dbc cache refresh")
 
     export = subparsers.add_parser("export", help="export session data")
     export.add_argument("source")
@@ -1163,6 +1200,84 @@ def dbc_payload(args: argparse.Namespace) -> tuple[dict[str, Any], list[dict[str
     raise AssertionError(f"unsupported dbc command: {args.command}")
 
 
+def dbc_provider_payload(args: argparse.Namespace) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
+    from canarchy.dbc_provider import get_registry
+    from canarchy.dbc_cache import cache_list, cache_prune
+
+    if args.command == "dbc provider list":
+        registry = get_registry()
+        providers = registry.list_providers()
+        return ({"providers": providers}, [], [])
+
+    if args.command == "dbc search":
+        registry = get_registry()
+        provider_filter = [args.provider] if getattr(args, "provider", None) else None
+        limit = getattr(args, "limit", 20)
+        results = registry.search(args.query, providers=provider_filter)[:limit]
+        items = [
+            {
+                "provider": d.provider,
+                "name": d.name,
+                "version": d.version,
+                "source_ref": d.source_ref,
+                "metadata": d.metadata,
+            }
+            for d in results
+        ]
+        warnings: list[str] = []
+        if not items:
+            warnings.append("No DBC files matched the query. Try `canarchy dbc cache refresh --provider opendbc` to populate the catalog.")
+        return ({"query": args.query, "count": len(items), "results": items}, [], warnings)
+
+    if args.command == "dbc fetch":
+        registry = get_registry()
+        resolution = registry.resolve(args.ref)
+        return (
+            {
+                "ref": args.ref,
+                "provider": resolution.descriptor.provider,
+                "name": resolution.descriptor.name,
+                "version": resolution.descriptor.version,
+                "local_path": str(resolution.local_path),
+                "is_cached": resolution.is_cached,
+            },
+            [],
+            [],
+        )
+
+    if args.command == "dbc cache list":
+        entries = cache_list()
+        return ({"entries": entries, "count": len(entries)}, [], [])
+
+    if args.command == "dbc cache prune":
+        provider_filter = getattr(args, "provider", None)
+        removed = cache_prune(provider_filter)
+        return ({"removed": removed, "count": len(removed)}, [], [])
+
+    if args.command == "dbc cache refresh":
+        provider_name = getattr(args, "provider", "opendbc")
+        registry = get_registry()
+        provider = registry.get_provider(provider_name)
+        if provider is None:
+            from canarchy.dbc import DbcError
+            raise DbcError(
+                code="DBC_PROVIDER_NOT_FOUND",
+                message=f"Provider '{provider_name}' is not registered.",
+                hint=f"Available providers: {', '.join(p['name'] for p in registry.list_providers())}.",
+            )
+        descriptors = provider.refresh()
+        return (
+            {
+                "provider": provider_name,
+                "dbc_count": len(descriptors),
+            },
+            [],
+            [],
+        )
+
+    raise AssertionError(f"unsupported dbc provider command: {args.command}")
+
+
 def uds_payload(args: argparse.Namespace) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
     transport = LocalTransport()
     backend_metadata = transport.backend_metadata()
@@ -1359,6 +1474,9 @@ def build_events(args: argparse.Namespace) -> list[dict[str, Any]]:
     if args.command in DBC_COMMANDS:
         _, events, _ = dbc_payload(args)
         return events
+    if args.command in DBC_PROVIDER_COMMANDS:
+        _, events, _ = dbc_provider_payload(args)
+        return events
     if args.command in J1939_COMMANDS:
         _, events, _ = j1939_payload(args)
         return events
@@ -1422,6 +1540,11 @@ def build_result(args: argparse.Namespace) -> CommandResult:
         data.update(decode_data)
         data["events"] = decode_events
         warnings.extend(decode_warnings)
+    elif args.command in DBC_PROVIDER_COMMANDS:
+        prov_data, prov_events, prov_warnings = dbc_provider_payload(args)
+        data.update(prov_data)
+        data["events"] = prov_events
+        warnings.extend(prov_warnings)
     elif args.command in UDS_COMMANDS:
         uds_data, uds_events, uds_warnings = uds_payload(args)
         data.update(uds_data)
@@ -1703,6 +1826,58 @@ def format_candump_frame(frame: dict[str, Any]) -> str:
     return f"{frame_id}#{frame['data'].upper()}"
 
 
+def format_dbc_table(result: CommandResult) -> list[str]:
+    lines = [f"command: {result.command}"]
+    db = result.data.get("database", {})
+    if db:
+        lines.append(f"path: {db.get('path', '')}")
+        lines.append(f"messages: {db.get('message_count', 0)}")
+        lines.append(f"signals: {db.get('signal_count', 0)}")
+    for message in result.data.get("messages", []):
+        lines.append(
+            f"  [{message.get('arbitration_id_hex', '')}] {message.get('name', '')} "
+            f"({message.get('signal_count', 0)} signals, {message.get('length', 0)} bytes)"
+        )
+        for signal in message.get("signals", []):
+            unit = f" [{signal['unit']}]" if signal.get("unit") else ""
+            lines.append(f"    {signal['name']}: {signal.get('byte_order', '')} {signal.get('length', '')}bit{unit}")
+    return lines
+
+
+def format_dbc_provider_table(result: CommandResult) -> list[str]:
+    lines = [f"command: {result.command}"]
+    if result.command == "dbc provider list":
+        for p in result.data.get("providers", []):
+            lines.append(f"  {p['name']}")
+    elif result.command == "dbc search":
+        lines.append(f"query: {result.data.get('query', '')}")
+        lines.append(f"results: {result.data.get('count', 0)}")
+        for item in result.data.get("results", []):
+            brand = item.get("metadata", {}).get("brand", "")
+            brand_text = f" ({brand})" if brand else ""
+            lines.append(f"  {item['source_ref']}{brand_text}")
+    elif result.command == "dbc fetch":
+        lines.append(f"ref: {result.data.get('ref', '')}")
+        lines.append(f"name: {result.data.get('name', '')}")
+        lines.append(f"version: {result.data.get('version', '')}")
+        lines.append(f"path: {result.data.get('local_path', '')}")
+    elif result.command == "dbc cache list":
+        for entry in result.data.get("entries", []):
+            lines.append(
+                f"  {entry['provider']}  commit={entry.get('commit', 'unknown')[:12]}  "
+                f"dbcs={entry.get('dbc_count', 0)}"
+            )
+    elif result.command == "dbc cache prune":
+        removed = result.data.get("removed", [])
+        lines.append(f"removed: {len(removed)}")
+        for path in removed:
+            lines.append(f"  {path}")
+    elif result.command == "dbc cache refresh":
+        lines.append(f"provider: {result.data.get('provider', '')}")
+        lines.append(f"dbc_count: {result.data.get('dbc_count', 0)}")
+    return lines
+
+
 def emit_live_capture(args: argparse.Namespace, output_format: str) -> int:
     """Stream live capture frames until Ctrl+C, honouring *output_format*.
 
@@ -1846,6 +2021,13 @@ def emit_result(result: CommandResult, output_format: str) -> None:
 
     if output_format == "table" and result.ok and result.command == "dbc inspect":
         for line in format_dbc_table(result):
+            print(line)
+        for warning in payload["warnings"]:
+            print(f"warning: {warning}")
+        return
+
+    if output_format == "table" and result.ok and result.command in DBC_PROVIDER_COMMANDS:
+        for line in format_dbc_provider_table(result):
             print(line)
         for warning in payload["warnings"]:
             print(f"warning: {warning}")

--- a/src/canarchy/dbc_cache.py
+++ b/src/canarchy/dbc_cache.py
@@ -1,0 +1,162 @@
+"""Cache directory management for DBC provider files."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+_CACHE_ROOT = Path.home() / ".canarchy" / "cache" / "dbc"
+_CONFIG_PATH = Path.home() / ".canarchy" / "config.toml"
+
+
+def cache_root() -> Path:
+    return _CACHE_ROOT
+
+
+def provider_cache_dir(provider_name: str) -> Path:
+    return _CACHE_ROOT / "providers" / provider_name
+
+
+def provider_manifest_path(provider_name: str) -> Path:
+    return provider_cache_dir(provider_name) / "manifest.json"
+
+
+def load_manifest(provider_name: str) -> dict[str, Any] | None:
+    path = provider_manifest_path(provider_name)
+    if not path.exists():
+        return None
+    with path.open() as f:
+        return json.load(f)
+
+
+def save_manifest(provider_name: str, manifest: dict[str, Any]) -> None:
+    path = provider_manifest_path(provider_name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        json.dump(manifest, f, indent=2)
+
+
+def cached_file_dir(provider_name: str, commit: str) -> Path:
+    return provider_cache_dir(provider_name) / "files" / commit
+
+
+def cached_file_path(provider_name: str, commit: str, filename: str) -> Path:
+    return cached_file_dir(provider_name, commit) / filename
+
+
+def sha256_of_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def cache_list() -> list[dict[str, Any]]:
+    """Return a summary of all cached provider manifests."""
+    results = []
+    providers_dir = _CACHE_ROOT / "providers"
+    if not providers_dir.exists():
+        return results
+    for provider_dir in sorted(providers_dir.iterdir()):
+        manifest_path = provider_dir / "manifest.json"
+        if not manifest_path.exists():
+            continue
+        with manifest_path.open() as f:
+            manifest = json.load(f)
+        dbc_count = len(manifest.get("dbcs", []))
+        results.append(
+            {
+                "provider": manifest.get("provider", provider_dir.name),
+                "repo": manifest.get("repo"),
+                "commit": manifest.get("commit"),
+                "generated_at": manifest.get("generated_at"),
+                "dbc_count": dbc_count,
+                "cache_dir": str(provider_dir),
+            }
+        )
+    return results
+
+
+def cache_prune(provider_name: str | None = None) -> list[str]:
+    """Remove stale commit snapshots, keeping only the pinned commit. Returns removed paths."""
+    removed = []
+    providers_dir = _CACHE_ROOT / "providers"
+    if not providers_dir.exists():
+        return removed
+
+    targets = (
+        [providers_dir / provider_name]
+        if provider_name
+        else list(providers_dir.iterdir())
+    )
+    for provider_dir in targets:
+        if not provider_dir.is_dir():
+            continue
+        manifest_path = provider_dir / "manifest.json"
+        if not manifest_path.exists():
+            continue
+        with manifest_path.open() as f:
+            manifest = json.load(f)
+        pinned_commit = manifest.get("commit")
+        files_dir = provider_dir / "files"
+        if not files_dir.exists():
+            continue
+        for commit_dir in files_dir.iterdir():
+            if commit_dir.name != pinned_commit:
+                import shutil
+                shutil.rmtree(commit_dir)
+                removed.append(str(commit_dir))
+    return removed
+
+
+def load_dbc_config() -> dict[str, Any]:
+    """Return the [dbc] section from ~/.canarchy/config.toml, or defaults."""
+    defaults: dict[str, Any] = {
+        "default_provider": os.environ.get("CANARCHY_DBC_DEFAULT_PROVIDER", "local"),
+        "search_order": ["local", "opendbc"],
+        "providers": {
+            "opendbc": {
+                "enabled": True,
+                "mode": "cache",
+                "repo": os.environ.get("CANARCHY_DBC_OPENDBC_REPO", "commaai/opendbc"),
+                "ref": os.environ.get("CANARCHY_DBC_OPENDBC_REF", "master"),
+                "auto_refresh": False,
+            }
+        },
+    }
+    if not _CONFIG_PATH.exists():
+        return defaults
+
+    try:
+        import tomllib
+    except ImportError:
+        return defaults
+
+    try:
+        with _CONFIG_PATH.open("rb") as f:
+            raw = tomllib.load(f)
+    except Exception:
+        return defaults
+
+    dbc_section = raw.get("dbc", {})
+    if not dbc_section:
+        return defaults
+
+    # Merge top-level keys.
+    result = dict(defaults)
+    for key in ("default_provider", "search_order"):
+        if key in dbc_section:
+            result[key] = dbc_section[key]
+
+    # Merge provider sub-sections.
+    if "providers" in dbc_section:
+        for pname, pconfig in dbc_section["providers"].items():
+            if pname not in result["providers"]:
+                result["providers"][pname] = {}
+            result["providers"][pname].update(pconfig)
+
+    return result

--- a/src/canarchy/dbc_opendbc.py
+++ b/src/canarchy/dbc_opendbc.py
@@ -1,0 +1,218 @@
+"""opendbc catalog provider: fetches DBC files from commaai/opendbc via GitHub API."""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from canarchy.dbc import DbcError
+from canarchy.dbc_provider import DbcDescriptor, DbcResolution
+
+_GITHUB_API = "https://api.github.com"
+_RAW_BASE = "https://raw.githubusercontent.com"
+
+
+def _github_get(url: str) -> Any:
+    req = urllib.request.Request(url, headers={"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"})
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read())
+
+
+def _resolve_commit(repo: str, ref: str) -> str:
+    data = _github_get(f"{_GITHUB_API}/repos/{repo}/commits/{ref}")
+    return data["sha"]
+
+
+def _list_dbc_files(repo: str, commit: str) -> list[dict[str, str]]:
+    """Return list of {name, path, sha} for all .dbc files under opendbc/dbc/."""
+    tree_data = _github_get(
+        f"{_GITHUB_API}/repos/{repo}/git/trees/{commit}?recursive=1"
+    )
+    results = []
+    for item in tree_data.get("tree", []):
+        path = item.get("path", "")
+        if path.startswith("opendbc/dbc/") and path.endswith(".dbc"):
+            results.append(
+                {
+                    "name": Path(path).stem,
+                    "path": path,
+                    "sha": item.get("sha", ""),
+                }
+            )
+    return results
+
+
+def _download_file(repo: str, commit: str, path: str, dest: Path) -> None:
+    url = f"{_RAW_BASE}/{repo}/{commit}/{path}"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    req = urllib.request.Request(url)
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        dest.write_bytes(resp.read())
+
+
+def _make_descriptor(entry: dict[str, str], commit: str, cache_path: Path | None) -> DbcDescriptor:
+    brand = _infer_brand(entry["name"])
+    return DbcDescriptor(
+        provider="opendbc",
+        name=entry["name"],
+        version=commit[:12],
+        source_ref=f"opendbc:{entry['name']}",
+        cache_path=cache_path,
+        sha256=None,
+        metadata={"path": entry["path"], "brand": brand},
+    )
+
+
+def _infer_brand(name: str) -> str | None:
+    prefixes = [
+        "toyota", "honda", "ford", "gm", "chevrolet", "cadillac", "buick",
+        "chrysler", "dodge", "jeep", "ram", "hyundai", "kia", "genesis",
+        "subaru", "volkswagen", "audi", "bmw", "mercedes", "nissan", "mazda",
+        "volvo", "tesla", "rivian", "acura", "infiniti", "lexus",
+    ]
+    lower = name.lower()
+    for prefix in prefixes:
+        if lower.startswith(prefix):
+            return prefix
+    return None
+
+
+def _score_match(name: str, query: str) -> int:
+    lower_name = name.lower()
+    lower_query = query.lower()
+    if lower_name == lower_query:
+        return 100
+    if lower_name.startswith(lower_query):
+        return 80
+    if lower_query in lower_name:
+        return 60
+    words = lower_query.split()
+    if all(w in lower_name for w in words):
+        return 40
+    if any(w in lower_name for w in words):
+        return 20
+    return 0
+
+
+class OpenDbcProvider:
+    name = "opendbc"
+
+    def __init__(self) -> None:
+        from canarchy.dbc_cache import load_dbc_config
+
+        cfg = load_dbc_config()
+        opendbc_cfg = cfg.get("providers", {}).get("opendbc", {})
+        self._repo: str = opendbc_cfg.get("repo", "commaai/opendbc")
+        self._ref: str = opendbc_cfg.get("ref", "master")
+        self._auto_refresh: bool = bool(opendbc_cfg.get("auto_refresh", False))
+
+    def _manifest(self) -> dict[str, Any] | None:
+        from canarchy.dbc_cache import load_manifest
+
+        return load_manifest("opendbc")
+
+    def _catalog(self) -> list[dict[str, str]]:
+        manifest = self._manifest()
+        if manifest is None:
+            return []
+        return manifest.get("dbcs", [])
+
+    def _commit(self) -> str | None:
+        manifest = self._manifest()
+        if manifest is None:
+            return None
+        return manifest.get("commit")
+
+    def search(self, query: str, limit: int = 20) -> list[DbcDescriptor]:
+        catalog = self._catalog()
+        if not catalog:
+            return []
+        commit = self._commit() or ""
+        scored = [
+            (entry, _score_match(entry["name"], query))
+            for entry in catalog
+        ]
+        scored = [(e, s) for e, s in scored if s > 0]
+        scored.sort(key=lambda x: x[1], reverse=True)
+        return [
+            _make_descriptor(entry, commit, None)
+            for entry, _ in scored[:limit]
+        ]
+
+    def resolve(self, ref: str) -> DbcResolution:
+        from canarchy.dbc_cache import cached_file_path, provider_cache_dir
+
+        manifest = self._manifest()
+        if manifest is None:
+            if self._auto_refresh:
+                self.refresh()
+                manifest = self._manifest()
+            if manifest is None:
+                raise DbcError(
+                    code="DBC_CACHE_MISS",
+                    message=f"opendbc catalog is not cached. Run `canarchy dbc cache refresh --provider opendbc` first.",
+                    hint="Run: canarchy dbc cache refresh --provider opendbc",
+                )
+
+        commit = manifest["commit"]
+        catalog = manifest.get("dbcs", [])
+        entry = next((e for e in catalog if e["name"] == ref), None)
+        if entry is None:
+            candidates = [e["name"] for e in catalog if ref.lower() in e["name"].lower()][:5]
+            raise DbcError(
+                code="DBC_NOT_FOUND",
+                message=f"DBC '{ref}' not found in opendbc catalog.",
+                hint=(
+                    f"Did you mean: {', '.join(candidates)}?"
+                    if candidates
+                    else "Run `canarchy dbc search <query> --provider opendbc` to find available DBCs."
+                ),
+            )
+
+        dest = cached_file_path("opendbc", commit, Path(entry["path"]).name)
+        if not dest.exists():
+            try:
+                _download_file(self._repo, commit, entry["path"], dest)
+            except Exception as exc:
+                raise DbcError(
+                    code="DBC_CACHE_STALE",
+                    message=f"Failed to download '{ref}' from opendbc.",
+                    hint="Check your network connection or re-run `canarchy dbc cache refresh --provider opendbc`.",
+                ) from exc
+
+        descriptor = _make_descriptor(entry, commit, dest)
+        return DbcResolution(descriptor=descriptor, local_path=dest, is_cached=True)
+
+    def refresh(self, ref: str | None = None) -> list[DbcDescriptor]:
+        from canarchy.dbc_cache import save_manifest
+
+        try:
+            commit = _resolve_commit(self._repo, self._ref)
+        except Exception as exc:
+            raise DbcError(
+                code="DBC_PROVIDER_NOT_FOUND",
+                message=f"Failed to resolve opendbc ref '{self._ref}' from {self._repo}.",
+                hint="Check your network connection and the configured repo/ref in ~/.canarchy/config.toml.",
+            ) from exc
+
+        try:
+            dbc_files = _list_dbc_files(self._repo, commit)
+        except Exception as exc:
+            raise DbcError(
+                code="DBC_PROVIDER_NOT_FOUND",
+                message="Failed to list DBC files from opendbc.",
+                hint="Check your network connection.",
+            ) from exc
+
+        manifest: dict[str, Any] = {
+            "provider": "opendbc",
+            "repo": self._repo,
+            "commit": commit,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "dbcs": dbc_files,
+        }
+        save_manifest("opendbc", manifest)
+        return [_make_descriptor(entry, commit, None) for entry in dbc_files]

--- a/src/canarchy/dbc_provider.py
+++ b/src/canarchy/dbc_provider.py
@@ -1,0 +1,165 @@
+"""DBC provider registry: type definitions, ref parsing, and provider dispatch."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal, Protocol, runtime_checkable
+
+from canarchy.dbc import DbcError
+
+ProviderKind = Literal["local", "opendbc"]
+
+_PROVIDER_ALIASES: dict[str, str] = {"comma": "opendbc"}
+
+
+@dataclass(frozen=True)
+class DbcDescriptor:
+    provider: ProviderKind
+    name: str
+    version: str | None
+    source_ref: str
+    cache_path: Path | None
+    sha256: str | None
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class DbcResolution:
+    descriptor: DbcDescriptor
+    local_path: Path
+    is_cached: bool
+
+
+@runtime_checkable
+class DbcProvider(Protocol):
+    name: str
+
+    def search(self, query: str, limit: int = 20) -> list[DbcDescriptor]: ...
+    def resolve(self, ref: str) -> DbcResolution: ...
+    def refresh(self, ref: str | None = None) -> list[DbcDescriptor]: ...
+
+
+def parse_provider_ref(ref: str) -> tuple[str | None, str]:
+    """Return (provider_name, logical_name) from a ref like 'opendbc:foo' or 'foo'."""
+    if ":" in ref:
+        prefix, name = ref.split(":", 1)
+        canonical = _PROVIDER_ALIASES.get(prefix, prefix)
+        return canonical, name
+    return None, ref
+
+
+class ProviderRegistry:
+    def __init__(self) -> None:
+        self._providers: dict[str, DbcProvider] = {}
+        self._search_order: list[str] = []
+
+    def register(self, provider: DbcProvider, *, prepend: bool = False) -> None:
+        self._providers[provider.name] = provider
+        if provider.name not in self._search_order:
+            if prepend:
+                self._search_order.insert(0, provider.name)
+            else:
+                self._search_order.append(provider.name)
+
+    def get_provider(self, name: str) -> DbcProvider | None:
+        return self._providers.get(name)
+
+    def resolve(self, ref: str) -> DbcResolution:
+        # 1. Explicit local path (absolute or relative) that exists on disk.
+        candidate = Path(ref)
+        if candidate.exists() and candidate.is_file():
+            from canarchy.dbc_provider_local import LocalDbcProvider
+
+            return LocalDbcProvider().resolve(ref)
+
+        # 2. Provider-prefixed ref: opendbc:<name> or comma:<name>.
+        provider_name, logical_name = parse_provider_ref(ref)
+        if provider_name is not None:
+            provider = self._providers.get(provider_name)
+            if provider is None:
+                raise DbcError(
+                    code="DBC_PROVIDER_NOT_FOUND",
+                    message=f"Unknown DBC provider '{provider_name}'.",
+                    hint=f"Registered providers: {', '.join(self._providers) or 'none'}.",
+                )
+            return provider.resolve(logical_name)
+
+        # 3. Bare name: search enabled providers in order.
+        candidates: list[DbcDescriptor] = []
+        for name in self._search_order:
+            provider = self._providers[name]
+            hits = provider.search(logical_name, limit=5)
+            candidates.extend(hits)
+            if hits:
+                exact = [d for d in hits if d.name == logical_name]
+                if exact:
+                    return self._providers[exact[0].provider].resolve(logical_name)
+
+        candidate_names = [d.name for d in candidates[:5]]
+        raise DbcError(
+            code="DBC_NOT_FOUND",
+            message=f"No DBC found for ref '{ref}'.",
+            hint=(
+                f"Did you mean: {', '.join(candidate_names)}?"
+                if candidate_names
+                else "Use an absolute/relative path, or 'opendbc:<name>' to search the opendbc catalog."
+            ),
+        )
+
+    def search(self, query: str, providers: list[str] | None = None) -> list[DbcDescriptor]:
+        names = providers if providers is not None else self._search_order
+        results: list[DbcDescriptor] = []
+        for name in names:
+            provider = self._providers.get(name)
+            if provider is None:
+                continue
+            results.extend(provider.search(query))
+        return results
+
+    def list_providers(self) -> list[dict]:
+        return [
+            {"name": name, "registered": True}
+            for name in self._search_order
+        ]
+
+
+_registry: ProviderRegistry | None = None
+
+
+def get_registry() -> ProviderRegistry:
+    global _registry
+    if _registry is None:
+        _registry = _build_default_registry()
+    return _registry
+
+
+def _build_default_registry() -> ProviderRegistry:
+    from canarchy.dbc_provider_local import LocalDbcProvider
+
+    registry = ProviderRegistry()
+    registry.register(LocalDbcProvider())
+
+    try:
+        from canarchy.dbc_opendbc import OpenDbcProvider
+        from canarchy.dbc_cache import load_dbc_config
+
+        cfg = load_dbc_config()
+        if cfg.get("providers", {}).get("opendbc", {}).get("enabled", True):
+            registry.register(OpenDbcProvider())
+    except Exception:
+        pass
+
+    return registry
+
+
+def reset_registry() -> None:
+    """Reset the module-level registry (used in tests)."""
+    global _registry
+    _registry = None
+
+
+def resolve_dbc_ref(ref: str) -> str:
+    """Resolve a DBC ref to a local file path string suitable for cantools."""
+    resolution = get_registry().resolve(ref)
+    return str(resolution.local_path)

--- a/src/canarchy/dbc_provider_local.py
+++ b/src/canarchy/dbc_provider_local.py
@@ -1,0 +1,43 @@
+"""Local filesystem DBC provider."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from canarchy.dbc import DbcError
+from canarchy.dbc_provider import DbcDescriptor, DbcResolution
+
+
+class LocalDbcProvider:
+    name = "local"
+
+    def search(self, query: str, limit: int = 20) -> list[DbcDescriptor]:
+        # Local provider resolves explicit paths only; no catalog to search.
+        return []
+
+    def resolve(self, ref: str) -> DbcResolution:
+        path = Path(ref)
+        if not path.exists():
+            raise DbcError(
+                code="DBC_NOT_FOUND",
+                message=f"DBC file '{ref}' was not found.",
+                hint="Pass a readable DBC file path with `--dbc`.",
+            )
+        if not path.is_file():
+            raise DbcError(
+                code="DBC_NOT_FOUND",
+                message=f"'{ref}' is not a file.",
+                hint="Pass a path to a .dbc file.",
+            )
+        descriptor = DbcDescriptor(
+            provider="local",
+            name=path.name,
+            version=None,
+            source_ref=ref,
+            cache_path=None,
+            sha256=None,
+        )
+        return DbcResolution(descriptor=descriptor, local_path=path.resolve(), is_cached=False)
+
+    def refresh(self, ref: str | None = None) -> list[DbcDescriptor]:
+        return []

--- a/src/canarchy/dbc_runtime.py
+++ b/src/canarchy/dbc_runtime.py
@@ -13,16 +13,15 @@ from canarchy.models import CanFrame, DecodedMessageEvent, FrameEvent, SignalVal
 
 
 def load_runtime_database(dbc_path: str) -> cantools.database.Database:
-    path = Path(dbc_path)
-    if not path.exists():
-        raise DbcError(
-            code="DBC_NOT_FOUND",
-            message=f"DBC file '{dbc_path}' was not found.",
-            hint="Pass a readable DBC file path with `--dbc`.",
-        )
+    from canarchy.dbc_provider import resolve_dbc_ref
+
+    resolved = resolve_dbc_ref(dbc_path)
+    path = Path(resolved)
 
     try:
         return cantools.database.load_file(str(path))
+    except DbcError:
+        raise
     except Exception as exc:  # pragma: no cover
         raise DbcError(
             code="DBC_LOAD_FAILED",

--- a/tests/test_dbc_provider.py
+++ b/tests/test_dbc_provider.py
@@ -1,0 +1,557 @@
+"""Tests for the DBC provider registry, cache, and opendbc provider."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from canarchy.cli import EXIT_DECODE_ERROR, EXIT_OK, main
+from canarchy.dbc import DbcError
+from canarchy.dbc_provider import (
+    DbcDescriptor,
+    DbcResolution,
+    ProviderRegistry,
+    parse_provider_ref,
+    reset_registry,
+)
+from canarchy.dbc_provider_local import LocalDbcProvider
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def run_cli(*argv: str) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        exit_code = main(argv)
+    return exit_code, stdout.getvalue(), stderr.getvalue()
+
+
+def tearDownModule() -> None:
+    reset_registry()
+
+
+class ParseProviderRefTests(unittest.TestCase):
+    def test_opendbc_prefix_extracted(self) -> None:
+        provider, name = parse_provider_ref("opendbc:toyota_tnga_k_pt_generated")
+        self.assertEqual(provider, "opendbc")
+        self.assertEqual(name, "toyota_tnga_k_pt_generated")
+
+    def test_comma_alias_normalized_to_opendbc(self) -> None:
+        provider, name = parse_provider_ref("comma:honda_civic")
+        self.assertEqual(provider, "opendbc")
+        self.assertEqual(name, "honda_civic")
+
+    def test_bare_name_returns_none_provider(self) -> None:
+        provider, name = parse_provider_ref("toyota_tnga_k_pt_generated")
+        self.assertIsNone(provider)
+        self.assertEqual(name, "toyota_tnga_k_pt_generated")
+
+    def test_local_path_has_no_provider(self) -> None:
+        provider, name = parse_provider_ref("/some/path/file.dbc")
+        self.assertIsNone(provider)
+        self.assertEqual(name, "/some/path/file.dbc")
+
+
+class LocalDbcProviderTests(unittest.TestCase):
+    def test_resolve_existing_file_returns_resolution(self) -> None:
+        provider = LocalDbcProvider()
+        resolution = provider.resolve(str(FIXTURES / "sample.dbc"))
+        self.assertEqual(resolution.descriptor.provider, "local")
+        self.assertEqual(resolution.descriptor.name, "sample.dbc")
+        self.assertFalse(resolution.is_cached)
+        self.assertTrue(resolution.local_path.exists())
+
+    def test_resolve_missing_file_raises_dbc_not_found(self) -> None:
+        provider = LocalDbcProvider()
+        with self.assertRaises(DbcError) as ctx:
+            provider.resolve("/does/not/exist.dbc")
+        self.assertEqual(ctx.exception.code, "DBC_NOT_FOUND")
+
+    def test_search_always_returns_empty(self) -> None:
+        provider = LocalDbcProvider()
+        self.assertEqual(provider.search("toyota"), [])
+
+    def test_refresh_always_returns_empty(self) -> None:
+        provider = LocalDbcProvider()
+        self.assertEqual(provider.refresh(), [])
+
+
+class ProviderRegistryTests(unittest.TestCase):
+    def _make_registry(self) -> ProviderRegistry:
+        registry = ProviderRegistry()
+        registry.register(LocalDbcProvider())
+        return registry
+
+    def test_resolve_existing_local_path(self) -> None:
+        registry = self._make_registry()
+        ref = str(FIXTURES / "sample.dbc")
+        resolution = registry.resolve(ref)
+        self.assertEqual(resolution.descriptor.provider, "local")
+        self.assertTrue(resolution.local_path.exists())
+
+    def test_resolve_missing_local_path_raises_not_found(self) -> None:
+        registry = self._make_registry()
+        with self.assertRaises(DbcError) as ctx:
+            registry.resolve("/no/such/file.dbc")
+        self.assertEqual(ctx.exception.code, "DBC_NOT_FOUND")
+
+    def test_resolve_unknown_provider_prefix_raises_provider_not_found(self) -> None:
+        registry = self._make_registry()
+        with self.assertRaises(DbcError) as ctx:
+            registry.resolve("unknown:some_dbc")
+        self.assertEqual(ctx.exception.code, "DBC_PROVIDER_NOT_FOUND")
+
+    def test_list_providers_returns_registered_names(self) -> None:
+        registry = self._make_registry()
+        names = [p["name"] for p in registry.list_providers()]
+        self.assertIn("local", names)
+
+    def test_get_provider_returns_registered_provider(self) -> None:
+        registry = self._make_registry()
+        provider = registry.get_provider("local")
+        self.assertIsNotNone(provider)
+        self.assertEqual(provider.name, "local")
+
+    def test_get_provider_returns_none_for_unknown(self) -> None:
+        registry = self._make_registry()
+        self.assertIsNone(registry.get_provider("opendbc"))
+
+
+class ProviderRegistryWithOpendbc(unittest.TestCase):
+    """Tests for opendbc provider routing when it's registered."""
+
+    def _make_mock_opendbc_provider(self) -> MagicMock:
+        mock = MagicMock()
+        mock.name = "opendbc"
+        mock.search.return_value = [
+            DbcDescriptor(
+                provider="opendbc",
+                name="toyota_tnga_k_pt_generated",
+                version="abc123",
+                source_ref="opendbc:toyota_tnga_k_pt_generated",
+                cache_path=None,
+                sha256=None,
+            )
+        ]
+        mock.resolve.return_value = DbcResolution(
+            descriptor=DbcDescriptor(
+                provider="opendbc",
+                name="toyota_tnga_k_pt_generated",
+                version="abc123",
+                source_ref="opendbc:toyota_tnga_k_pt_generated",
+                cache_path=None,
+                sha256=None,
+            ),
+            local_path=FIXTURES / "sample.dbc",
+            is_cached=True,
+        )
+        return mock
+
+    def test_opendbc_prefix_routes_to_opendbc_provider(self) -> None:
+        registry = ProviderRegistry()
+        registry.register(LocalDbcProvider())
+        mock_opendbc = self._make_mock_opendbc_provider()
+        registry.register(mock_opendbc)
+
+        resolution = registry.resolve("opendbc:toyota_tnga_k_pt_generated")
+        self.assertEqual(resolution.descriptor.provider, "opendbc")
+        mock_opendbc.resolve.assert_called_once_with("toyota_tnga_k_pt_generated")
+
+    def test_comma_alias_routes_to_opendbc_provider(self) -> None:
+        registry = ProviderRegistry()
+        registry.register(LocalDbcProvider())
+        mock_opendbc = self._make_mock_opendbc_provider()
+        registry.register(mock_opendbc)
+
+        registry.resolve("comma:toyota_tnga_k_pt_generated")
+        mock_opendbc.resolve.assert_called_once_with("toyota_tnga_k_pt_generated")
+
+    def test_search_aggregates_across_providers(self) -> None:
+        registry = ProviderRegistry()
+        registry.register(LocalDbcProvider())
+        mock_opendbc = self._make_mock_opendbc_provider()
+        registry.register(mock_opendbc)
+
+        results = registry.search("toyota")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].name, "toyota_tnga_k_pt_generated")
+
+
+class ProviderResolutionIntegrationTests(unittest.TestCase):
+    """Integration tests: provider resolution flows through to cantools."""
+
+    def test_existing_dbc_path_resolves_and_loads(self) -> None:
+        from canarchy.dbc_runtime import load_runtime_database
+
+        reset_registry()
+        db = load_runtime_database(str(FIXTURES / "sample.dbc"))
+        self.assertIsNotNone(db.get_message_by_name("EngineStatus1"))
+
+    def test_missing_dbc_path_raises_dbc_not_found(self) -> None:
+        from canarchy.dbc_runtime import load_runtime_database
+
+        reset_registry()
+        with self.assertRaises(DbcError) as ctx:
+            load_runtime_database("/does/not/exist.dbc")
+        self.assertEqual(ctx.exception.code, "DBC_NOT_FOUND")
+
+
+class CacheTests(unittest.TestCase):
+    def test_load_dbc_config_returns_defaults_when_no_config_file(self) -> None:
+        from canarchy.dbc_cache import load_dbc_config
+
+        with patch("canarchy.dbc_cache._CONFIG_PATH", Path("/does/not/exist/config.toml")):
+            cfg = load_dbc_config()
+        self.assertEqual(cfg["default_provider"], "local")
+        self.assertIn("opendbc", cfg["search_order"])
+        self.assertIn("opendbc", cfg["providers"])
+
+    def test_cache_list_returns_empty_when_no_cache(self) -> None:
+        from canarchy.dbc_cache import cache_list
+
+        with patch("canarchy.dbc_cache._CACHE_ROOT", Path("/does/not/exist/cache")):
+            entries = cache_list()
+        self.assertEqual(entries, [])
+
+    def test_cache_list_returns_manifest_entries(self) -> None:
+        from canarchy.dbc_cache import cache_list, save_manifest
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            with patch("canarchy.dbc_cache._CACHE_ROOT", cache_root):
+                save_manifest("opendbc", {
+                    "provider": "opendbc",
+                    "repo": "commaai/opendbc",
+                    "commit": "abc123def456",
+                    "generated_at": "2026-04-19T00:00:00Z",
+                    "dbcs": [{"name": "foo", "path": "opendbc/dbc/foo.dbc", "sha256": ""}],
+                })
+                entries = cache_list()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["provider"], "opendbc")
+        self.assertEqual(entries[0]["dbc_count"], 1)
+
+    def test_cache_prune_removes_stale_commit_dirs(self) -> None:
+        from canarchy.dbc_cache import cache_prune, save_manifest
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            with patch("canarchy.dbc_cache._CACHE_ROOT", cache_root):
+                save_manifest("opendbc", {
+                    "provider": "opendbc",
+                    "repo": "commaai/opendbc",
+                    "commit": "new123",
+                    "generated_at": "2026-04-19T00:00:00Z",
+                    "dbcs": [],
+                })
+                stale_dir = cache_root / "providers" / "opendbc" / "files" / "old456"
+                stale_dir.mkdir(parents=True)
+                (stale_dir / "foo.dbc").write_text("")
+                kept_dir = cache_root / "providers" / "opendbc" / "files" / "new123"
+                kept_dir.mkdir(parents=True)
+                (kept_dir / "foo.dbc").write_text("")
+
+                removed = cache_prune("opendbc")
+
+        self.assertEqual(len(removed), 1)
+        self.assertIn("old456", removed[0])
+
+
+class OpenDbcProviderTests(unittest.TestCase):
+    """Tests for OpenDbcProvider using mocked GitHub API responses."""
+
+    def _make_manifest(self, commit: str = "abc123def456") -> dict:
+        return {
+            "provider": "opendbc",
+            "repo": "commaai/opendbc",
+            "commit": commit,
+            "generated_at": "2026-04-19T00:00:00Z",
+            "dbcs": [
+                {"name": "toyota_tnga_k_pt_generated", "path": "opendbc/dbc/toyota_tnga_k_pt_generated.dbc", "sha": "sha1"},
+                {"name": "honda_civic_ex_2022", "path": "opendbc/dbc/honda_civic_ex_2022.dbc", "sha": "sha2"},
+            ],
+        }
+
+    def test_search_returns_ranked_matches_from_manifest(self) -> None:
+        from canarchy.dbc_opendbc import OpenDbcProvider
+
+        with patch("canarchy.dbc_cache.load_manifest", return_value=self._make_manifest()):
+            with patch("canarchy.dbc_cache.load_dbc_config", return_value={
+                "providers": {"opendbc": {"enabled": True, "repo": "commaai/opendbc", "ref": "master", "auto_refresh": False}}
+            }):
+                provider = OpenDbcProvider()
+                results = provider.search("toyota")
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].name, "toyota_tnga_k_pt_generated")
+        self.assertEqual(results[0].provider, "opendbc")
+
+    def test_search_returns_empty_when_no_manifest(self) -> None:
+        from canarchy.dbc_opendbc import OpenDbcProvider
+
+        with patch("canarchy.dbc_cache.load_manifest", return_value=None):
+            with patch("canarchy.dbc_cache.load_dbc_config", return_value={
+                "providers": {"opendbc": {"enabled": True, "repo": "commaai/opendbc", "ref": "master", "auto_refresh": False}}
+            }):
+                provider = OpenDbcProvider()
+                results = provider.search("toyota")
+
+        self.assertEqual(results, [])
+
+    def test_resolve_cached_file_returns_resolution(self) -> None:
+        from canarchy.dbc_opendbc import OpenDbcProvider
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            commit = "abc123def456"
+            cached = cache_root / "providers" / "opendbc" / "files" / commit / "toyota_tnga_k_pt_generated.dbc"
+            cached.parent.mkdir(parents=True)
+            cached.write_text("")
+
+            with patch("canarchy.dbc_cache.load_manifest", return_value=self._make_manifest(commit)):
+            	with patch("canarchy.dbc_cache.load_dbc_config", return_value={
+                    "providers": {"opendbc": {"enabled": True, "repo": "commaai/opendbc", "ref": "master", "auto_refresh": False}}
+                }):
+                    with patch("canarchy.dbc_cache.cached_file_path", return_value=cached):
+                        provider = OpenDbcProvider()
+                        resolution = provider.resolve("toyota_tnga_k_pt_generated")
+
+        self.assertEqual(resolution.descriptor.name, "toyota_tnga_k_pt_generated")
+        self.assertTrue(resolution.is_cached)
+        self.assertEqual(resolution.local_path, cached)
+
+    def test_resolve_unknown_name_raises_not_found(self) -> None:
+        from canarchy.dbc_opendbc import OpenDbcProvider
+
+        with patch("canarchy.dbc_cache.load_manifest", return_value=self._make_manifest()):
+            with patch("canarchy.dbc_cache.load_dbc_config", return_value={
+                "providers": {"opendbc": {"enabled": True, "repo": "commaai/opendbc", "ref": "master", "auto_refresh": False}}
+            }):
+                provider = OpenDbcProvider()
+                with self.assertRaises(DbcError) as ctx:
+                    provider.resolve("does_not_exist")
+
+        self.assertEqual(ctx.exception.code, "DBC_NOT_FOUND")
+
+    def test_resolve_without_manifest_raises_cache_miss(self) -> None:
+        from canarchy.dbc_opendbc import OpenDbcProvider
+
+        with patch("canarchy.dbc_cache.load_manifest", return_value=None):
+            with patch("canarchy.dbc_cache.load_dbc_config", return_value={
+                "providers": {"opendbc": {"enabled": True, "repo": "commaai/opendbc", "ref": "master", "auto_refresh": False}}
+            }):
+                provider = OpenDbcProvider()
+                with self.assertRaises(DbcError) as ctx:
+                    provider.resolve("toyota_tnga_k_pt_generated")
+
+        self.assertEqual(ctx.exception.code, "DBC_CACHE_MISS")
+
+    def test_refresh_saves_manifest(self) -> None:
+        from canarchy.dbc_opendbc import OpenDbcProvider, _github_get
+
+        commit = "freshcommit123"
+        api_responses = {
+            f"https://api.github.com/repos/commaai/opendbc/commits/master": {"sha": commit},
+            f"https://api.github.com/repos/commaai/opendbc/git/trees/{commit}?recursive=1": {
+                "tree": [
+                    {"path": "opendbc/dbc/toyota_tnga_k_pt_generated.dbc", "sha": "s1"},
+                    {"path": "opendbc/dbc/honda_civic_ex_2022.dbc", "sha": "s2"},
+                    {"path": "opendbc/car/toyota.py", "sha": "s3"},  # should be excluded
+                ]
+            },
+        }
+
+        saved: dict = {}
+
+        def mock_github_get(url: str):
+            return api_responses[url]
+
+        def mock_save_manifest(provider: str, manifest: dict) -> None:
+            saved.update(manifest)
+
+        with patch("canarchy.dbc_opendbc._github_get", side_effect=mock_github_get):
+            with patch("canarchy.dbc_cache.save_manifest", side_effect=mock_save_manifest):
+                with patch("canarchy.dbc_cache.load_dbc_config", return_value={
+                    "providers": {"opendbc": {"enabled": True, "repo": "commaai/opendbc", "ref": "master", "auto_refresh": False}}
+                }):
+                    provider = OpenDbcProvider()
+                    descriptors = provider.refresh()
+
+        self.assertEqual(saved["commit"], commit)
+        self.assertEqual(len(saved["dbcs"]), 2)
+        dbc_names = {d["name"] for d in saved["dbcs"]}
+        self.assertIn("toyota_tnga_k_pt_generated", dbc_names)
+        self.assertNotIn("toyota", dbc_names)  # car/ files excluded
+        self.assertEqual(len(descriptors), 2)
+
+
+class CliProviderCommandTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_registry()
+
+    def tearDown(self) -> None:
+        reset_registry()
+
+    def _make_mock_opendbc_provider(self) -> MagicMock:
+        mock = MagicMock()
+        mock.name = "opendbc"
+        mock.search.return_value = [
+            DbcDescriptor(
+                provider="opendbc",
+                name="toyota_tnga_k_pt_generated",
+                version="abc123",
+                source_ref="opendbc:toyota_tnga_k_pt_generated",
+                cache_path=None,
+                sha256=None,
+                metadata={"brand": "toyota"},
+            )
+        ]
+        mock.resolve.return_value = DbcResolution(
+            descriptor=DbcDescriptor(
+                provider="opendbc",
+                name="toyota_tnga_k_pt_generated",
+                version="abc123",
+                source_ref="opendbc:toyota_tnga_k_pt_generated",
+                cache_path=None,
+                sha256=None,
+            ),
+            local_path=FIXTURES / "sample.dbc",
+            is_cached=True,
+        )
+        mock.refresh.return_value = [
+            DbcDescriptor(
+                provider="opendbc",
+                name="toyota_tnga_k_pt_generated",
+                version="abc123",
+                source_ref="opendbc:toyota_tnga_k_pt_generated",
+                cache_path=None,
+                sha256=None,
+            )
+        ]
+        return mock
+
+    def test_dbc_provider_list_returns_registered_providers(self) -> None:
+        exit_code, stdout, _ = run_cli("dbc", "provider", "list", "--json")
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        names = [p["name"] for p in payload["data"]["providers"]]
+        self.assertIn("local", names)
+
+    def test_dbc_search_with_mock_opendbc_returns_results(self) -> None:
+        mock = self._make_mock_opendbc_provider()
+        with patch("canarchy.dbc_provider._build_default_registry") as mock_build:
+            registry = ProviderRegistry()
+            registry.register(LocalDbcProvider())
+            registry.register(mock)
+            mock_build.return_value = registry
+
+            reset_registry()
+            exit_code, stdout, _ = run_cli("dbc", "search", "toyota", "--provider", "opendbc", "--json")
+
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["data"]["count"], 1)
+        self.assertEqual(payload["data"]["results"][0]["name"], "toyota_tnga_k_pt_generated")
+
+    def test_dbc_fetch_with_mock_opendbc_returns_resolution(self) -> None:
+        mock = self._make_mock_opendbc_provider()
+        with patch("canarchy.dbc_provider._build_default_registry") as mock_build:
+            registry = ProviderRegistry()
+            registry.register(LocalDbcProvider())
+            registry.register(mock)
+            mock_build.return_value = registry
+
+            reset_registry()
+            exit_code, stdout, _ = run_cli("dbc", "fetch", "opendbc:toyota_tnga_k_pt_generated", "--json")
+
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["data"]["name"], "toyota_tnga_k_pt_generated")
+        self.assertTrue(payload["data"]["is_cached"])
+
+    def test_dbc_cache_list_returns_entries(self) -> None:
+        with patch("canarchy.dbc_cache.cache_list", return_value=[
+            {"provider": "opendbc", "commit": "abc123", "dbc_count": 42, "repo": "commaai/opendbc", "generated_at": "2026-04-19", "cache_dir": "/tmp/foo"}
+        ]):
+            exit_code, stdout, _ = run_cli("dbc", "cache", "list", "--json")
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["data"]["count"], 1)
+
+    def test_dbc_cache_prune_returns_removed_paths(self) -> None:
+        with patch("canarchy.dbc_cache.cache_prune", return_value=["/some/old/path"]):
+            exit_code, stdout, _ = run_cli("dbc", "cache", "prune", "--json")
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["data"]["count"], 1)
+
+    def test_dbc_cache_refresh_returns_dbc_count(self) -> None:
+        mock = self._make_mock_opendbc_provider()
+        with patch("canarchy.dbc_provider._build_default_registry") as mock_build:
+            registry = ProviderRegistry()
+            registry.register(LocalDbcProvider())
+            registry.register(mock)
+            mock_build.return_value = registry
+
+            reset_registry()
+            exit_code, stdout, _ = run_cli("dbc", "cache", "refresh", "--provider", "opendbc", "--json")
+
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["data"]["provider"], "opendbc")
+        self.assertEqual(payload["data"]["dbc_count"], 1)
+
+    def test_dbc_cache_refresh_unknown_provider_returns_error(self) -> None:
+        exit_code, stdout, _ = run_cli("dbc", "cache", "refresh", "--provider", "unknown_provider", "--json")
+        self.assertEqual(exit_code, EXIT_DECODE_ERROR)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["errors"][0]["code"], "DBC_PROVIDER_NOT_FOUND")
+
+    def test_dbc_fetch_unknown_opendbc_ref_returns_not_found(self) -> None:
+        mock = self._make_mock_opendbc_provider()
+        mock.resolve.side_effect = DbcError(
+            code="DBC_NOT_FOUND",
+            message="DBC 'does_not_exist' not found in opendbc catalog.",
+            hint="Run dbc search to find available DBCs.",
+        )
+        with patch("canarchy.dbc_provider._build_default_registry") as mock_build:
+            registry = ProviderRegistry()
+            registry.register(LocalDbcProvider())
+            registry.register(mock)
+            mock_build.return_value = registry
+
+            reset_registry()
+            exit_code, stdout, _ = run_cli("dbc", "fetch", "opendbc:does_not_exist", "--json")
+
+        self.assertEqual(exit_code, EXIT_DECODE_ERROR)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["errors"][0]["code"], "DBC_NOT_FOUND")
+
+    def test_decode_accepts_resolved_opendbc_ref(self) -> None:
+        """decode --dbc opendbc:<name> resolves through the registry transparently."""
+        mock = self._make_mock_opendbc_provider()
+        with patch("canarchy.dbc_provider._build_default_registry") as mock_build:
+            registry = ProviderRegistry()
+            registry.register(LocalDbcProvider())
+            registry.register(mock)
+            mock_build.return_value = registry
+
+            reset_registry()
+            exit_code, stdout, _ = run_cli(
+                "decode",
+                str(FIXTURES / "sample.candump"),
+                "--dbc",
+                "opendbc:toyota_tnga_k_pt_generated",
+                "--json",
+            )
+
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["command"], "decode")


### PR DESCRIPTION
## Summary

- Adds a provider registry so `--dbc opendbc:toyota_tnga_k_pt_generated` resolves transparently in every decode, encode, and inspect workflow — no breaking changes to existing `--dbc ./file.dbc` usage
- opendbc catalog is fetched from commaai/opendbc via GitHub API and cached locally at `~/.canarchy/cache/dbc/`, pinned to a commit (no git clone required)
- Five new `dbc` subcommands: `provider list`, `search`, `fetch`, `cache list/prune/refresh`
- Also fixes the missing `format_dbc_table` function (was called but never defined after the cantools migration)

## New modules

| File | Purpose |
|------|---------|
| `dbc_provider.py` | `DbcDescriptor`, `DbcResolution`, `DbcProvider` Protocol, `ProviderRegistry`, `resolve_dbc_ref()` |
| `dbc_provider_local.py` | local filesystem provider — wraps existing behavior |
| `dbc_cache.py` | `~/.canarchy/cache/dbc/` manifest r/w, prune, config loading |
| `dbc_opendbc.py` | opendbc catalog provider via GitHub API |

## Resolution order

1. Explicit local path that exists on disk
2. `opendbc:<name>` or `comma:<name>` prefix → routed to opendbc provider
3. Bare name → searched across enabled providers in config order
4. Structured `DBC_NOT_FOUND` error with candidate suggestions

## New CLI surface

```bash
canarchy dbc provider list
canarchy dbc search toyota [--provider opendbc] [--limit 20]
canarchy dbc fetch opendbc:toyota_tnga_k_pt_generated
canarchy dbc cache list
canarchy dbc cache prune [--provider opendbc]
canarchy dbc cache refresh [--provider opendbc]

# existing commands unchanged, now also accept provider refs:
canarchy decode --dbc opendbc:toyota_tnga_k_pt_generated ...
canarchy encode --dbc opendbc:honda_civic_ex_2022 ...
canarchy dbc inspect opendbc:toyota_tnga_k_pt_generated
```

## Out of scope (by design)

`opendbc/car/`, `opendbc/safety/`, fingerprinting, and actuation workflows are not imported. opendbc is treated as a versioned DBC catalog only.

## Test plan

- [ ] 38 new tests in `tests/test_dbc_provider.py` — all passing
- [ ] Full suite: 280 passed, 1 skipped
- [ ] Offline decode succeeds once cache is populated (`canarchy dbc cache refresh --provider opendbc` then disconnect)
- [ ] `canarchy decode --dbc opendbc:<name>` produces same event shape as `--dbc ./file.dbc`
- [ ] Unknown provider ref returns structured `DBC_PROVIDER_NOT_FOUND` error
- [ ] Cache miss before refresh returns structured `DBC_CACHE_MISS` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)