### PR TITLE
test: add table output test for dbc inspect and implement format_dbc_table

### DIFF
--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -1558,6 +1558,24 @@ def format_j1939_table(result: CommandResult) -> list[str]:
             f"data={frame['data']}"
         )
     return lines
+def format_dbc_table(result: CommandResult) -> list[str]:
+    lines = [f"command: {result.command}"]
+    database = result.data.get("database", {})
+    message_count = database.get("message_count", 0)
+    lines.append(f"messages: {message_count}")
+    messages = result.data.get("messages", [])
+    if not messages:
+        lines.append("- no messages")
+        return lines
+    for message in messages:
+        lines.append(
+            "- "
+            f"name={message['name']} "
+            f"id={message['arbitration_id_hex']} "
+            f"signals={message['signal_count']} "
+            f"length={message['length']}"
+        )
+    return lines
 def format_uds_table(result: CommandResult) -> list[str]:
     lines = [f"command: {result.command}"]
     if result.command == "uds services":

--- a/tests/test_dbc.py
+++ b/tests/test_dbc.py
@@ -147,3 +147,15 @@ class DbcTests(unittest.TestCase):
 
         payload = json.loads(stdout)
         self.assertEqual(payload["errors"][0]["code"], "DBC_MESSAGE_NOT_FOUND")
+
+    def test_dbc_inspect_table_output(self) -> None:
+        exit_code, stdout, _ = run_cli(
+            "dbc",
+            "inspect",
+            str(FIXTURES / "sample.dbc"),
+            "--table",
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertIn("messages: 2", stdout)
+        self.assertIn("EngineSpeed1", stdout)
+        self.assertIn("EngineStatus1", stdout)


### PR DESCRIPTION
Adds test_dbc_inspect_table_output to cover the --table output path on
`dbc inspect`, which was previously uncovered. Implements format_dbc_table
in cli.py (called at emit_result:1848 but never defined) following the
same pattern as format_j1939_table.

https://claude.ai/code/session_01DG5vNDuiKRraLTaPrZFD3Z