### PR TITLE
feat: attach dbc_source provenance to decode/encode/inspect output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+* `decode`, `encode`, and `dbc inspect` now include a `dbc_source` field in `CommandResult.data` reporting the provider, DBC name, pinned version, and resolved local path. Provider refs (`opendbc:<name>`) include a commit SHA version; local file refs include `provider: "local"` and `version: null`.
+
 ### Changed
 
 * `dbc inspect` now uses the internal `cantools` runtime adapter while preserving the existing CLI, MCP, and structured output contracts for the current fixtures.

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -1151,12 +1151,28 @@ def j1939_payload(
     raise AssertionError(f"unsupported j1939 command: {args.command}")
 
 
+def _build_dbc_source(resolution: Any) -> dict[str, Any]:
+    d = resolution.descriptor
+    return {
+        "provider": d.provider,
+        "name": d.name,
+        "version": d.version,
+        "path": str(resolution.local_path),
+    }
+
+
 def dbc_payload(args: argparse.Namespace) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
+    from canarchy.dbc_provider import get_registry
+
     transport = LocalTransport()
+    resolution = get_registry().resolve(args.dbc)
+    dbc_path = str(resolution.local_path)
+    dbc_source = _build_dbc_source(resolution)
+
     if args.command == "decode":
         frames = frames_from_stdin(command=args.command) if args.stdin else transport.frames_from_file(args.file)
-        
-        events = decode_frames(frames, args.dbc)
+
+        events = decode_frames(frames, dbc_path)
         warnings = []
         if not events:
             warnings.append("No frames in the capture matched messages from the selected DBC.")
@@ -1166,6 +1182,7 @@ def dbc_payload(args: argparse.Namespace) -> tuple[dict[str, Any], list[dict[str
         return (
             {
                 "dbc": args.dbc,
+                "dbc_source": dbc_source,
                 "file": args.file,
                 "matched_messages": matched_messages,
                 "mode": "passive",
@@ -1176,10 +1193,11 @@ def dbc_payload(args: argparse.Namespace) -> tuple[dict[str, Any], list[dict[str
         )
     if args.command == "encode":
         signals = parse_signal_assignments(args.signals)
-        frame, events = encode_message(args.dbc, args.message, signals)
+        frame, events = encode_message(dbc_path, args.message, signals)
         return (
             {
                 "dbc": args.dbc,
+                "dbc_source": dbc_source,
                 "frame": frame.to_payload(),
                 "message": args.message,
                 "mode": "active",
@@ -1192,10 +1210,11 @@ def dbc_payload(args: argparse.Namespace) -> tuple[dict[str, Any], list[dict[str
         )
     if args.command == "dbc inspect":
         data, events = inspect_database(
-            args.dbc,
+            dbc_path,
             message_name=args.message,
             signals_only=args.signals_only,
         )
+        data["dbc_source"] = dbc_source
         return (data, events, [])
     raise AssertionError(f"unsupported dbc command: {args.command}")
 

--- a/tests/test_dbc_provider.py
+++ b/tests/test_dbc_provider.py
@@ -555,3 +555,122 @@ class CliProviderCommandTests(unittest.TestCase):
         self.assertEqual(exit_code, EXIT_OK)
         payload = json.loads(stdout)
         self.assertEqual(payload["command"], "decode")
+
+    def test_decode_opendbc_ref_includes_dbc_source(self) -> None:
+        mock = self._make_mock_opendbc_provider()
+        with patch("canarchy.dbc_provider._build_default_registry") as mock_build:
+            registry = ProviderRegistry()
+            registry.register(LocalDbcProvider())
+            registry.register(mock)
+            mock_build.return_value = registry
+
+            reset_registry()
+            exit_code, stdout, _ = run_cli(
+                "decode",
+                str(FIXTURES / "sample.candump"),
+                "--dbc",
+                "opendbc:toyota_tnga_k_pt_generated",
+                "--json",
+            )
+
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        dbc_source = payload["data"]["dbc_source"]
+        self.assertEqual(dbc_source["provider"], "opendbc")
+        self.assertEqual(dbc_source["name"], "toyota_tnga_k_pt_generated")
+        self.assertEqual(dbc_source["version"], "abc123")
+        self.assertIn("path", dbc_source)
+
+    def test_decode_local_ref_includes_dbc_source_with_local_provider(self) -> None:
+        exit_code, stdout, _ = run_cli(
+            "decode",
+            str(FIXTURES / "sample.candump"),
+            "--dbc",
+            str(FIXTURES / "sample.dbc"),
+            "--json",
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        dbc_source = payload["data"]["dbc_source"]
+        self.assertEqual(dbc_source["provider"], "local")
+        self.assertIsNone(dbc_source["version"])
+
+    def test_encode_opendbc_ref_includes_dbc_source(self) -> None:
+        mock = self._make_mock_opendbc_provider()
+        with patch("canarchy.dbc_provider._build_default_registry") as mock_build:
+            registry = ProviderRegistry()
+            registry.register(LocalDbcProvider())
+            registry.register(mock)
+            mock_build.return_value = registry
+
+            reset_registry()
+            exit_code, stdout, _ = run_cli(
+                "encode",
+                "--dbc",
+                "opendbc:toyota_tnga_k_pt_generated",
+                "EngineStatus1",
+                "CoolantTemp=55",
+                "OilTemp=65",
+                "Load=40",
+                "LampState=1",
+                "--json",
+            )
+
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        dbc_source = payload["data"]["dbc_source"]
+        self.assertEqual(dbc_source["provider"], "opendbc")
+        self.assertEqual(dbc_source["version"], "abc123")
+
+    def test_encode_local_ref_includes_dbc_source_with_local_provider(self) -> None:
+        exit_code, stdout, _ = run_cli(
+            "encode",
+            "--dbc",
+            str(FIXTURES / "sample.dbc"),
+            "EngineStatus1",
+            "CoolantTemp=55",
+            "OilTemp=65",
+            "Load=40",
+            "LampState=1",
+            "--json",
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        dbc_source = payload["data"]["dbc_source"]
+        self.assertEqual(dbc_source["provider"], "local")
+        self.assertIsNone(dbc_source["version"])
+
+    def test_dbc_inspect_opendbc_ref_includes_dbc_source(self) -> None:
+        mock = self._make_mock_opendbc_provider()
+        with patch("canarchy.dbc_provider._build_default_registry") as mock_build:
+            registry = ProviderRegistry()
+            registry.register(LocalDbcProvider())
+            registry.register(mock)
+            mock_build.return_value = registry
+
+            reset_registry()
+            exit_code, stdout, _ = run_cli(
+                "dbc",
+                "inspect",
+                "opendbc:toyota_tnga_k_pt_generated",
+                "--json",
+            )
+
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        dbc_source = payload["data"]["dbc_source"]
+        self.assertEqual(dbc_source["provider"], "opendbc")
+        self.assertEqual(dbc_source["version"], "abc123")
+
+    def test_dbc_inspect_local_ref_includes_dbc_source_with_local_provider(self) -> None:
+        exit_code, stdout, _ = run_cli(
+            "dbc",
+            "inspect",
+            str(FIXTURES / "sample.dbc"),
+            "--json",
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        dbc_source = payload["data"]["dbc_source"]
+        self.assertEqual(dbc_source["provider"], "local")
+        self.assertIsNone(dbc_source["version"])


### PR DESCRIPTION
## Summary

- Adds a `dbc_source` field to `CommandResult.data` for `decode`, `encode`, and `dbc inspect` commands
- For provider refs (`opendbc:<name>`): includes `provider`, `name`, `version` (commit SHA), and `path`
- For local file refs: includes `provider: "local"` and `version: null`
- `dbc_payload()` now resolves the DBC ref via `get_registry().resolve()` once and passes `str(resolution.local_path)` to the runtime functions
- 6 new tests covering `dbc_source` shape for both opendbc and local refs across all three commands
- CHANGELOG updated under `[Unreleased]`

Closes #75

## Test plan

- [x] `uv run pytest tests/ -q` — 286 passed, 1 skipped
- [x] `dbc_source.provider == "opendbc"` and `dbc_source.version` is commit SHA for opendbc refs
- [x] `dbc_source.provider == "local"` and `dbc_source.version == null` for local file refs
- [x] Event payloads unchanged — provenance is only in `data`, not per-event
- [x] All existing tests still pass (additive change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)