### PR TITLE
feat: add re match-dbc and re shortlist-dbc commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+* `re match-dbc <capture> [--provider opendbc] [--limit 10]` — ranks all locally-cached DBC files against a capture file using a frequency-weighted ID coverage score; returns the top N candidates sorted by score descending.
+* `re shortlist-dbc <capture> --make <brand> [--provider opendbc] [--limit 10]` — same as `re match-dbc` but pre-filters candidates by vehicle brand before scoring.
+* `score_dbc_candidates()` scoring function in `reverse_engineering.py` — pure function that accepts a `capture_ids` frequency map and a pre-built catalog; no network calls or file I/O at score time.
+
 * `DBC_CACHE_MISS` error now includes a copy-pasteable `canarchy dbc cache refresh --provider opendbc` command and a hint about the `auto_refresh` config option.
 * `auto_refresh` opt-in for `[dbc.providers.opendbc]` in `~/.canarchy/config.toml`: when `true`, the first `resolve()` call on a cold cache triggers `refresh()` automatically instead of raising `DBC_CACHE_MISS`. Defaults to `false` for offline safety.
 

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -22,7 +22,7 @@ from canarchy.models import (
     serialize_events,
 )
 from canarchy.replay import build_replay_plan
-from canarchy.reverse_engineering import counter_candidates, entropy_candidates
+from canarchy.reverse_engineering import counter_candidates, entropy_candidates, score_dbc_candidates
 from canarchy.session import SessionError, SessionStore, build_session_context
 from canarchy.transport import (
     LocalTransport,
@@ -46,7 +46,7 @@ J1939_COMMANDS = {"j1939 monitor", "j1939 decode", "j1939 pgn", "j1939 spn", "j1
 SESSION_COMMANDS = {"session save", "session load", "session show"}
 UDS_COMMANDS = {"uds scan", "uds trace", "uds services"}
 CONFIG_COMMANDS = {"config show"}
-RE_COMMANDS = {"re counters", "re entropy"}
+RE_COMMANDS = {"re counters", "re entropy", "re match-dbc", "re shortlist-dbc"}
 ACTIVE_TRANSMIT_COMMANDS = {"send", "generate", "gateway", "uds scan"}
 IMPLEMENTED_COMMANDS = TRANSPORT_COMMANDS | DBC_COMMANDS | DBC_PROVIDER_COMMANDS | J1939_COMMANDS | SESSION_COMMANDS | UDS_COMMANDS | CONFIG_COMMANDS | RE_COMMANDS | {"mcp serve", "replay", "gateway", "shell", "export"}
 
@@ -382,6 +382,21 @@ def build_parser() -> CanarchyArgumentParser:
     re_correlate.add_argument("file")
     add_output_arguments(re_correlate)
     re_correlate.set_defaults(command="re correlate")
+
+    re_match_dbc = re_subparsers.add_parser("match-dbc", help="rank candidate DBCs against a capture")
+    re_match_dbc.add_argument("capture", help="capture file to analyse")
+    re_match_dbc.add_argument("--provider", default="opendbc", help="DBC provider catalog to search (default: opendbc)")
+    re_match_dbc.add_argument("--limit", type=int, default=10, help="maximum candidates to return (default: 10)")
+    add_output_arguments(re_match_dbc)
+    re_match_dbc.set_defaults(command="re match-dbc")
+
+    re_shortlist_dbc = re_subparsers.add_parser("shortlist-dbc", help="rank candidate DBCs filtered by vehicle make")
+    re_shortlist_dbc.add_argument("capture", help="capture file to analyse")
+    re_shortlist_dbc.add_argument("--make", required=True, help="vehicle make to pre-filter candidates (e.g. toyota)")
+    re_shortlist_dbc.add_argument("--provider", default="opendbc", help="DBC provider catalog to search (default: opendbc)")
+    re_shortlist_dbc.add_argument("--limit", type=int, default=10, help="maximum candidates to return (default: 10)")
+    add_output_arguments(re_shortlist_dbc)
+    re_shortlist_dbc.set_defaults(command="re shortlist-dbc")
 
     fuzz = subparsers.add_parser("fuzz", help="active fuzzing workflows")
     fuzz_subparsers = fuzz.add_subparsers(dest="fuzz_action", required=True)
@@ -1443,6 +1458,58 @@ def session_payload(
     raise AssertionError(f"unsupported session command: {args.command}")
 
 
+def _build_match_catalog(
+    provider_name: str,
+    make_filter: str | None = None,
+) -> list[dict[str, Any]]:
+    """Build a catalog of {name, source_ref, message_ids} from cached DBC files.
+
+    Only entries with a cached DBC file on disk are included — no network calls.
+    """
+    from pathlib import Path as _Path
+    import cantools as _cantools
+    from canarchy.dbc_cache import load_manifest, cached_file_path
+    from canarchy.dbc_opendbc import _infer_brand
+
+    manifest = load_manifest(provider_name)
+    if manifest is None:
+        return []
+
+    commit = manifest.get("commit", "")
+    catalog_entries: list[dict[str, str]] = manifest.get("dbcs", [])
+
+    result: list[dict[str, Any]] = []
+    for entry in catalog_entries:
+        name = entry["name"]
+
+        if make_filter:
+            brand = _infer_brand(name)
+            if brand != make_filter.lower():
+                continue
+
+        filename = _Path(entry["path"]).name
+        cached = cached_file_path(provider_name, commit, filename)
+        if not cached.exists():
+            continue
+
+        try:
+            db = _cantools.database.load_file(str(cached))
+            message_ids = [int(msg.frame_id) for msg in db.messages]
+        except Exception:
+            continue
+
+        result.append(
+            {
+                "name": name,
+                "source_ref": f"{provider_name}:{name}",
+                "message_ids": message_ids,
+                "metadata": {"brand": _infer_brand(name)},
+            }
+        )
+
+    return result
+
+
 def reverse_engineering_payload(
     args: argparse.Namespace,
 ) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
@@ -1483,6 +1550,47 @@ def reverse_engineering_payload(
             [],
             warnings,
         )
+    if args.command in {"re match-dbc", "re shortlist-dbc"}:
+        capture_file = args.capture
+        provider_name = getattr(args, "provider", "opendbc")
+        limit = getattr(args, "limit", 10)
+        make_filter = getattr(args, "make", None)
+
+        frames = transport.frames_from_file(capture_file)
+        capture_id_counts: dict[int, int] = {}
+        for frame in frames:
+            if not frame.is_remote_frame and not frame.is_error_frame:
+                capture_id_counts[frame.arbitration_id] = (
+                    capture_id_counts.get(frame.arbitration_id, 0) + 1
+                )
+
+        catalog = _build_match_catalog(provider_name, make_filter=make_filter)
+        candidates = score_dbc_candidates(capture_id_counts, catalog)[:limit]
+
+        warnings: list[str] = []
+        if not catalog:
+            warnings.append(
+                f"No cached DBC files found for provider '{provider_name}'. "
+                "Run `canarchy dbc cache refresh --provider opendbc` then fetch DBCs with `canarchy dbc fetch`."
+            )
+        elif not candidates:
+            filter_note = f" matching make '{make_filter}'" if make_filter else ""
+            warnings.append(
+                f"No candidate DBCs{filter_note} scored above zero against this capture."
+            )
+
+        command_label = "re match-dbc" if args.command == "re match-dbc" else "re shortlist-dbc"
+        data: dict[str, Any] = {
+            "capture": capture_file,
+            "provider": provider_name,
+            "candidate_count": len(candidates),
+            "candidates": candidates,
+            "events": [],
+        }
+        if make_filter:
+            data["make"] = make_filter
+        return (data, [], warnings)
+
     raise AssertionError(f"unsupported reverse-engineering command: {args.command}")
 
 
@@ -1769,6 +1877,28 @@ def format_uds_table(result: CommandResult) -> list[str]:
 
 def format_re_table(result: CommandResult) -> list[str]:
     lines = [f"command: {result.command}"]
+
+    if result.command in {"re match-dbc", "re shortlist-dbc"}:
+        lines.append(f"capture: {result.data.get('capture')}")
+        lines.append(f"provider: {result.data.get('provider')}")
+        if result.command == "re shortlist-dbc":
+            lines.append(f"make: {result.data.get('make')}")
+        lines.append(f"candidate_count: {result.data.get('candidate_count', 0)}")
+        lines.append("candidates:")
+        candidates = result.data.get("candidates", [])
+        if not candidates:
+            lines.append("- no matching candidates")
+            return lines
+        for candidate in candidates:
+            lines.append(
+                "- "
+                f"name={candidate['name']} "
+                f"score={candidate['score']} "
+                f"matched={candidate['matched_ids']}/{candidate['total_capture_ids']} "
+                f"ref={candidate['source_ref']}"
+            )
+        return lines
+
     lines.append(f"file: {result.data.get('file')}")
     lines.append(f"analysis: {result.data.get('analysis')}")
     lines.append(f"candidate_count: {result.data.get('candidate_count', 0)}")

--- a/src/canarchy/reverse_engineering.py
+++ b/src/canarchy/reverse_engineering.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass
 from math import log2
+from typing import Any
 
 from canarchy.models import CanFrame
 
@@ -231,3 +232,46 @@ def _entropy_byte_summary(
         entropy=round(entropy, 3),
         unique_values=len(counts),
     )
+
+
+def score_dbc_candidates(
+    capture_ids: dict[int, int],
+    catalog: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Score each catalog DBC by how well it covers the capture's arbitration IDs.
+
+    capture_ids maps arbitration_id -> frame_count.
+    Each catalog entry must have: name, source_ref, message_ids (list[int]).
+    Score = fraction of total captured frames whose ID is known to the DBC.
+    """
+    if not capture_ids or not catalog:
+        return []
+
+    total_capture_ids = len(capture_ids)
+    total_frames = sum(capture_ids.values()) or 1
+
+    results: list[dict[str, Any]] = []
+    for entry in catalog:
+        message_ids: set[int] = set(entry.get("message_ids", []))
+        if not message_ids:
+            continue
+
+        matched_ids = {arb_id for arb_id in capture_ids if arb_id in message_ids}
+        if not matched_ids:
+            continue
+
+        matched_frames = sum(capture_ids[arb_id] for arb_id in matched_ids)
+        score = round(matched_frames / total_frames, 2)
+
+        results.append(
+            {
+                "name": entry["name"],
+                "source_ref": entry.get("source_ref", f"opendbc:{entry['name']}"),
+                "score": score,
+                "matched_ids": len(matched_ids),
+                "total_capture_ids": total_capture_ids,
+            }
+        )
+
+    results.sort(key=lambda x: (-x["score"], x["name"]))
+    return results

--- a/tests/test_reverse_engineering.py
+++ b/tests/test_reverse_engineering.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
-from canarchy.reverse_engineering import counter_candidates, entropy_candidates
+from canarchy.reverse_engineering import counter_candidates, entropy_candidates, score_dbc_candidates
 from canarchy.transport import LocalTransport
 
 
@@ -89,3 +90,181 @@ class ReverseEngineeringTests(unittest.TestCase):
         low_sample = next(candidate for candidate in candidates if candidate["arbitration_id"] == 0x103)
         self.assertTrue(low_sample["low_sample"])
         self.assertEqual(low_sample["frame_count"], 5)
+
+
+class ScoreDbcCandidatesTests(unittest.TestCase):
+    def _make_catalog(self) -> list[dict]:
+        return [
+            {
+                "name": "toyota_tnga_k_pt_generated",
+                "source_ref": "opendbc:toyota_tnga_k_pt_generated",
+                "message_ids": [0x100, 0x200, 0x300, 0x400, 0x500],
+            },
+            {
+                "name": "toyota_nodsu_pt_generated",
+                "source_ref": "opendbc:toyota_nodsu_pt_generated",
+                "message_ids": [0x100, 0x200, 0x600],
+            },
+            {
+                "name": "honda_accord",
+                "source_ref": "opendbc:honda_accord",
+                "message_ids": [0xAA0, 0xAA1, 0xAA2],
+            },
+        ]
+
+    def test_score_returns_candidates_sorted_by_score_descending(self) -> None:
+        # 0x100–0x500 are capture IDs; toyota_tnga matches 5/5, nodsu matches 2/5
+        capture_ids = {0x100: 10, 0x200: 10, 0x300: 10, 0x400: 10, 0x500: 10}
+
+        results = score_dbc_candidates(capture_ids, self._make_catalog())
+
+        self.assertEqual(results[0]["name"], "toyota_tnga_k_pt_generated")
+        self.assertGreater(results[0]["score"], results[1]["score"])
+
+    def test_score_excludes_zero_match_candidates(self) -> None:
+        capture_ids = {0x100: 1, 0x200: 1}
+
+        results = score_dbc_candidates(capture_ids, self._make_catalog())
+
+        names = [r["name"] for r in results]
+        self.assertNotIn("honda_accord", names)
+
+    def test_score_output_shape(self) -> None:
+        capture_ids = {0x100: 5, 0x200: 5, 0x999: 40}
+
+        results = score_dbc_candidates(capture_ids, self._make_catalog())
+
+        self.assertTrue(results)
+        top = results[0]
+        self.assertIn("name", top)
+        self.assertIn("source_ref", top)
+        self.assertIn("score", top)
+        self.assertIn("matched_ids", top)
+        self.assertIn("total_capture_ids", top)
+        self.assertEqual(top["total_capture_ids"], 3)
+
+    def test_score_frequency_weighted(self) -> None:
+        # toyota_tnga matches 0x100 (1 frame) and 0x200 (99 frames)
+        # honda matches 0xAA0 (50 frames)
+        capture_ids = {0x100: 1, 0x200: 99, 0xAA0: 50}
+
+        results = score_dbc_candidates(capture_ids, self._make_catalog())
+
+        tnga = next(r for r in results if r["name"] == "toyota_tnga_k_pt_generated")
+        honda = next(r for r in results if r["name"] == "honda_accord")
+        # toyota accounts for 100/150 frames, honda for 50/150
+        self.assertGreater(tnga["score"], honda["score"])
+
+    def test_score_empty_catalog_returns_empty(self) -> None:
+        self.assertEqual(score_dbc_candidates({0x100: 1}, []), [])
+
+    def test_score_empty_capture_ids_returns_empty(self) -> None:
+        self.assertEqual(score_dbc_candidates({}, self._make_catalog()), [])
+
+    def test_score_skips_catalog_entries_without_message_ids(self) -> None:
+        catalog = [{"name": "no_ids", "source_ref": "opendbc:no_ids", "message_ids": []}]
+        self.assertEqual(score_dbc_candidates({0x100: 1}, catalog), [])
+
+
+class MatchDbcCliTests(unittest.TestCase):
+    """Test CLI output shape for re match-dbc and re shortlist-dbc using mocked catalog."""
+
+    _MOCK_CATALOG = [
+        {
+            "name": "toyota_tnga_k_pt_generated",
+            "source_ref": "opendbc:toyota_tnga_k_pt_generated",
+            "message_ids": [0x18FEEE31, 0x18F00431],
+        },
+        {
+            "name": "honda_accord",
+            "source_ref": "opendbc:honda_accord",
+            "message_ids": [0x1234],
+        },
+    ]
+
+    def test_re_match_dbc_json_output_shape(self) -> None:
+        from canarchy.cli import execute_command
+
+        with patch("canarchy.cli._build_match_catalog", return_value=self._MOCK_CATALOG):
+            exit_code, result = execute_command(
+                ["re", "match-dbc", str(FIXTURES / "sample.candump"), "--json"]
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertTrue(result.ok)
+        self.assertEqual(result.command, "re match-dbc")
+        data = result.data
+        self.assertIn("capture", data)
+        self.assertIn("provider", data)
+        self.assertIn("candidate_count", data)
+        self.assertIn("candidates", data)
+        self.assertIn("events", data)
+
+    def test_re_match_dbc_candidates_structure(self) -> None:
+        from canarchy.cli import execute_command
+
+        with patch("canarchy.cli._build_match_catalog", return_value=self._MOCK_CATALOG):
+            _, result = execute_command(
+                ["re", "match-dbc", str(FIXTURES / "sample.candump"), "--json"]
+            )
+
+        assert result is not None
+        candidates = result.data["candidates"]
+        self.assertTrue(len(candidates) > 0)
+        top = candidates[0]
+        self.assertIn("name", top)
+        self.assertIn("source_ref", top)
+        self.assertIn("score", top)
+        self.assertIn("matched_ids", top)
+        self.assertIn("total_capture_ids", top)
+
+    def test_re_shortlist_dbc_json_output_shape(self) -> None:
+        from canarchy.cli import execute_command
+
+        with patch("canarchy.cli._build_match_catalog", return_value=self._MOCK_CATALOG):
+            exit_code, result = execute_command(
+                ["re", "shortlist-dbc", str(FIXTURES / "sample.candump"), "--make", "toyota", "--json"]
+            )
+
+        self.assertEqual(exit_code, 0)
+        assert result is not None
+        self.assertTrue(result.ok)
+        self.assertEqual(result.command, "re shortlist-dbc")
+        self.assertIn("make", result.data)
+        self.assertEqual(result.data["make"], "toyota")
+
+    def test_re_match_dbc_empty_catalog_emits_warning(self) -> None:
+        from canarchy.cli import execute_command
+
+        with patch("canarchy.cli._build_match_catalog", return_value=[]):
+            _, result = execute_command(
+                ["re", "match-dbc", str(FIXTURES / "sample.candump"), "--json"]
+            )
+
+        assert result is not None
+        self.assertTrue(result.ok)
+        self.assertIsNotNone(result.warnings)
+        assert result.warnings is not None
+        self.assertTrue(len(result.warnings) > 0)
+
+    def test_re_match_dbc_limit_respected(self) -> None:
+        from canarchy.cli import execute_command
+
+        catalog = [
+            {
+                "name": f"dbc_{i}",
+                "source_ref": f"opendbc:dbc_{i}",
+                "message_ids": [0x18FEEE31, 0x18F00431],
+            }
+            for i in range(20)
+        ]
+
+        with patch("canarchy.cli._build_match_catalog", return_value=catalog):
+            _, result = execute_command(
+                ["re", "match-dbc", str(FIXTURES / "sample.candump"), "--limit", "3", "--json"]
+            )
+
+        assert result is not None
+        self.assertLessEqual(len(result.data["candidates"]), 3)


### PR DESCRIPTION
## Summary

- Adds `re match-dbc <capture> [--provider opendbc] [--limit 10]` to rank locally-cached DBCs against a capture file using frequency-weighted arbitration-ID coverage scoring
- Adds `re shortlist-dbc <capture> --make <brand> [--provider opendbc] [--limit 10]` for the same ranking pre-filtered by vehicle brand
- Adds `score_dbc_candidates()` pure scoring function to `reverse_engineering.py`; no network calls or DBC parsing at score time (uses cached on-disk files via `_build_match_catalog`)

Closes #73

## Implementation notes

- Score = fraction of total captured frames whose arbitration ID is known to the candidate DBC (frequency-weighted ID coverage)
- `_build_match_catalog()` in `cli.py` loads the opendbc manifest and only includes DBC entries with a cached file on disk — no network calls
- Both commands work with `--json`, `--jsonl`, and `--table`
- Scoring logic lives in `reverse_engineering.py`; catalog assembly lives in `cli.py`

## Test plan

- [x] `score_dbc_candidates` unit tests: sorting, zero-match exclusion, output shape, frequency weighting, edge cases (empty catalog, empty capture)
- [x] CLI integration tests for `re match-dbc` and `re shortlist-dbc`: JSON output shape, `--make` field, empty-catalog warning, `--limit` enforcement
- [x] `uv run pytest tests/ -q` — 303 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)