### PR TITLE
docs: refresh command and agent docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Documentation
 
+* Refreshed `docs/command_spec.md`, `docs/agents.md`, and related operator/spec docs to reflect the current DBC provider workflows, `dbc_source` provenance, reverse-engineering DBC matching commands, and the current curated MCP tool surface.
 * Added planning specs for a future `dbc inspect` command and a phased DBC runtime/schema split using a stable CANarchy facade.
 * Reorganized the docs site top navigation into header tabs, added a dedicated Tutorials section, and introduced a Tutorials landing page for the J1939 and generate/capture walkthroughs.
 * Migrated all design specs (`docs/design/*.md`) to EARS requirements syntax with an explicit Type column per requirement row.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -45,7 +45,7 @@ With `uv` in a project environment:
 
 ### Available Tools
 
-Every implemented CLI command is exposed as an MCP tool. Spaces in command names become underscores:
+The current MCP surface exposes a curated non-interactive subset of the CLI. Spaces in command names become underscores:
 
 | MCP tool | CLI equivalent |
 |----------|---------------|
@@ -73,6 +73,12 @@ Every implemented CLI command is exposed as an MCP tool. Spaces in command names
 | `uds_trace` | `canarchy uds trace` |
 | `uds_services` | `canarchy uds services` |
 | `config_show` | `canarchy config show` |
+
+Current exclusions:
+
+* DBC provider and cache commands such as `dbc search` and `dbc fetch`
+* reverse-engineering helpers such as `re counters`, `re entropy`, `re match-dbc`, and `re shortlist-dbc`
+* interactive or service commands such as `shell`, `tui`, and `mcp serve`
 
 ### Response Format
 
@@ -105,6 +111,6 @@ tool: send {"interface": "vcan0", "frame_id": "0x7DF", "data": "0201F1"}
 
 ### Notes
 
-- Streaming is not supported in v1 — live-capture tools (`capture`, `gateway`) return a buffered batch from the active backend.
-- `shell` and `tui` are not exposed as MCP tools.
-- Error codes are identical to the CLI, so existing JSON-parsing logic transfers without changes.
+* Streaming is not supported in v1 — live-capture tools (`capture`, `gateway`) return a buffered batch from the active backend.
+* `shell`, `tui`, and `mcp serve` are not exposed as MCP tools.
+* Error codes are identical to the CLI, so existing JSON-parsing logic transfers without changes.

--- a/docs/command_spec.md
+++ b/docs/command_spec.md
@@ -12,12 +12,16 @@ Implemented and verified in the current codebase:
 * deterministic `replay`
 * live `gateway` bridging between CAN interfaces via `python-can`
 * structured `export` for capture files and saved sessions
-* DBC-backed `decode` and `encode`
+* DBC-backed `decode`, `encode`, and `dbc inspect`
+* DBC provider workflows for `dbc provider list`, `dbc search`, `dbc fetch`, `dbc cache list`, `dbc cache prune`, and `dbc cache refresh`
 * J1939 `monitor`, `decode`, `pgn`, `spn`, `tp`, and `dm1`
 * session `save`, `load`, and `show`
 * shell one-shot command execution
 * initial text-mode `tui` shell over the shared command layer
 * UDS `scan`, `trace`, and `services`
+* `config show` for effective transport configuration inspection
+* `re counters` and `re entropy` for passive file-backed analysis
+* `re match-dbc` and `re shortlist-dbc` for provider-backed DBC candidate ranking against captures
 * structured JSON and JSONL output
 * explicit error schema and exit codes
 
@@ -28,6 +32,8 @@ Important current behavior:
 * live transport-facing commands default to the `python-can` backend; set `backend = "scaffold"` in `~/.canarchy/config.toml` or export `CANARCHY_TRANSPORT_BACKEND=scaffold` for deterministic offline behavior
 * `capture`, `send`, and `gateway` use the selected transport backend, but `gateway` specifically requires `python-can`
 * the default `python-can` interface is `socketcan`; set `interface` in the config file or `CANARCHY_PYTHON_CAN_INTERFACE` to change it
+* DBC-backed commands accept local paths and provider refs such as `opendbc:<name>` or `comma:<name>`
+* `decode`, `encode`, and `dbc inspect` include `data.dbc_source` in structured output so callers can see the provider, logical DBC name, pinned version, and resolved local path
 * placeholder-only commands still return `status: planned` and `implementation: command surface scaffold`
 * some protocol-oriented commands currently use explicit sample/reference providers rather than true transport-backed execution paths
 * specialized table formatting exists for J1939 monitor and decode style output; other `--table` output is generic key/value rendering
@@ -200,6 +206,11 @@ Example:
 canarchy decode tests/fixtures/sample.candump --dbc tests/fixtures/sample.dbc --json
 ```
 
+Notes:
+
+* `--dbc` accepts a local file path or a provider ref such as `opendbc:<name>`
+* structured output includes a `dbc_source` object describing the provider-backed or local DBC resolution that was used
+
 ### encode
 
 Encode a DBC message into a frame payload.
@@ -213,6 +224,96 @@ Example:
 ```bash
 canarchy encode --dbc tests/fixtures/sample.dbc EngineStatus1 CoolantTemp=55 OilTemp=65 Load=40 LampState=1 --json
 ```
+
+Notes:
+
+* `--dbc` accepts a local file path or a provider ref such as `opendbc:toyota_tnga_k_pt_generated`
+* structured output includes a `dbc_source` object describing the provider-backed or local DBC resolution that was used
+
+### dbc inspect
+
+Inspect database, message, and signal metadata for a DBC file or provider ref.
+
+```bash
+canarchy dbc inspect <dbc> [--message <name>] [--signals-only] [--json|--jsonl|--table|--raw]
+```
+
+Examples:
+
+```bash
+canarchy dbc inspect tests/fixtures/sample.dbc --json
+canarchy dbc inspect opendbc:toyota_tnga_k_pt_generated --message STEER_TORQUE_SENSOR --json
+```
+
+Notes:
+
+* `<dbc>` accepts a local file path or a provider ref such as `opendbc:<name>` or `comma:<name>`
+* structured output includes `dbc_source` provenance alongside the inspection payload
+
+### dbc provider list
+
+List registered DBC providers.
+
+```bash
+canarchy dbc provider list [--json|--jsonl|--table|--raw]
+```
+
+### dbc search
+
+Search DBC catalogs across enabled providers.
+
+```bash
+canarchy dbc search <query> [--provider <name>] [--limit <n>] [--json|--jsonl|--table|--raw]
+```
+
+Example:
+
+```bash
+canarchy dbc search toyota --provider opendbc --limit 5 --json
+```
+
+### dbc fetch
+
+Fetch and cache a DBC file from a provider.
+
+```bash
+canarchy dbc fetch <ref> [--json|--jsonl|--table|--raw]
+```
+
+Example:
+
+```bash
+canarchy dbc fetch opendbc:toyota_tnga_k_pt_generated --json
+```
+
+### dbc cache list
+
+List cached provider manifests.
+
+```bash
+canarchy dbc cache list [--json|--jsonl|--table|--raw]
+```
+
+### dbc cache prune
+
+Remove stale cached provider snapshots while keeping the pinned commit.
+
+```bash
+canarchy dbc cache prune [--provider <name>] [--json|--jsonl|--table|--raw]
+```
+
+### dbc cache refresh
+
+Refresh a provider catalog from upstream.
+
+```bash
+canarchy dbc cache refresh [--provider <name>] [--json|--jsonl|--table|--raw]
+```
+
+Notes:
+
+* the default provider is `opendbc`
+* refreshing updates the cached catalog manifest; individual DBC files are fetched on demand or through `dbc fetch`
 
 ### session save
 
@@ -416,6 +517,55 @@ Notes:
 * JSON output includes one candidate per arbitration ID plus a per-byte entropy breakdown inside each candidate
 * IDs with fewer than 10 observed frames are retained and marked with `low_sample: true`
 
+### re match-dbc
+
+Rank candidate DBC files against a capture using provider-backed catalog metadata.
+
+```bash
+canarchy re match-dbc <capture> [--provider <name>] [--limit <n>] [--json|--jsonl|--table|--raw]
+```
+
+Notes:
+
+* this command is passive and file-backed
+* candidates are scored by frequency-weighted arbitration-ID coverage against the capture
+* the default provider is `opendbc`
+
+### re shortlist-dbc
+
+Rank candidate DBC files against a capture after pre-filtering by vehicle make.
+
+```bash
+canarchy re shortlist-dbc <capture> --make <brand> [--provider <name>] [--limit <n>] [--json|--jsonl|--table|--raw]
+```
+
+Notes:
+
+* this command is passive and file-backed
+* `--make` narrows provider-catalog candidates before scoring them against the capture
+* the default provider is `opendbc`
+
+### config show
+
+Inspect the effective transport configuration and the source of each setting.
+
+```bash
+canarchy config show [--json|--jsonl|--table|--raw]
+```
+
+### mcp serve
+
+Start the MCP server over stdio.
+
+```bash
+canarchy mcp serve
+```
+
+Notes:
+
+* this command does not accept output flags
+* the current MCP tool surface is a curated non-interactive subset of the CLI, not every implemented command
+
 ---
 
 ## Output Modes
@@ -549,6 +699,24 @@ canarchy j1939 monitor --pgn 65262 --json
 canarchy decode tests/fixtures/sample.candump --dbc tests/fixtures/sample.dbc --json
 ```
 
+### DBC Provider Search
+
+```bash
+canarchy dbc search toyota --provider opendbc --json
+```
+
+### DBC Provider Decode
+
+```bash
+canarchy decode tests/fixtures/sample.candump --dbc opendbc:toyota_tnga_k_pt_generated --json
+```
+
+### Reverse-Engineering DBC Match
+
+```bash
+canarchy re match-dbc tests/fixtures/sample.candump --provider opendbc --limit 5 --json
+```
+
 ### DBC Encode
 
 ```bash
@@ -585,7 +753,7 @@ canarchy shell --command "capture can0 --raw"
 
 These commands are present in the CLI tree but not yet implemented end to end:
 
-* `re signals|correlate`
+* `re signals` and `re correlate`
 * `fuzz replay|mutate|id`
 
 These deeper capabilities are also not implemented yet even where the command surface exists:

--- a/docs/design/mcp-server.md
+++ b/docs/design/mcp-server.md
@@ -21,11 +21,11 @@ Agents that already call tools via MCP (Claude, OpenCode, etc.) can integrate CA
 | ID | Type | Requirement |
 |----|------|-------------|
 | `REQ-MCP-01` | Ubiquitous | The system shall provide a `canarchy mcp serve` subcommand that starts an MCP server over stdio. |
-| `REQ-MCP-02` | Ubiquitous | Each implemented CLI command shall surface as an MCP tool whose name is the command string with spaces replaced by underscores (e.g. `j1939 monitor` → `j1939_monitor`). |
+| `REQ-MCP-02` | Ubiquitous | Each command selected for the MCP surface shall surface as an MCP tool whose name is the command string with spaces replaced by underscores (e.g. `j1939 monitor` → `j1939_monitor`). |
 | `REQ-MCP-03` | Ubiquitous | Each MCP tool's input schema shall be derived from the argparse parameter definitions of the corresponding CLI command. |
 | `REQ-MCP-04` | Event-driven | When an MCP tool call is received, the system shall return the canonical command result envelope (`ok`, `command`, `data`, `warnings`, `errors`) serialised as JSON text content. |
 | `REQ-MCP-05` | Event-driven | When an MCP tool call is received with invalid inputs, the system shall return the same structured error codes as the equivalent CLI invocation. |
-| `REQ-MCP-06` | Event-driven | When a `list_tools` request is received, the system shall return all implemented tools with name, description, and input schema. |
+| `REQ-MCP-06` | Event-driven | When a `list_tools` request is received, the system shall return all registered MCP tools with name, description, and input schema. |
 | `REQ-MCP-07` | Ubiquitous | The MCP server shall use stdio transport only. |
 | `REQ-MCP-08` | Unwanted behaviour | If a `call_tool` request names an unregistered tool, the system shall raise an error indicating the tool is unknown. |
 | `REQ-MCP-09` | Ubiquitous | The `mcp` package shall be declared as a project dependency in `pyproject.toml`. |
@@ -38,6 +38,8 @@ canarchy mcp serve
 ```
 
 The `serve` subcommand accepts no positional arguments or output flags. The server runs until the stdio transport closes (client disconnect or EOF).
+
+The current MCP tool surface is a curated non-interactive subset of the CLI. It intentionally excludes interactive commands and some newer command families that do not yet have MCP adapters.
 
 ## Tool Naming Convention
 
@@ -109,7 +111,7 @@ In scope:
 
 * stdio MCP transport only
 * buffered (non-streaming) tool responses for all commands including live-capture variants (scaffold backend returns a fixed event batch)
-* full implemented command surface excluding interactive front ends (`shell`, `tui`)
+* a curated non-interactive CLI subset covering transport, protocol, export, session, and configuration workflows
 
 Out of scope:
 
@@ -117,3 +119,4 @@ Out of scope:
 * streaming tool responses / MCP notifications for live capture
 * authentication or access control
 * plugin or custom tool registration
+* exposing every implemented CLI command automatically

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -154,6 +154,25 @@ Replay a capture with deterministic timing:
 canarchy replay tests/fixtures/sample.candump --rate 1.0 --json
 ```
 
+## Discover and Use DBC Files
+
+CANarchy can work with local DBC files or provider-backed refs.
+
+Search the optional opendbc catalog:
+
+```bash
+canarchy dbc cache refresh --provider opendbc
+canarchy dbc search toyota --provider opendbc --limit 5 --json
+```
+
+Decode using a provider ref instead of a local file path:
+
+```bash
+canarchy decode tests/fixtures/sample.candump --dbc opendbc:toyota_tnga_k_pt_generated --json
+```
+
+Structured output for `decode`, `encode`, and `dbc inspect` includes a `data.dbc_source` object so you can see which local or provider-backed DBC resolution was used.
+
 ## Supported Candump Forms
 
 Current supported candump text forms include:

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -15,15 +15,18 @@ Implemented and exercised in the current codebase:
 
 * `python-can`-backed live transport workflows plus deterministic scaffold transport for `capture` and `send`
 * file-backed `filter`, `stats`, `decode`, `j1939 decode`, and `replay` using candump logs
-* DBC-backed decode and encode
+* DBC-backed `decode`, `encode`, and `dbc inspect`, including provider-ref resolution and `dbc_source` provenance in structured output
+* DBC provider and cache workflows for catalog search, fetch, and refresh through the optional opendbc integration
 * J1939 `monitor`, `decode`, `pgn`, `spn`, `tp`, and `dm1`
 * UDS `scan`, `trace`, and `services`
 * `re counters` for file-backed likely-counter detection
 * `re entropy` for file-backed per-ID and per-byte entropy ranking
+* `re match-dbc` and `re shortlist-dbc` for provider-backed DBC candidate ranking against captures
 * session `save`, `load`, and `show`
 * structured `export` for capture files and saved sessions
 * shell command reuse through `canarchy shell --command ...`
 * initial text-mode `tui` shell over the shared command layer
+* `config show` for effective transport configuration inspection
 * structured `--json`, `--jsonl`, `--table`, and `--raw` output modes
 
 Some protocol-oriented commands still use explicit sample/reference providers rather than true transport-backed execution. See [Architecture](architecture.md) and [Command Spec](command_spec.md) for the current boundary.

--- a/docs/tests/mcp-server.md
+++ b/docs/tests/mcp-server.md
@@ -13,11 +13,11 @@
 | REQ ID | Description | TEST IDs |
 |--------|-------------|----------|
 | REQ-MCP-01 | `mcp serve` subcommand starts MCP server | TEST-MCP-01 |
-| REQ-MCP-02 | Each CLI command surfaces as an MCP tool | TEST-MCP-02, TEST-MCP-03 |
+| REQ-MCP-02 | Each selected CLI command surfaces as an MCP tool | TEST-MCP-02, TEST-MCP-03 |
 | REQ-MCP-03 | Input schemas derived from argparse definitions | TEST-MCP-04 |
 | REQ-MCP-04 | Tool responses use canonical event envelope | TEST-MCP-05, TEST-MCP-06 |
 | REQ-MCP-05 | Invalid inputs return same error codes as CLI | TEST-MCP-07, TEST-MCP-08 |
-| REQ-MCP-06 | Tool discovery returns all tools with metadata | TEST-MCP-02, TEST-MCP-03 |
+| REQ-MCP-06 | Tool discovery returns all registered MCP tools with metadata | TEST-MCP-02, TEST-MCP-03 |
 | REQ-MCP-07 | stdio transport only | TEST-MCP-01 |
 | REQ-MCP-08 | Unknown tool name raises error | TEST-MCP-09 |
 | REQ-MCP-09 | `mcp` declared in pyproject.toml | TEST-MCP-10 |
@@ -50,12 +50,12 @@ Then   the returned set shall contain at minimum: `capture`, `send`, `filter`, `
 
 ---
 
-### `TEST-MCP-03` — Tool count matches implemented command surface
+### `TEST-MCP-03` — Tool count matches the registered MCP surface
 
 ```gherkin
 Given  the MCP server is initialised
 When   `handle_list_tools()` is called
-Then   at least 24 tools shall be returned — one per implemented non-interactive command
+Then   at least 24 tools shall be returned — one per registered MCP tool in the current curated surface
 ```
 
 **Fixture:** none.
@@ -166,7 +166,22 @@ And    `"tui"` shall not appear in the set of tool names
 
 ---
 
-### `TEST-MCP-12` — `_build_argv` produces correct argv for representative tools
+### `TEST-MCP-12` — Unregistered implemented commands are excluded from MCP
+
+```gherkin
+Given  the MCP server is initialised
+When   `handle_list_tools()` is called
+Then   `"dbc_search"` shall not appear in the set of tool names
+And    `"dbc_fetch"` shall not appear in the set of tool names
+And    `"re_counters"` shall not appear in the set of tool names
+And    `"re_match_dbc"` shall not appear in the set of tool names
+```
+
+**Fixture:** none.
+
+---
+
+### `TEST-MCP-13` — `_build_argv` produces correct argv for representative tools
 
 ```gherkin
 Given  the `_build_argv` helper is available
@@ -191,7 +206,7 @@ And    `"--json"` shall be the final element in each case
 
 ---
 
-### `TEST-MCP-13` — `_build_argv` raises for unknown tool
+### `TEST-MCP-14` — `_build_argv` raises for unknown tool
 
 ```gherkin
 Given  the `_build_argv` helper is available


### PR DESCRIPTION
## Summary
- refresh `docs/command_spec.md` for the current DBC provider, provenance, config, and reverse-engineering command surface
- update operator and agent docs to describe provider-ref workflows and the current curated MCP tool surface
- align the MCP design and test specs with the actual registered tool set and add a changelog entry

## Verification
- `uv run --group docs mkdocs build --strict`

Closes #83