### PR TITLE
docs: refresh tutorials and comparison docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Documentation
 
+* Refreshed tutorials and comparison docs to add a provider-backed DBC workflow tutorial, update tutorial discoverability, and align the feature matrix with the shipped reverse-engineering and DBC-provider capabilities.
 * Refreshed `docs/command_spec.md`, `docs/agents.md`, and related operator/spec docs to reflect the current DBC provider workflows, `dbc_source` provenance, reverse-engineering DBC matching commands, and the current curated MCP tool surface.
 * Updated `docs/architecture.md` to reflect the current DBC provider/cache/provenance subsystem and the shipped reverse-engineering DBC-matching commands.
 * Added planning specs for a future `dbc inspect` command and a phased DBC runtime/schema split using a stable CANarchy facade.

--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -33,6 +33,7 @@ Legend:
 | Frame gateway / bridge workflow | Yes | Partial | No | No | Partial | No | No | No | No | No |
 | DBC decode | Yes | No | No | Yes | Yes | No | No | No | Partial | No |
 | DBC encode | Yes | No | No | Yes | Partial | No | No | No | Partial | No |
+| Provider-backed DBC discovery / cache workflow | Yes | No | No | No | No | No | No | No | No | No |
 | J1939-first operator workflows | Yes | Partial | No | No | Partial | No | Yes | Partial | No | No |
 | UDS discovery / trace workflows | Yes | Partial | No | No | No | Yes | No | Yes | Partial | Yes |
 | Security research / fuzzing emphasis | Partial | No | No | No | Partial | Yes | Partial | Yes | No | No |
@@ -50,7 +51,7 @@ The workflow matrix above is useful for operator-facing comparison, but several 
 | Plotting / visualization depth | No | No | No | Yes | Yes | No | No | No | Partial | No |
 | Code generation | No | No | No | Yes | No | No | No | No | No | No |
 | Extensibility via plugins / modules | Planned | No | Yes | Partial | Partial | Yes | Yes | Partial | Partial | Partial |
-| Reverse-engineering workflow depth | Planned | Partial | No | Partial | Yes | Yes | Partial | Yes | Partial | No |
+| Reverse-engineering workflow depth | Partial | Partial | No | Partial | Yes | Yes | Partial | Yes | Partial | No |
 | Protocol breadth beyond raw CAN | Partial | Yes | Partial | Partial | Partial | Yes | Partial | Yes | Yes | No |
 | Session / bookmark / saved analysis workflow | Partial | No | Partial | No | Partial | Partial | Partial | Yes | Yes | No |
 | Embedded-library ergonomics | No | No | Yes | Yes | No | No | No | Partial | No | Yes |
@@ -85,6 +86,7 @@ The workflow matrix does not fully capture several important reasons someone mig
 
 * `python-can` excels at hardware abstraction, interface coverage, and embedded Python integration.
 * `cantools` excels at database-heavy engineering: multiple schema formats, inspection, plotting, monitor workflows, and C code generation.
+* CANarchy now includes provider-backed DBC discovery plus initial reverse-engineering DBC matching, but it is still much earlier in depth than mature database-centric or visual RE tools.
 * SavvyCAN excels at visual exploration and reverse-engineering-oriented desktop analysis.
 * Caring Caribou excels at automotive security workflows, including UDS fuzzing, DoIP, and XCP-oriented work.
 * TruckDevil excels at truck and J1939-focused ECU assessment workflows.

--- a/docs/tutorials/dbc_provider_workflow.md
+++ b/docs/tutorials/dbc_provider_workflow.md
@@ -1,0 +1,111 @@
+# Tutorial: Discover and Use Provider-Backed DBC Files
+
+This tutorial walks through the current provider-backed DBC workflow from catalog refresh to capture decoding.
+
+It is useful when you have a candump trace but do not already have the matching DBC file on disk.
+
+## Goal
+
+By the end of this tutorial you will:
+
+* refresh the optional opendbc catalog
+* search for likely DBC files
+* fetch a DBC into the local cache
+* inspect it before use
+* decode a capture with a provider ref instead of a local file path
+* use `re match-dbc` to rank candidate DBCs against a capture
+
+## Prerequisites
+
+This workflow uses the optional opendbc integration, so it requires network access for the catalog refresh and fetch steps.
+
+The examples below use `tests/fixtures/sample.candump` as the capture source.
+
+## Step 1 — Refresh the Provider Catalog
+
+Populate the local catalog manifest from the configured provider:
+
+```bash
+canarchy dbc cache refresh --provider opendbc --json
+```
+
+This updates the cached provider manifest under `~/.canarchy/cache/dbc`.
+
+## Step 2 — Search for Candidate DBCs
+
+Search by make, model family, or another keyword:
+
+```bash
+canarchy dbc search toyota --provider opendbc --limit 5 --table
+```
+
+This returns provider-catalog matches without downloading every DBC file.
+
+## Step 3 — Fetch a DBC Into the Local Cache
+
+Once you have a likely candidate, fetch it by provider ref:
+
+```bash
+canarchy dbc fetch opendbc:toyota_tnga_k_pt_generated --json
+```
+
+Provider refs can also use the `comma:` alias:
+
+```bash
+canarchy dbc fetch comma:toyota_tnga_k_pt_generated --json
+```
+
+## Step 4 — Inspect the DBC Before Decoding
+
+Inspect the database metadata directly from the provider ref:
+
+```bash
+canarchy dbc inspect opendbc:toyota_tnga_k_pt_generated --json
+```
+
+Restrict the result to a single message when needed:
+
+```bash
+canarchy dbc inspect opendbc:toyota_tnga_k_pt_generated --message STEER_TORQUE_SENSOR --table
+```
+
+Structured output includes `data.dbc_source`, which records the provider, logical DBC name, pinned version, and resolved local cache path.
+
+## Step 5 — Decode a Capture Using the Provider Ref
+
+Use the same provider ref directly with `decode`:
+
+```bash
+canarchy decode tests/fixtures/sample.candump --dbc opendbc:toyota_tnga_k_pt_generated --json
+```
+
+This avoids copying or hard-coding a separate local path.
+
+## Step 6 — Rank Candidate DBCs Against a Capture
+
+If you are not sure which catalog entry fits the capture best, score multiple candidates against the observed arbitration IDs:
+
+```bash
+canarchy re match-dbc tests/fixtures/sample.candump --provider opendbc --limit 5 --table
+```
+
+To narrow the catalog first by vehicle make:
+
+```bash
+canarchy re shortlist-dbc tests/fixtures/sample.candump --make toyota --provider opendbc --limit 5 --table
+```
+
+These commands are passive and file-backed. They do not decode payload semantics; they rank candidate DBCs by frequency-weighted arbitration-ID coverage.
+
+## Summary
+
+| Step | Command | Why it matters |
+|------|---------|----------------|
+| 1 | `dbc cache refresh` | populates the local provider catalog |
+| 2 | `dbc search` | finds likely DBC names before fetching |
+| 3 | `dbc fetch` | downloads and caches a specific DBC |
+| 4 | `dbc inspect` | verifies the schema before use |
+| 5 | `decode --dbc opendbc:<name>` | decodes without a separate local path |
+| 6 | `re match-dbc` / `re shortlist-dbc` | ranks likely DBC fits against a capture |
+
+For the full command contract, see the [Command Spec](../command_spec.md).

--- a/docs/tutorials/generate_and_capture.md
+++ b/docs/tutorials/generate_and_capture.md
@@ -52,6 +52,8 @@ The terminal blocks and waits. Each arriving frame prints as a `candump`-style l
 
 ## Terminal 2 — Generate Frames
 
+If your `~/.canarchy/config.toml` enables `[safety].require_active_ack = true`, add `--ack-active` and reply `YES` when prompted before the transmit step begins.
+
 ### Random frames
 
 ```bash

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -8,9 +8,11 @@ Use them when you want a realistic, command-by-command path instead of reference
 
 * [J1939 Heavy Vehicle Analysis](j1939_heavy_vehicle.md) walks through PGN inspection, SPN extraction, and DM1 fault decoding from a heavy-vehicle trace.
 * [Generate and Capture](generate_and_capture.md) shows how to generate traffic in one terminal and observe it live from another terminal.
+* [Discover and Use Provider-Backed DBC Files](dbc_provider_workflow.md) walks through provider catalog refresh, search, fetch, inspection, decode, and DBC matching against a capture.
 
 ## Suggested Reading Order
 
 1. Start with [Getting Started](../getting_started.md) if you have not run CANarchy yet.
 2. Use [Generate and Capture](generate_and_capture.md) for a quick no-hardware workflow.
-3. Use [J1939 Heavy Vehicle Analysis](j1939_heavy_vehicle.md) for a protocol-aware analysis example.
+3. Use [Discover and Use Provider-Backed DBC Files](dbc_provider_workflow.md) for the current DBC catalog and provider-ref workflow.
+4. Use [J1939 Heavy Vehicle Analysis](j1939_heavy_vehicle.md) for a protocol-aware analysis example.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
       - CAN Tool Feature Matrix: feature-matrix.md
   - Tutorials:
       - Overview: tutorials/index.md
+      - Discover and Use Provider-Backed DBC Files: tutorials/dbc_provider_workflow.md
       - J1939 Heavy Vehicle Analysis: tutorials/j1939_heavy_vehicle.md
       - Generate and Capture: tutorials/generate_and_capture.md
   - Developers:


### PR DESCRIPTION
## Summary
- add a new provider-backed DBC workflow tutorial and wire it into the tutorials nav
- update tutorial discoverability and active-transmit guidance in the generate/capture walkthrough
- align the feature matrix with the shipped reverse-engineering and DBC-provider capabilities

## Verification
- `uv run --group docs mkdocs build --strict`

Closes #85