### PR TITLE
docs: refresh reverse-engineering specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Documentation
 
+* Refreshed the reverse-engineering design and test specs to distinguish the shipped helpers (`re counters`, `re entropy`, `re match-dbc`, `re shortlist-dbc`) from still-deferred `re signals` and `re correlate` work.
 * Refreshed tutorials and comparison docs to add a provider-backed DBC workflow tutorial, update tutorial discoverability, and align the feature matrix with the shipped reverse-engineering and DBC-provider capabilities.
 * Refreshed `docs/command_spec.md`, `docs/agents.md`, and related operator/spec docs to reflect the current DBC provider workflows, `dbc_source` provenance, reverse-engineering DBC matching commands, and the current curated MCP tool surface.
 * Updated `docs/architecture.md` to reflect the current DBC provider/cache/provenance subsystem and the shipped reverse-engineering DBC-matching commands.

--- a/docs/design/reverse-engineering-helpers.md
+++ b/docs/design/reverse-engineering-helpers.md
@@ -5,12 +5,12 @@
 | Field | Value |
 |-------|-------|
 | Status | Partial |
-| Command surface | `canarchy re signals`, `re counters`, `re entropy`, `re correlate` |
+| Command surface | `canarchy re signals`, `re counters`, `re entropy`, `re correlate`, `re match-dbc`, `re shortlist-dbc` |
 | Primary area | CLI, analysis |
 
 ## Goal
 
-Provide evidence-driven reverse-engineering helpers over recorded CAN traffic so operators can identify likely signals, counters, entropy-heavy fields, and correlations without treating heuristics as ground truth.
+Provide evidence-driven reverse-engineering helpers over recorded CAN traffic so operators can identify likely signals, counters, entropy-heavy fields, candidate DBC matches, and future correlations without treating heuristics as ground truth.
 
 ## User-Facing Motivation
 
@@ -20,7 +20,7 @@ Operators analysing unknown traffic need repeatable helpers that summarise likel
 
 | ID | Type | Requirement |
 |----|------|-------------|
-| `REQ-RE-01` | Ubiquitous | The system shall provide `re signals`, `re counters`, `re entropy`, and `re correlate` commands over capture files. |
+| `REQ-RE-01` | Ubiquitous | The system shall provide `re signals`, `re counters`, `re entropy`, `re correlate`, `re match-dbc`, and `re shortlist-dbc` commands over capture files. |
 | `REQ-RE-02` | Ubiquitous | Each reverse-engineering command shall operate passively on recorded traffic and shall not transmit frames. |
 | `REQ-RE-03` | Event-driven | When `re signals <file>` is invoked, the system shall return candidate field boundaries with supporting rationale and confidence metadata. |
 | `REQ-RE-04` | Event-driven | When `re counters <file>` is invoked, the system shall return candidate fields that exhibit monotonic incrementing behaviour, including rollover detection and monotonicity evidence. |
@@ -30,6 +30,8 @@ Operators analysing unknown traffic need repeatable helpers that summarise likel
 | `REQ-RE-08` | Ubiquitous | The commands shall support `--json`, `--jsonl`, and `--table` output modes. |
 | `REQ-RE-09` | Unwanted behaviour | If `re correlate` is invoked without `--reference`, the system shall return a structured error with code `RE_REFERENCE_REQUIRED` and exit code 1. |
 | `REQ-RE-10` | Unwanted behaviour | If the reference file is missing, malformed, or does not match the required timestamped numeric sample schema, the system shall return a structured error with code `RE_REFERENCE_INVALID` and exit code 1. |
+| `REQ-RE-11` | Event-driven | When `re match-dbc <capture>` is invoked, the system shall rank candidate DBCs by comparing provider-catalog message IDs against the capture's observed arbitration IDs. |
+| `REQ-RE-12` | Event-driven | When `re shortlist-dbc <capture> --make <brand>` is invoked, the system shall pre-filter provider-catalog candidates by make before ranking them against the capture. |
 
 ## Command Surface
 
@@ -38,11 +40,18 @@ canarchy re signals <file> [--json] [--jsonl] [--table] [--raw]
 canarchy re counters <file> [--json] [--jsonl] [--table] [--raw]
 canarchy re entropy <file> [--json] [--jsonl] [--table] [--raw]
 canarchy re correlate <file> --reference <file> [--json] [--jsonl] [--table] [--raw]
+canarchy re match-dbc <capture> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--table] [--raw]
+canarchy re shortlist-dbc <capture> --make <brand> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--table] [--raw]
 ```
 
 ### Initial scope assumptions
 
 The first implementation should be file-backed and deterministic. Live capture subscriptions, interactive tuning, and OEM-specific knowledge are explicitly deferred.
+
+Current implementation note:
+
+* `re counters`, `re entropy`, `re match-dbc`, and `re shortlist-dbc` are implemented as deterministic file-backed helpers
+* `re signals` and `re correlate` remain command-surface placeholders and are still deferred
 
 ## Responsibilities And Boundaries
 
@@ -51,6 +60,7 @@ In scope:
 * file-backed heuristic analysis over candump-style captures
 * confidence-bearing candidate output
 * command-specific summaries over arbitration IDs, bytes, bit ranges, and observed value series
+* provider-backed DBC candidate ranking against capture arbitration IDs
 
 Out of scope:
 
@@ -74,9 +84,9 @@ All reverse-engineering commands shall return:
 
 Each candidate shall include at least:
 
-* `arbitration_id`
-* `score` or `confidence`
-* `rationale`
+* an identifier appropriate to the candidate family, such as `arbitration_id` or `source_ref`
+* `score` or `confidence` when the helper returns ranked candidates
+* `rationale` when the helper emits heuristic justification
 
 ### `re signals`
 
@@ -144,6 +154,31 @@ Correlation candidates shall include:
 * `correlation`
 * `lag` when relevant
 * `sample_count`
+
+### `re match-dbc`
+
+DBC match candidates shall include:
+
+* `name`
+* `source_ref`
+* `score`
+* `matched_ids`
+* `total_capture_ids`
+
+Current implementation note:
+
+* `re match-dbc` is implemented as a deterministic file-backed helper
+* candidate scoring is frequency-weighted by captured arbitration-ID occurrence, not just unique ID overlap
+* the default provider is `opendbc`
+
+### `re shortlist-dbc`
+
+Shortlist candidates shall use the same output shape as `re match-dbc` with additional request metadata for the selected make filter.
+
+Current implementation note:
+
+* `re shortlist-dbc` is implemented as a deterministic file-backed helper
+* `--make` is required and narrows provider-catalog candidates before scoring
 
 ## Output Contracts
 

--- a/docs/tests/reverse-engineering-helpers.md
+++ b/docs/tests/reverse-engineering-helpers.md
@@ -14,41 +14,42 @@ Define the expected coverage for the reverse-engineering helper family so shippe
 
 ## Coverage Requirements
 
-* command-level success coverage for `re signals`, `re counters`, `re entropy`, and `re correlate`
+* command-level success coverage for shipped helpers: `re counters`, `re entropy`, `re match-dbc`, and `re shortlist-dbc`
 * passive file-backed analysis behavior
 * structured candidate output with rationale and confidence or score fields
 * representative edge cases for sparse captures, low-sample captures, and mixed arbitration IDs
-* structured error handling for missing captures and unsupported correlation references
-* human-readable ranked table output for each command
+* warning and limit behavior for provider-backed DBC matching workflows
+* structured error handling for missing captures and, when correlation is implemented, unsupported reference inputs
+* human-readable ranked table output for each shipped helper
 
 ## Requirement Traceability
 
 | Requirement ID | Covered by test IDs |
 |----------------|---------------------|
-| `REQ-RE-01` | `TEST-RE-01`, `TEST-RE-02`, `TEST-RE-03`, `TEST-RE-04` |
-| `REQ-RE-02` | `TEST-RE-01`, `TEST-RE-02`, `TEST-RE-03`, `TEST-RE-04` |
-| `REQ-RE-03` | `TEST-RE-01` |
+| `REQ-RE-01` | `TEST-RE-02`, `TEST-RE-03`, `TEST-RE-04`, `TEST-RE-05` |
+| `REQ-RE-02` | `TEST-RE-02`, `TEST-RE-03`, `TEST-RE-04`, `TEST-RE-05` |
+| `REQ-RE-03` | Deferred |
 | `REQ-RE-04` | `TEST-RE-02` |
 | `REQ-RE-05` | `TEST-RE-03` |
-| `REQ-RE-06` | `TEST-RE-04`, `TEST-RE-08` |
-| `REQ-RE-07` | `TEST-RE-01`, `TEST-RE-02`, `TEST-RE-03`, `TEST-RE-04` |
-| `REQ-RE-08` | `TEST-RE-05`, `TEST-RE-06` |
-| `REQ-RE-09` | `TEST-RE-04`, `TEST-RE-08` |
-| `REQ-RE-10` | `TEST-RE-07`, `TEST-RE-08`, `TEST-RE-09` |
+| `REQ-RE-06` | Deferred |
+| `REQ-RE-07` | `TEST-RE-02`, `TEST-RE-03`, `TEST-RE-04`, `TEST-RE-05` |
+| `REQ-RE-08` | `TEST-RE-06`, `TEST-RE-07` |
+| `REQ-RE-09` | Deferred |
+| `REQ-RE-10` | Deferred |
+| `REQ-RE-11` | `TEST-RE-04`, `TEST-RE-05`, `TEST-RE-08`, `TEST-RE-09` |
+| `REQ-RE-12` | `TEST-RE-05` |
 
 ## Representative Test Cases
 
-### `TEST-RE-01` — Signal candidate analysis
+### `TEST-RE-01` — Deferred signal candidate analysis
 
 ```gherkin
-Given  a capture fixture with varying byte fields is available
-When   the operator runs `canarchy re signals <fixture> --json`
-Then   the result shall indicate passive mode
-And    the result shall include ranked signal candidates
-And    each candidate shall include a confidence or score field and a rationale
+Given  `re signals` remains unimplemented
+When   the operator reviews the current shipped reverse-engineering helper coverage
+Then   signal candidate analysis shall be tracked as deferred work rather than represented as implemented coverage
 ```
 
-**Fixture:** capture file with signal-like byte variation.
+**Fixture:** none.
 
 ---
 
@@ -78,46 +79,58 @@ And    each entry shall include a sample count
 
 ---
 
-### `TEST-RE-04` — Correlation analysis
+### `TEST-RE-04` — DBC match analysis
 
 ```gherkin
-Given  a capture fixture and a reference series file are available
-And    the reference file conforms to the documented schema with timestamp and value fields
-When   the operator runs `canarchy re correlate <fixture> --reference <reference> --json`
-Then   the result shall include ranked correlation candidates
-And    each candidate shall include a correlation strength value and rationale
+Given  a capture fixture and a provider-backed DBC catalog are available
+When   the operator runs `canarchy re match-dbc <fixture> --json`
+Then   the result shall include ranked DBC candidates
+And    each candidate shall include `name`, `source_ref`, `score`, `matched_ids`, and `total_capture_ids`
 ```
 
-**Fixture:** capture file, `.json` or `.jsonl` reference series file.
+**Fixture:** capture file and mocked or cached provider catalog.
 
 ---
 
-### `TEST-RE-05` — Table output summaries
+### `TEST-RE-05` — DBC shortlist analysis
+
+```gherkin
+Given  a valid capture fixture and provider catalog are available
+When   the operator runs `canarchy re shortlist-dbc <fixture> --make <brand> --json`
+Then   the result shall include shortlist candidates filtered by make
+And    the response data shall record the selected `make`
+```
+
+**Fixture:** capture file and mocked or cached provider catalog.
+
+---
+
+### `TEST-RE-06` — Table output summaries for shipped helpers
 
 ```gherkin
 Given  a valid capture fixture is available
-When   the operator runs any `re` command with `--table`
+When   the operator runs a shipped `re` helper with `--table`
 Then   the output shall present a compact ranked summary
 And    score or confidence data shall be visible in the table
 ```
 
-**Fixture:** capture file appropriate to the command.
+**Fixture:** capture file appropriate to the shipped helper.
 
 ---
 
-### `TEST-RE-06` — JSONL behavior
+### `TEST-RE-07` — JSONL behavior for shipped helpers
 
 ```gherkin
 Given  a valid capture fixture is available
-When   the operator runs any `re` command with `--jsonl`
+When   the operator runs a shipped `re` helper with `--jsonl`
 Then   the output shall match the documented JSONL contract selected by the implementation
 ```
 
-**Fixture:** capture file appropriate to the command.
+**Fixture:** capture file appropriate to the shipped helper.
 
 ---
 
-### `TEST-RE-07` — Missing capture error
+### `TEST-RE-08` — Missing capture error
 
 ```gherkin
 Given  the specified capture file does not exist
@@ -130,24 +143,32 @@ And    the error shall be a structured capture-source error
 
 ---
 
-### `TEST-RE-08` — Missing or unsupported reference input
+### `TEST-RE-09` — Empty-catalog warning behavior for DBC matching
 
 ```gherkin
-Given  no `--reference` argument is provided
-When   the operator runs `canarchy re correlate <fixture>`
-Then   the command shall exit with code `1`
-And    `errors[0].code` shall equal `"RE_REFERENCE_REQUIRED"`
-
-Given  a reference file exists but does not contain timestamped numeric samples
-When   the operator runs `re correlate` with that reference file
-Then   `errors[0].code` shall equal `"RE_REFERENCE_INVALID"`
+Given  no provider-catalog candidates are available for DBC matching
+When   the operator runs `canarchy re match-dbc <fixture> --json`
+Then   the command shall still succeed
+And    the result shall contain a warning explaining that no candidates were available
 ```
 
-**Fixture:** none for missing-reference case; malformed reference file for schema-invalid case.
+**Fixture:** capture file and an empty mocked catalog.
 
 ---
 
-### `TEST-RE-09` — Low-sample or sparse capture behavior
+### `TEST-RE-10` — Match limit behavior
+
+```gherkin
+Given  more candidate DBCs are available than the requested limit
+When   the operator runs `canarchy re match-dbc <fixture> --limit <n> --json`
+Then   no more than `<n>` candidates shall be returned
+```
+
+**Fixture:** capture file and mocked catalog larger than the requested limit.
+
+---
+
+### `TEST-RE-11` — Low-sample or sparse capture behavior
 
 ```gherkin
 Given  a capture fixture with very few frames or low field variance is available
@@ -163,17 +184,18 @@ And    no candidates shall be presented as authoritative facts
 
 ## Fixture Requirements
 
-Planned fixtures should include:
+Fixtures should include:
 
 * captures with stable counters
 * captures with mixed-entropy fields
-* captures with likely analog-like signals
-* captures plus `.json` and `.jsonl` reference-series fixtures for correlation
+* captures sufficient for DBC-candidate ranking against mocked or cached provider catalogs
 * malformed and low-sample fixtures
 
 Current implementation note:
 
 * `re counters` is covered with fixtures for nibble counters, rollover counters, non-counter noise, and low-sample captures
+* `re entropy` is covered with fixtures for constant, alternating, high-entropy, and low-sample arbitration IDs
+* `re match-dbc` and `re shortlist-dbc` are covered with mocked provider catalogs for output shape, warnings, and limit handling
 
 ## Explicit Non-Coverage
 
@@ -183,4 +205,4 @@ Current implementation note:
 
 ## Traceability
 
-This spec defines the coverage target for the planned reverse-engineering helper implementation and should be refined as concrete candidate schemas and fixtures are chosen.
+This spec defines the coverage target for the current shipped reverse-engineering helpers and the deferred helpers that remain to be implemented.


### PR DESCRIPTION
## Summary
- update the reverse-engineering design spec to include shipped DBC-matching helpers and clarify deferred helpers
- update the reverse-engineering test spec so traceability and representative cases reflect current implementation coverage
- add the required changelog entry for the spec refresh

## Verification
- `uv run --group docs mkdocs build --strict`

Closes #87