### PR TITLE
fix: j1939 jsonl output for spn, tp, dm1 commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed `--jsonl` output for `j1939 spn`, `j1939 tp`, and `j1939 dm1` commands to emit one line per observation/session/message instead of falling back to full JSON payload. The JSONL emitter now checks for `observations`, `sessions`, and `messages` in addition to `events`.
+
 ### Documentation
 
 * Added dedicated design and test specs for the provider-backed DBC workflow, covering provider listing, catalog search, fetch, cache management, provider-ref resolution, `dbc_source` provenance, and `auto_refresh` behavior.

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -2116,6 +2116,20 @@ def emit_live_gateway(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def _emit_warnings_jsonl(payload: dict[str, Any], result: CommandResult) -> None:
+    for warning in payload["warnings"]:
+        print(
+            json.dumps(
+                AlertEvent(
+                    level="warning",
+                    message=warning,
+                    source=f"cli.{result.command}",
+                ).to_event().to_payload(),
+                sort_keys=True,
+            )
+        )
+
+
 def emit_result(result: CommandResult, output_format: str) -> None:
     payload = result.to_payload()
     if output_format == "json":
@@ -2123,21 +2137,30 @@ def emit_result(result: CommandResult, output_format: str) -> None:
         return
 
     if output_format == "jsonl":
-        events = payload.get("data", {}).get("events")
+        data = payload.get("data", {})
+        events = data.get("events")
         if result.ok and isinstance(events, list) and events:
             for event in events:
                 print(json.dumps(event, sort_keys=True))
-            for warning in payload["warnings"]:
-                print(
-                    json.dumps(
-                        AlertEvent(
-                            level="warning",
-                            message=warning,
-                            source=f"cli.{result.command}",
-                        ).to_event().to_payload(),
-                        sort_keys=True,
-                    )
-                )
+            _emit_warnings_jsonl(payload, result)
+            return
+        observations = data.get("observations")
+        if result.ok and isinstance(observations, list) and observations:
+            for observation in observations:
+                print(json.dumps(observation, sort_keys=True))
+            _emit_warnings_jsonl(payload, result)
+            return
+        sessions = data.get("sessions")
+        if result.ok and isinstance(sessions, list) and sessions:
+            for session in sessions:
+                print(json.dumps(session, sort_keys=True))
+            _emit_warnings_jsonl(payload, result)
+            return
+        messages = data.get("messages")
+        if result.ok and isinstance(messages, list) and messages:
+            for message in messages:
+                print(json.dumps(message, sort_keys=True))
+            _emit_warnings_jsonl(payload, result)
             return
         print(json.dumps(payload, sort_keys=True))
         return


### PR DESCRIPTION
## Summary
- Fixes `--jsonl` output for `j1939 spn`, `j1939 tp`, and `j1939 dm1` commands
- The JSONL emitter now checks for `observations`, `sessions`, and `messages` keys in addition to `events`
- Extracts warning emission into a reusable helper function

## Changes
- `cli.py`: Updated `emit_result()` to handle non-events result keys for JSONL output
- `CHANGELOG.md`: Added entry under `### Fixed`

## Verification
- j1939 spn --jsonl now emits one line per observation with spn, value, units, timestamp
- j1939 tp --jsonl now emits one line per session
- j1939 dm1 --jsonl now emits one line per message

Closes #100
