### PR TITLE
docs: fix j1939 spn jsonl jq example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * Added dedicated design and test specs for the provider-backed DBC workflow, covering provider listing, catalog search, fetch, cache management, provider-ref resolution, `dbc_source` provenance, and `auto_refresh` behavior.
 * Updated the command reference to document the shipped `generate` command plus current `--stdin` and `--ack-active` command-surface details where the docs had drifted from the implementation.
 * Corrected several requirement-to-test traceability tables so the current spec set no longer overstates coverage for transport, UDS, J1939, shell, gateway, and generate workflows.
+* Updated the J1939 heavy-vehicle tutorial so its `jq` example matches the current `j1939 spn --jsonl` output shape and no longer queries stale `.payload.*` fields.
 
 ## [0.2.0] - 2026-04-19
 

--- a/docs/tutorials/j1939_heavy_vehicle.md
+++ b/docs/tutorials/j1939_heavy_vehicle.md
@@ -105,7 +105,7 @@ The ECU has already flagged both the coolant overheat and engine speed anomaly. 
 
 ## Machine-Readable Output
 
-All three commands support `--json` for a full structured envelope or `--jsonl` for a streaming event-per-line format. JSONL is suitable for piping into further analysis tools:
+All three commands support `--json` for a full structured envelope or `--jsonl` for one structured record per line. `j1939 decode` emits J1939 observation events, while `j1939 spn`, `j1939 tp`, and `j1939 dm1` emit the decoded observation, session, or message objects directly. JSONL is suitable for piping into further analysis tools:
 
 ```bash
 # Stream all J1939 observations as JSONL
@@ -113,7 +113,7 @@ canarchy j1939 decode tests/fixtures/j1939_heavy_vehicle.candump --jsonl
 
 # Extract just the coolant temperature values with jq
 canarchy j1939 spn 110 --file tests/fixtures/j1939_heavy_vehicle.candump --jsonl \
-  | jq '[.payload.spn, .payload.value, .payload.units, .payload.timestamp]'
+  | jq '[.spn, .value, .units, .timestamp]'
 ```
 
 ```text
@@ -122,7 +122,7 @@ canarchy j1939 spn 110 --file tests/fixtures/j1939_heavy_vehicle.candump --jsonl
 [110, 87.0, "degC", 0.55]
 ```
 
-See the [Event Schema](../event-schema.md) for the full structure of each event type.
+See the [Event Schema](../event-schema.md) for the streamed event types such as `j1939 decode`.
 
 ---
 


### PR DESCRIPTION
## Summary
- update the J1939 heavy-vehicle tutorial to match the current `j1939 spn --jsonl` output shape
- switch the `jq` example from stale `.payload.*` fields to direct object fields
- record the tutorial correction in the changelog

## Verification
- `uv run canarchy j1939 spn 110 --file tests/fixtures/j1939_heavy_vehicle.candump --jsonl | jq '[.spn, .value, .units, .timestamp]'`

Refs #100
