### PR TITLE
perf: stream j1939 file-backed analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * Expanded `j1939 spn` beyond the curated starter map by resolving non-curated SPNs from J1939 DBC signal `SPN` metadata when a matching DBC is supplied or configured as the default J1939 database.
 * Extended the same J1939 DBC coverage idea into `j1939 dm1` so DTC names and units can be enriched from DBC signal `SPN` metadata, with the same `--dbc` and default J1939 DBC config path used by other J1939 decode workflows.
 * Deepened the J1939 transport and DM1 path beyond the earlier BAM-only starter behavior so `j1939 tp` and `j1939 dm1` now handle RTS/CTS sessions in addition to BAM, including reassembly and session-level acknowledgement metadata.
+* File-backed J1939 decode paths now stream candump input line-by-line instead of reading the whole capture text into memory up front, and the hot `j1939 decode`, `j1939 pgn`, `j1939 spn`, `j1939 tp`, and `j1939 dm1` paths now use single-pass iteration where DBC enrichment does not require a retained frame list.
 
 ### Documentation
 

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -1163,8 +1163,16 @@ def j1939_payload(
         )
     if args.command == "j1939 decode":
         decoder = get_j1939_decoder()
-        frames = frames_from_stdin(command=args.command) if args.stdin else transport.frames_from_file(args.file)
-        events = decoder.decode_events(frames)
+        dbc_ref = getattr(args, "dbc", None) or default_j1939_dbc()
+        if args.stdin:
+            frames = frames_from_stdin(command=args.command)
+            events = decoder.decode_events(frames)
+        elif dbc_ref:
+            frames = transport.frames_from_file(args.file)
+            events = decoder.decode_events(frames)
+        else:
+            events = decoder.decode_events(transport.iter_frames_from_file(args.file))
+            frames = []
         warnings = []
         if not events:
             warnings.append("No J1939 extended ID frames were found in the input.")
@@ -1184,8 +1192,7 @@ def j1939_payload(
         )
     if args.command == "j1939 pgn":
         decoder = get_j1939_decoder()
-        frames = transport.frames_from_file(args.file)
-        event_objects = decoder.decode_pgn_events(frames, args.pgn)
+        event_objects = decoder.decode_pgn_events(transport.iter_frames_from_file(args.file), args.pgn)
         matched_frames = [frame for frame in (getattr(event, "frame", None) for event in event_objects) if frame is not None]
         data, dbc_warnings = enrich_with_dbc(
             {"mode": "passive", "pgn": args.pgn, "file": args.file},
@@ -1198,26 +1205,31 @@ def j1939_payload(
         )
     if args.command == "j1939 spn":
         decoder = get_j1939_decoder()
-        frames = transport.frames_from_file(args.file)
         dbc_ref = getattr(args, "dbc", None) or default_j1939_dbc()
-        if args.spn in decoder.supported_spns():
-            observations = decoder.spn_observations(frames, args.spn)
+        if args.spn in decoder.supported_spns() and not dbc_ref:
+            observations = decoder.spn_observations(transport.iter_frames_from_file(args.file), args.spn)
             decoder_name = "curated_spn_map"
-        elif dbc_ref:
-            observations = decode_j1939_spn(frames, dbc_ref, args.spn)
-            decoder_name = "dbc_spn_map"
+            matching_frames: list[Any] = []
         else:
-            observations = []
-            decoder_name = "curated_spn_map"
+            frames = transport.frames_from_file(args.file)
+            if args.spn in decoder.supported_spns():
+                observations = decoder.spn_observations(frames, args.spn)
+                decoder_name = "curated_spn_map"
+            elif dbc_ref:
+                observations = decode_j1939_spn(frames, dbc_ref, args.spn)
+                decoder_name = "dbc_spn_map"
+            else:
+                observations = []
+                decoder_name = "curated_spn_map"
+            matched_pgns = {int(observation["pgn"]) for observation in observations}
+            matching_frames = [
+                frame
+                for frame in frames
+                if frame.is_extended_id and decompose_arbitration_id(frame.arbitration_id).pgn in matched_pgns
+            ]
         warnings = []
         if not observations:
             warnings.append("No observations for the selected SPN were found in the capture.")
-        matched_pgns = {int(observation["pgn"]) for observation in observations}
-        matching_frames = [
-            frame
-            for frame in frames
-            if frame.is_extended_id and decompose_arbitration_id(frame.arbitration_id).pgn in matched_pgns
-        ]
         data, dbc_warnings = enrich_with_dbc(
             {
                 "mode": "passive",
@@ -1237,7 +1249,7 @@ def j1939_payload(
         )
     if args.command == "j1939 tp":
         decoder = get_j1939_decoder()
-        sessions = decoder.transport_protocol_sessions(transport.frames_from_file(args.file))
+        sessions = decoder.transport_protocol_sessions(transport.iter_frames_from_file(args.file))
         warnings = []
         if not sessions:
             warnings.append("No J1939 transport protocol sessions were found in the capture.")
@@ -1253,7 +1265,7 @@ def j1939_payload(
         )
     if args.command == "j1939 dm1":
         decoder = get_j1939_decoder()
-        messages = decoder.dm1_messages(transport.frames_from_file(args.file))
+        messages = decoder.dm1_messages(transport.iter_frames_from_file(args.file))
         warnings = dm1_warnings(messages)
         data, dbc_warnings = enrich_dm1_with_dbc(
             {

--- a/src/canarchy/j1939_decoder.py
+++ b/src/canarchy/j1939_decoder.py
@@ -8,7 +8,7 @@ decoder without reshaping command handlers first.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Iterable, Protocol
 
 import j1939 as can_j1939
 
@@ -19,15 +19,15 @@ from canarchy.models import CanFrame, J1939ObservationEvent
 class J1939Decoder(Protocol):
     def supported_spns(self) -> set[int]: ...
 
-    def decode_events(self, frames: list[CanFrame]) -> list[J1939ObservationEvent]: ...
+    def decode_events(self, frames: Iterable[CanFrame]) -> list[J1939ObservationEvent]: ...
 
-    def decode_pgn_events(self, frames: list[CanFrame], pgn: int) -> list[J1939ObservationEvent]: ...
+    def decode_pgn_events(self, frames: Iterable[CanFrame], pgn: int) -> list[J1939ObservationEvent]: ...
 
-    def spn_observations(self, frames: list[CanFrame], spn: int) -> list[dict[str, object]]: ...
+    def spn_observations(self, frames: Iterable[CanFrame], spn: int) -> list[dict[str, object]]: ...
 
-    def transport_protocol_sessions(self, frames: list[CanFrame]) -> list[dict[str, object]]: ...
+    def transport_protocol_sessions(self, frames: Iterable[CanFrame]) -> list[dict[str, object]]: ...
 
-    def dm1_messages(self, frames: list[CanFrame]) -> list[dict[str, object]]: ...
+    def dm1_messages(self, frames: Iterable[CanFrame]) -> list[dict[str, object]]: ...
 
 
 @dataclass(slots=True)
@@ -43,13 +43,13 @@ class CanJ1939Decoder:
     def supported_spns(self) -> set[int]:
         return set(SUPPORTED_SPN_DEFINITIONS)
 
-    def decode_events(self, frames: list[CanFrame]) -> list[J1939ObservationEvent]:
+    def decode_events(self, frames: Iterable[CanFrame]) -> list[J1939ObservationEvent]:
         return self._decode_events(frames, pgn=None)
 
-    def decode_pgn_events(self, frames: list[CanFrame], pgn: int) -> list[J1939ObservationEvent]:
+    def decode_pgn_events(self, frames: Iterable[CanFrame], pgn: int) -> list[J1939ObservationEvent]:
         return self._decode_events(frames, pgn=pgn)
 
-    def _decode_events(self, frames: list[CanFrame], pgn: int | None) -> list[J1939ObservationEvent]:
+    def _decode_events(self, frames: Iterable[CanFrame], pgn: int | None) -> list[J1939ObservationEvent]:
         events: list[J1939ObservationEvent] = []
         for frame in frames:
             if not frame.is_extended_id:
@@ -69,7 +69,7 @@ class CanJ1939Decoder:
             )
         return events
 
-    def spn_observations(self, frames: list[CanFrame], spn: int) -> list[dict[str, object]]:
+    def spn_observations(self, frames: Iterable[CanFrame], spn: int) -> list[dict[str, object]]:
         definition = SUPPORTED_SPN_DEFINITIONS[spn]
         observations: list[dict[str, object]] = []
         for frame in frames:
@@ -99,7 +99,7 @@ class CanJ1939Decoder:
             )
         return observations
 
-    def transport_protocol_sessions(self, frames: list[CanFrame]) -> list[dict[str, object]]:
+    def transport_protocol_sessions(self, frames: Iterable[CanFrame]) -> list[dict[str, object]]:
         sessions: list[dict[str, object]] = []
         open_sessions: dict[tuple[int, int | None], dict[str, object]] = {}
         tp_cm_pgn = can_j1939.ParameterGroupNumber.PGN.TP_CM
@@ -183,14 +183,55 @@ class CanJ1939Decoder:
             )
         return summaries
 
-    def dm1_messages(self, frames: list[CanFrame]) -> list[dict[str, object]]:
+    def dm1_messages(self, frames: Iterable[CanFrame]) -> list[dict[str, object]]:
         messages: list[dict[str, object]] = []
+        open_sessions: dict[tuple[int, int | None], dict[str, object]] = {}
+        tp_sessions: list[dict[str, object]] = []
+        tp_cm_pgn = can_j1939.ParameterGroupNumber.PGN.TP_CM
+        tp_dt_pgn = can_j1939.ParameterGroupNumber.PGN.DATATRANSFER
+
         for frame in frames:
             if not frame.is_extended_id:
                 continue
             identifier = decompose_arbitration_id(frame.arbitration_id)
             if identifier.pgn != DM1_PGN:
+                if identifier.pgn == tp_cm_pgn and len(frame.data) >= 8:
+                    control = frame.data[0]
+                    if control in {self.TP_CM_BAM, self.TP_CM_RTS}:
+                        transfer_pgn = frame.data[5] | (frame.data[6] << 8) | (frame.data[7] << 16)
+                        if transfer_pgn != DM1_PGN:
+                            continue
+                        session = {
+                            "destination_address": identifier.destination_address,
+                            "packets": {},
+                            "source_address": identifier.source_address,
+                            "timestamp": frame.timestamp,
+                            "total_bytes": frame.data[1] | (frame.data[2] << 8),
+                            "total_packets": frame.data[3],
+                            "transfer_pgn": transfer_pgn,
+                        }
+                        open_sessions[(identifier.source_address, identifier.destination_address)] = session
+                        tp_sessions.append(session)
+                        continue
+
+                    reverse_key = (identifier.destination_address, identifier.source_address)
+                    session = open_sessions.get(reverse_key)
+                    if session is None:
+                        continue
+                    if control == self.TP_CM_ABORT:
+                        session["aborted"] = True
+                    continue
+
+                if identifier.pgn == tp_dt_pgn and len(frame.data) >= 2:
+                    key = (identifier.source_address, identifier.destination_address)
+                    session = open_sessions.get(key)
+                    if session is None:
+                        continue
+                    packets = session["packets"]
+                    assert isinstance(packets, dict)
+                    packets[frame.data[0]] = frame.data[1:]
                 continue
+
             messages.append(
                 self._build_dm1_message(
                     payload=frame.data,
@@ -201,10 +242,16 @@ class CanJ1939Decoder:
                 )
             )
 
-        for session in self.transport_protocol_sessions(frames):
-            if session["transfer_pgn"] != DM1_PGN or not session["complete"]:
+        for session in tp_sessions:
+            packets = session.pop("packets")
+            assert isinstance(packets, dict)
+            total_packets = int(session["total_packets"])
+            packet_count = len(packets)
+            reassembled = b"".join(packets[index] for index in range(1, total_packets + 1) if index in packets)
+            total_bytes = int(session["total_bytes"])
+            payload = reassembled[:total_bytes]
+            if bool(session.get("aborted", False)) or len(payload) < total_bytes or packet_count < total_packets:
                 continue
-            payload = bytes.fromhex(str(session["reassembled_data"]))
             messages.append(
                 self._build_dm1_message(
                     payload=payload,

--- a/src/canarchy/transport.py
+++ b/src/canarchy/transport.py
@@ -515,7 +515,18 @@ class LocalTransport:
         )
 
     def frames_from_file(self, file_name: str) -> list[CanFrame]:
-        return self._frames_for_file(file_name)
+        return list(self.iter_frames_from_file(file_name))
+
+    def iter_frames_from_file(self, file_name: str) -> Iterator[CanFrame]:
+        path = self._capture_file_path(file_name)
+        try:
+            yield from iter_candump_file(path)
+        except OSError as exc:
+            raise TransportError(
+                "CAPTURE_SOURCE_UNAVAILABLE",
+                f"Capture source '{file_name}' could not be read.",
+                "Check file permissions and try again.",
+            ) from exc
 
     def capture_events(self, interface: str) -> list[dict[str, object]]:
         frames = self.capture(interface)
@@ -768,6 +779,9 @@ class LocalTransport:
         ScaffoldCanBackend()._require_interface(interface)
 
     def _frames_for_file(self, file_name: str) -> list[CanFrame]:
+        return list(self.iter_frames_from_file(file_name))
+
+    def _capture_file_path(self, file_name: str) -> Path:
         path = Path(file_name)
         if file_name.lower() in {"missing.log", "missing", "offline.log"} or not path.exists():
             raise TransportError(
@@ -788,15 +802,7 @@ class LocalTransport:
                 f"Capture source '{file_name}' uses an unsupported file format.",
                 f"Use a candump log file with one of these suffixes: {supported_formats}.",
             )
-
-        try:
-            return load_candump_file(path)
-        except OSError as exc:
-            raise TransportError(
-                "CAPTURE_SOURCE_UNAVAILABLE",
-                f"Capture source '{file_name}' could not be read.",
-                "Check file permissions and try again.",
-            ) from exc
+        return path
 
     def _pgn(self, frame: CanFrame) -> int:
         return decompose_arbitration_id(frame.arbitration_id).pgn
@@ -826,13 +832,19 @@ class LocalTransport:
         return events
 
 
+def iter_candump_file(path: Path) -> Iterator[CanFrame]:
+    with path.open(encoding="utf-8") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            stripped = raw_line.strip()
+            if not stripped:
+                continue
+            yield parse_candump_line(stripped, path=path, line_number=line_number)
+
+
 def load_candump_file(path: Path) -> list[CanFrame]:
     frames: list[CanFrame] = []
-    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-        stripped = raw_line.strip()
-        if not stripped:
-            continue
-        frames.append(parse_candump_line(stripped, path=path, line_number=line_number))
+    for frame in iter_candump_file(path):
+        frames.append(frame)
     return frames
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1619,7 +1619,7 @@ class CliTests(unittest.TestCase):
 
         with (
             patch("canarchy.cli.get_j1939_decoder", return_value=fake_decoder),
-            patch("canarchy.cli.LocalTransport.frames_from_file", return_value=[frame]),
+            patch("canarchy.cli.LocalTransport.iter_frames_from_file", return_value=iter([frame])),
         ):
             exit_code, stdout, stderr = run_cli(
                 "j1939",
@@ -1658,7 +1658,7 @@ class CliTests(unittest.TestCase):
 
         with (
             patch("canarchy.cli.get_j1939_decoder", return_value=fake_decoder),
-            patch("canarchy.cli.LocalTransport.frames_from_file", return_value=[frame]),
+            patch("canarchy.cli.LocalTransport.iter_frames_from_file", return_value=iter([frame])),
         ):
             exit_code, stdout, stderr = run_cli(
                 "j1939",
@@ -1711,7 +1711,7 @@ class CliTests(unittest.TestCase):
 
         with (
             patch("canarchy.cli.get_j1939_decoder", return_value=fake_decoder),
-            patch("canarchy.cli.LocalTransport.frames_from_file", return_value=[frame]),
+            patch("canarchy.cli.LocalTransport.iter_frames_from_file", return_value=iter([frame])),
         ):
             tp_exit_code, tp_stdout, tp_stderr = run_cli(
                 "j1939",
@@ -1760,7 +1760,7 @@ class CliTests(unittest.TestCase):
 
         with (
             patch("canarchy.cli.get_j1939_decoder", return_value=fake_decoder),
-            patch("canarchy.cli.LocalTransport.frames_from_file", return_value=[frame]),
+            patch("canarchy.cli.LocalTransport.iter_frames_from_file", return_value=iter([frame])),
         ):
             exit_code, stdout, stderr = run_cli(
                 "j1939",

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -18,6 +18,7 @@ from canarchy.transport import (
     TransportBackendConfig,
     TransportError,
     build_live_backend,
+    iter_candump_file,
     load_candump_file,
     parse_candump_line,
     python_can,
@@ -90,6 +91,18 @@ class TransportBackendTests(unittest.TestCase):
         self.assertEqual(frames[1].arbitration_id, 0x18F00431)
         self.assertTrue(frames[1].is_extended_id)
         self.assertEqual(frames[2].interface, "can1")
+
+    def test_load_candump_file_streams_without_read_text(self) -> None:
+        with patch.object(Path, "read_text", side_effect=AssertionError("read_text should not be used")):
+            frames = load_candump_file(FIXTURES / "sample.candump")
+
+        self.assertEqual(len(frames), 3)
+
+    def test_iter_candump_file_yields_real_frames(self) -> None:
+        frames = list(iter_candump_file(FIXTURES / "sample.candump"))
+
+        self.assertEqual(len(frames), 3)
+        self.assertEqual(frames[0].interface, "can0")
 
     def test_parse_candump_line_rejects_malformed_lines(self) -> None:
         with self.assertRaises(TransportError) as ctx:


### PR DESCRIPTION
## Summary
- stream candump input line-by-line through a new iter_frames_from_file transport path instead of loading full capture text up front
- switch the hot file-backed J1939 command paths (j1939 decode, j1939 pgn, j1939 spn, j1939 tp, and j1939 dm1) to single-pass iteration where DBC enrichment does not require a retained frame list
- keep DM1 transport reassembly single-pass so j1939 dm1 no longer requires a second full scan over an in-memory frame list, and add regression coverage for the streamed loader path

## Profiling Notes
Profiling a 20k-line synthetic candump after initialization showed the file-backed hot path dominated by line parsing in iter_candump_file, parse_candump_line, and parse_candump_classic_line. This branch removes the avoidable whole-file text read and frame-list materialization step before that parse work for the targeted J1939 commands.

## Verification
- uv run pytest tests/test_transport.py tests/test_cli.py -k "j1939 or candump"
- uv run pytest tests/test_j1939.py

Refs #103