### PR TITLE
feat: add bounded j1939 file analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * Extended the same J1939 DBC coverage idea into `j1939 dm1` so DTC names and units can be enriched from DBC signal `SPN` metadata, with the same `--dbc` and default J1939 DBC config path used by other J1939 decode workflows.
 * Deepened the J1939 transport and DM1 path beyond the earlier BAM-only starter behavior so `j1939 tp` and `j1939 dm1` now handle RTS/CTS sessions in addition to BAM, including reassembly and session-level acknowledgement metadata.
 * File-backed J1939 decode paths now stream candump input line-by-line instead of reading the whole capture text into memory up front, and the hot `j1939 decode`, `j1939 pgn`, `j1939 spn`, `j1939 tp`, and `j1939 dm1` paths now use single-pass iteration where DBC enrichment does not require a retained frame list.
+* File-backed `j1939 decode`, `j1939 pgn`, `j1939 spn`, `j1939 tp`, and `j1939 dm1` now accept `--max-frames` and `--seconds` bounds so operators can scope large-capture analysis to an initial frame window or time window without scanning the entire file.
 
 ### Documentation
 

--- a/docs/design/j1939-bounded-analysis.md
+++ b/docs/design/j1939-bounded-analysis.md
@@ -1,0 +1,75 @@
+# Design Spec: J1939 Bounded File Analysis
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| Status | Implemented |
+| Command surface | `canarchy j1939 decode`, `j1939 pgn`, `j1939 spn`, `j1939 tp`, `j1939 dm1` |
+| Primary area | CLI, transport, protocol |
+| Related specs | `docs/design/j1939-first-class-decoder.md`, `docs/design/j1939-expanded-workflows.md` |
+
+## Goal
+
+Add bounded-analysis controls to file-backed J1939 workflows so operators can inspect large captures predictably without forcing every command to scan the entire file.
+
+## User-Facing Motivation
+
+Large heavy-vehicle captures often contain millions of frames. Analysts need to ask scoped questions such as "show me the first 30 seconds" or "inspect only the first 10,000 frames" before committing to a full-file pass.
+
+## Requirements
+
+| ID | Type | Requirement |
+|----|------|-------------|
+| `REQ-J1939WIN-01` | Optional feature | Where a file-backed J1939 analysis command supports bounded analysis, the system shall accept `--max-frames <n>` to limit work to the first `<n>` frames in the capture. |
+| `REQ-J1939WIN-02` | Optional feature | Where a file-backed J1939 analysis command supports bounded analysis, the system shall accept `--seconds <n>` to limit work to frames whose timestamps fall within the first `<n>` seconds of the capture window. |
+| `REQ-J1939WIN-03` | Event-driven | When `j1939 decode`, `j1939 pgn`, `j1939 spn`, `j1939 tp`, or `j1939 dm1` is invoked with bounded-analysis flags against a capture file, the system shall apply those bounds during file iteration rather than after a full-file read. |
+| `REQ-J1939WIN-04` | Unwanted behaviour | If `--max-frames` is less than `1`, the system shall return a structured user error with code `INVALID_MAX_FRAMES`. |
+| `REQ-J1939WIN-05` | Unwanted behaviour | If `--seconds` is negative, the system shall return a structured user error with code `INVALID_ANALYSIS_SECONDS`. |
+| `REQ-J1939WIN-06` | Unwanted behaviour | If bounded-analysis flags are used with `j1939 decode --stdin`, the system shall return a structured user error with code `ANALYSIS_WINDOW_REQUIRES_FILE`. |
+
+## Command Surface
+
+```text
+canarchy j1939 decode <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--table] [--raw]
+canarchy j1939 pgn <pgn> --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--table] [--raw]
+canarchy j1939 spn <spn> --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--table] [--raw]
+canarchy j1939 tp <capture> [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--table] [--raw]
+canarchy j1939 dm1 <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--table] [--raw]
+```
+
+## Responsibilities And Boundaries
+
+In scope:
+
+* frame-count bounds for file-backed J1939 analysis
+* initial time-window bounds measured from the first parsed frame timestamp in the capture
+* enforcing bounds while iterating over candump files
+
+Out of scope:
+
+* arbitrary later-window selection such as `--from` / `--to`
+* sampling semantics such as every-Nth-frame selection
+* bounded-analysis controls for live monitor or stdin workflows
+
+## Data Model
+
+The existing command result envelopes remain unchanged. Bounded-analysis flags affect which capture frames are inspected and therefore which events, observations, sessions, or messages appear in `data`.
+
+## Output Contracts
+
+All existing output modes remain available. `--json` and `--jsonl` continue to emit the same command-specific payload shapes as their unbounded counterparts, but only for the bounded capture slice.
+
+## Error Contracts
+
+| Code | Trigger | Exit code |
+|------|---------|-----------|
+| `INVALID_MAX_FRAMES` | `--max-frames` is less than `1` | 1 |
+| `INVALID_ANALYSIS_SECONDS` | `--seconds` is negative | 1 |
+| `ANALYSIS_WINDOW_REQUIRES_FILE` | bounded-analysis flags are used with `j1939 decode --stdin` | 1 |
+
+## Deferred Decisions
+
+* whether later-window selection should use `--from` / `--to` capture timestamps or relative offsets
+* whether bounded-analysis metadata should be echoed explicitly in command payloads
+* whether sampling controls should share this command surface or land as a separate follow-on feature

--- a/docs/tests/j1939-bounded-analysis.md
+++ b/docs/tests/j1939-bounded-analysis.md
@@ -1,0 +1,123 @@
+# Test Spec: J1939 Bounded File Analysis
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| Status | Implemented |
+| Design doc | `docs/design/j1939-bounded-analysis.md` |
+| Test file | `tests/test_cli.py`, `tests/test_transport.py` |
+
+## Requirement Traceability
+
+| REQ ID | Description summary | TEST IDs |
+|--------|--------------------|----------|
+| `REQ-J1939WIN-01` | File-backed J1939 commands support `--max-frames` | `TEST-J1939WIN-01`, `TEST-J1939WIN-04` |
+| `REQ-J1939WIN-02` | File-backed J1939 commands support `--seconds` | `TEST-J1939WIN-02`, `TEST-J1939WIN-05` |
+| `REQ-J1939WIN-03` | Bounds are applied during file iteration | `TEST-J1939WIN-04`, `TEST-J1939WIN-05` |
+| `REQ-J1939WIN-04` | Invalid `--max-frames` returns structured error | `TEST-J1939WIN-03` |
+| `REQ-J1939WIN-05` | Invalid `--seconds` returns structured error | `TEST-J1939WIN-06` |
+| `REQ-J1939WIN-06` | Bounded analysis is rejected with `j1939 decode --stdin` | `TEST-J1939WIN-07` |
+
+## Test Cases
+
+### TEST-J1939WIN-01 — Frame bound limits `j1939 decode`
+
+```gherkin
+Given  a capture fixture contains more J1939 frames than the requested frame bound
+When   the operator runs `canarchy j1939 decode <capture> --max-frames 3 --json`
+Then   the system shall return only records derived from the first three capture frames
+And    the command shall remain otherwise valid JSON output
+```
+
+**Fixture:** `tests/fixtures/j1939_heavy_vehicle.candump`.
+
+---
+
+### TEST-J1939WIN-02 — Time bound limits `j1939 tp`
+
+```gherkin
+Given  a transport-protocol fixture spans multiple timestamps
+When   the operator runs `canarchy j1939 tp <capture> --seconds 0.08 --json`
+Then   the system shall analyse only the initial capture-time window
+And    the returned session summary shall reflect an incomplete reassembly if later packets fall outside the window
+```
+
+**Fixture:** `tests/fixtures/j1939_dm1_tp.candump`.
+
+---
+
+### TEST-J1939WIN-03 — Invalid frame bounds fail cleanly
+
+```gherkin
+Given  a valid J1939 DM1 capture file
+When   the operator runs `canarchy j1939 dm1 <capture> --max-frames 0 --json`
+Then   the system shall exit with code `1`
+And    `errors[0].code` shall equal `"INVALID_MAX_FRAMES"`
+```
+
+**Fixture:** `tests/fixtures/j1939_dm1_tp.candump`.
+
+---
+
+### TEST-J1939WIN-04 — Transport iterator enforces frame count bounds
+
+```gherkin
+Given  a candump fixture contains more than three frames
+When   the transport layer iterates that file with `max_frames=3`
+Then   the system shall yield exactly three parsed frames
+And    the iterator shall stop without reading the rest of the capture into the returned sequence
+```
+
+**Fixture:** `tests/fixtures/j1939_heavy_vehicle.candump`.
+
+---
+
+### TEST-J1939WIN-05 — Transport iterator enforces time bounds
+
+```gherkin
+Given  a candump fixture contains timestamps beyond the requested time window
+When   the transport layer iterates that file with `seconds=0.15`
+Then   the system shall yield only frames whose timestamps fall within the initial 0.15-second window
+And    later frames shall not appear in the yielded sequence
+```
+
+**Fixture:** `tests/fixtures/j1939_heavy_vehicle.candump`.
+
+---
+
+### TEST-J1939WIN-06 — Invalid seconds fail cleanly
+
+```gherkin
+Given  a valid J1939 TP capture file
+When   the operator runs `canarchy j1939 tp <capture> --seconds -1 --json`
+Then   the system shall exit with code `1`
+And    `errors[0].code` shall equal `"INVALID_ANALYSIS_SECONDS"`
+```
+
+**Fixture:** `tests/fixtures/j1939_dm1_tp.candump`.
+
+---
+
+### TEST-J1939WIN-07 — Bounded analysis flags are file-only for `j1939 decode`
+
+```gherkin
+Given  `j1939 decode` is reading frame events from stdin
+When   the operator runs `canarchy j1939 decode --stdin --seconds 1.0 --json`
+Then   the system shall exit with code `1`
+And    `errors[0].code` shall equal `"ANALYSIS_WINDOW_REQUIRES_FILE"`
+```
+
+**Fixture:** mocked stdin JSONL frame event stream.
+
+## Fixtures And Environment
+
+* `tests/fixtures/j1939_heavy_vehicle.candump`
+* `tests/fixtures/j1939_dm1_tp.candump`
+* mocked stdin JSONL frame event input for the file-only validation path
+
+## Explicit Non-Coverage
+
+* later-window selection such as `--from` / `--to`
+* sampling or every-Nth-frame semantics
+* performance benchmarking on production-sized captures, which remains a separate performance concern

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -147,6 +147,19 @@ def add_active_ack_argument(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def add_j1939_file_analysis_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--max-frames",
+        type=int,
+        help="limit analysis to the first N frames from the capture file",
+    )
+    parser.add_argument(
+        "--seconds",
+        type=float,
+        help="limit analysis to the first N seconds from the capture start timestamp",
+    )
+
+
 def build_parser() -> CanarchyArgumentParser:
     parser = CanarchyArgumentParser(
         prog="canarchy", description="CLI-first CAN security research toolkit"
@@ -320,6 +333,7 @@ def build_parser() -> CanarchyArgumentParser:
     j1939_decode.add_argument("file", nargs="?", default=None)
     j1939_decode.add_argument("--stdin", action="store_true", help="read JSONL FrameEvents from stdin")
     j1939_decode.add_argument("--dbc", help="enrich J1939 results with a local DBC path or provider ref")
+    add_j1939_file_analysis_arguments(j1939_decode)
     add_output_arguments(j1939_decode)
     j1939_decode.set_defaults(command="j1939 decode")
 
@@ -327,6 +341,7 @@ def build_parser() -> CanarchyArgumentParser:
     j1939_pgn.add_argument("pgn", type=int)
     j1939_pgn.add_argument("--file", help="inspect the PGN within a capture file")
     j1939_pgn.add_argument("--dbc", help="enrich J1939 results with a local DBC path or provider ref")
+    add_j1939_file_analysis_arguments(j1939_pgn)
     add_output_arguments(j1939_pgn)
     j1939_pgn.set_defaults(command="j1939 pgn")
 
@@ -334,17 +349,20 @@ def build_parser() -> CanarchyArgumentParser:
     j1939_spn.add_argument("spn", type=int)
     j1939_spn.add_argument("--file", help="inspect the SPN within a capture file")
     j1939_spn.add_argument("--dbc", help="enrich J1939 results with a local DBC path or provider ref")
+    add_j1939_file_analysis_arguments(j1939_spn)
     add_output_arguments(j1939_spn)
     j1939_spn.set_defaults(command="j1939 spn")
 
     j1939_tp = j1939_subparsers.add_parser("tp", help="inspect J1939 transport protocol")
     j1939_tp.add_argument("file")
+    add_j1939_file_analysis_arguments(j1939_tp)
     add_output_arguments(j1939_tp)
     j1939_tp.set_defaults(command="j1939 tp")
 
     j1939_dm1 = j1939_subparsers.add_parser("dm1", help="inspect J1939 DM1 traffic")
     j1939_dm1.add_argument("file")
     j1939_dm1.add_argument("--dbc", help="enrich DM1 DTC names with a local DBC path or provider ref")
+    add_j1939_file_analysis_arguments(j1939_dm1)
     add_output_arguments(j1939_dm1)
     j1939_dm1.set_defaults(command="j1939 dm1")
 
@@ -786,6 +804,48 @@ def validate_args(args: argparse.Namespace) -> None:
             data={"spn": args.spn},
         )
 
+    if args.command in {"j1939 decode", "j1939 pgn", "j1939 spn", "j1939 tp", "j1939 dm1"}:
+        max_frames = getattr(args, "max_frames", None)
+        seconds = getattr(args, "seconds", None)
+        if max_frames is not None and max_frames < 1:
+            raise CommandError(
+                command=args.command,
+                exit_code=EXIT_USER_ERROR,
+                errors=[
+                    ErrorDetail(
+                        code="INVALID_MAX_FRAMES",
+                        message="Maximum frame bound must be at least 1.",
+                        hint="Pass a positive integer to --max-frames.",
+                    )
+                ],
+                data={"max_frames": max_frames},
+            )
+        if seconds is not None and seconds < 0:
+            raise CommandError(
+                command=args.command,
+                exit_code=EXIT_USER_ERROR,
+                errors=[
+                    ErrorDetail(
+                        code="INVALID_ANALYSIS_SECONDS",
+                        message="Analysis time bound must be zero or greater.",
+                        hint="Pass a non-negative value to --seconds.",
+                    )
+                ],
+                data={"seconds": seconds},
+            )
+        if args.command == "j1939 decode" and getattr(args, "stdin", False) and (max_frames is not None or seconds is not None):
+            raise CommandError(
+                command=args.command,
+                exit_code=EXIT_USER_ERROR,
+                errors=[
+                    ErrorDetail(
+                        code="ANALYSIS_WINDOW_REQUIRES_FILE",
+                        message="J1939 bounded-analysis flags currently require a capture file.",
+                        hint="Use a capture file for --max-frames or --seconds, or remove those flags when using --stdin.",
+                    )
+                ],
+            )
+
     if args.command == "encode":
         for assignment in args.signals:
             if "=" not in assignment:
@@ -895,6 +955,13 @@ def frames_from_stdin(*, command: str) -> list[CanFrame]:
             ],
         )
     return frames
+
+
+def j1939_file_analysis_kwargs(args: argparse.Namespace) -> dict[str, int | float | None]:
+    return {
+        "max_frames": getattr(args, "max_frames", None),
+        "seconds": getattr(args, "seconds", None),
+    }
 
 
 def sample_frame(*, interface: str | None = None, frame_format: str = "can") -> CanFrame:
@@ -1164,14 +1231,15 @@ def j1939_payload(
     if args.command == "j1939 decode":
         decoder = get_j1939_decoder()
         dbc_ref = getattr(args, "dbc", None) or default_j1939_dbc()
+        analysis_kwargs = j1939_file_analysis_kwargs(args)
         if args.stdin:
             frames = frames_from_stdin(command=args.command)
             events = decoder.decode_events(frames)
         elif dbc_ref:
-            frames = transport.frames_from_file(args.file)
+            frames = transport.frames_from_file(args.file, **analysis_kwargs)
             events = decoder.decode_events(frames)
         else:
-            events = decoder.decode_events(transport.iter_frames_from_file(args.file))
+            events = decoder.decode_events(transport.iter_frames_from_file(args.file, **analysis_kwargs))
             frames = []
         warnings = []
         if not events:
@@ -1192,7 +1260,10 @@ def j1939_payload(
         )
     if args.command == "j1939 pgn":
         decoder = get_j1939_decoder()
-        event_objects = decoder.decode_pgn_events(transport.iter_frames_from_file(args.file), args.pgn)
+        event_objects = decoder.decode_pgn_events(
+            transport.iter_frames_from_file(args.file, **j1939_file_analysis_kwargs(args)),
+            args.pgn,
+        )
         matched_frames = [frame for frame in (getattr(event, "frame", None) for event in event_objects) if frame is not None]
         data, dbc_warnings = enrich_with_dbc(
             {"mode": "passive", "pgn": args.pgn, "file": args.file},
@@ -1206,12 +1277,13 @@ def j1939_payload(
     if args.command == "j1939 spn":
         decoder = get_j1939_decoder()
         dbc_ref = getattr(args, "dbc", None) or default_j1939_dbc()
+        analysis_kwargs = j1939_file_analysis_kwargs(args)
         if args.spn in decoder.supported_spns() and not dbc_ref:
-            observations = decoder.spn_observations(transport.iter_frames_from_file(args.file), args.spn)
+            observations = decoder.spn_observations(transport.iter_frames_from_file(args.file, **analysis_kwargs), args.spn)
             decoder_name = "curated_spn_map"
             matching_frames: list[Any] = []
         else:
-            frames = transport.frames_from_file(args.file)
+            frames = transport.frames_from_file(args.file, **analysis_kwargs)
             if args.spn in decoder.supported_spns():
                 observations = decoder.spn_observations(frames, args.spn)
                 decoder_name = "curated_spn_map"
@@ -1249,7 +1321,9 @@ def j1939_payload(
         )
     if args.command == "j1939 tp":
         decoder = get_j1939_decoder()
-        sessions = decoder.transport_protocol_sessions(transport.iter_frames_from_file(args.file))
+        sessions = decoder.transport_protocol_sessions(
+            transport.iter_frames_from_file(args.file, **j1939_file_analysis_kwargs(args))
+        )
         warnings = []
         if not sessions:
             warnings.append("No J1939 transport protocol sessions were found in the capture.")
@@ -1265,7 +1339,9 @@ def j1939_payload(
         )
     if args.command == "j1939 dm1":
         decoder = get_j1939_decoder()
-        messages = decoder.dm1_messages(transport.iter_frames_from_file(args.file))
+        messages = decoder.dm1_messages(
+            transport.iter_frames_from_file(args.file, **j1939_file_analysis_kwargs(args))
+        )
         warnings = dm1_warnings(messages)
         data, dbc_warnings = enrich_dm1_with_dbc(
             {

--- a/src/canarchy/completion.py
+++ b/src/canarchy/completion.py
@@ -55,6 +55,7 @@ SUBCOMMANDS: dict[str, list[str]] = {
 
 # Output format flags shared by every command.
 _OUTPUT = ["--json", "--jsonl", "--raw", "--table"]
+_J1939_FILE_BOUNDS = ["--max-frames", "--seconds"]
 
 # Per-command (or per-subcommand) flag lists.
 # Keys for subcommand groups use the "group subcommand" form.
@@ -82,12 +83,12 @@ FLAGS: dict[str, list[str]] = {
         "--gap",
         "--id",
     ] + _OUTPUT,
-    "j1939 decode": ["--dbc"] + _OUTPUT,
-    "j1939 dm1": ["--dbc"] + _OUTPUT,
+    "j1939 decode": ["--dbc"] + _J1939_FILE_BOUNDS + _OUTPUT,
+    "j1939 dm1": ["--dbc"] + _J1939_FILE_BOUNDS + _OUTPUT,
     "j1939 monitor": ["--pgn"] + _OUTPUT,
-    "j1939 pgn": ["--dbc", "--file"] + _OUTPUT,
-    "j1939 spn": ["--dbc", "--file"] + _OUTPUT,
-    "j1939 tp": _OUTPUT,
+    "j1939 pgn": ["--dbc", "--file"] + _J1939_FILE_BOUNDS + _OUTPUT,
+    "j1939 spn": ["--dbc", "--file"] + _J1939_FILE_BOUNDS + _OUTPUT,
+    "j1939 tp": _J1939_FILE_BOUNDS + _OUTPUT,
     "re correlate": _OUTPUT,
     "re counters": _OUTPUT,
     "re entropy": _OUTPUT,

--- a/src/canarchy/transport.py
+++ b/src/canarchy/transport.py
@@ -514,13 +514,25 @@ class LocalTransport:
             interfaces=sorted({frame.interface or "unknown" for frame in frames}),
         )
 
-    def frames_from_file(self, file_name: str) -> list[CanFrame]:
-        return list(self.iter_frames_from_file(file_name))
+    def frames_from_file(
+        self,
+        file_name: str,
+        *,
+        max_frames: int | None = None,
+        seconds: float | None = None,
+    ) -> list[CanFrame]:
+        return list(self.iter_frames_from_file(file_name, max_frames=max_frames, seconds=seconds))
 
-    def iter_frames_from_file(self, file_name: str) -> Iterator[CanFrame]:
+    def iter_frames_from_file(
+        self,
+        file_name: str,
+        *,
+        max_frames: int | None = None,
+        seconds: float | None = None,
+    ) -> Iterator[CanFrame]:
         path = self._capture_file_path(file_name)
         try:
-            yield from iter_candump_file(path)
+            yield from iter_candump_file(path, max_frames=max_frames, seconds=seconds)
         except OSError as exc:
             raise TransportError(
                 "CAPTURE_SOURCE_UNAVAILABLE",
@@ -832,13 +844,28 @@ class LocalTransport:
         return events
 
 
-def iter_candump_file(path: Path) -> Iterator[CanFrame]:
+def iter_candump_file(
+    path: Path,
+    *,
+    max_frames: int | None = None,
+    seconds: float | None = None,
+) -> Iterator[CanFrame]:
+    yielded = 0
+    start_timestamp: float | None = None
     with path.open(encoding="utf-8") as handle:
         for line_number, raw_line in enumerate(handle, start=1):
             stripped = raw_line.strip()
             if not stripped:
                 continue
-            yield parse_candump_line(stripped, path=path, line_number=line_number)
+            frame = parse_candump_line(stripped, path=path, line_number=line_number)
+            if start_timestamp is None:
+                start_timestamp = frame.timestamp
+            if seconds is not None and start_timestamp is not None and frame.timestamp - start_timestamp > seconds:
+                break
+            yield frame
+            yielded += 1
+            if max_frames is not None and yielded >= max_frames:
+                break
 
 
 def load_candump_file(path: Path) -> list[CanFrame]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -845,6 +845,97 @@ class CliTests(unittest.TestCase):
         self.assertIn("transport=tp", stdout)
         self.assertIn("spn=110/fmi=5", stdout)
 
+    def test_j1939_decode_max_frames_limits_analysis(self) -> None:
+        exit_code, stdout, stderr = run_cli(
+            "j1939",
+            "decode",
+            str(FIXTURES / "j1939_heavy_vehicle.candump"),
+            "--max-frames",
+            "3",
+            "--json",
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(stderr, "")
+
+        payload = json.loads(stdout)
+        self.assertEqual(len(payload["data"]["events"]), 3)
+
+    def test_j1939_tp_seconds_limits_analysis_window(self) -> None:
+        exit_code, stdout, stderr = run_cli(
+            "j1939",
+            "tp",
+            str(FIXTURES / "j1939_dm1_tp.candump"),
+            "--seconds",
+            "0.08",
+            "--json",
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(stderr, "")
+
+        payload = json.loads(stdout)
+        self.assertEqual(payload["data"]["session_count"], 1)
+        self.assertFalse(payload["data"]["sessions"][0]["complete"])
+        self.assertEqual(payload["data"]["sessions"][0]["packet_count"], 1)
+
+    def test_j1939_decode_rejects_window_flags_with_stdin(self) -> None:
+        event = {
+            "event_type": "frame",
+            "payload": {
+                "frame": CanFrame(
+                    arbitration_id=0x18FEEE31,
+                    data=bytes.fromhex("7DFFFFFF"),
+                    timestamp=0.0,
+                    is_extended_id=True,
+                ).to_payload()
+            },
+            "source": "test.stdin",
+            "timestamp": 0.0,
+        }
+        exit_code, stdout, stderr = run_cli(
+            "j1939",
+            "decode",
+            "--stdin",
+            "--seconds",
+            "1.0",
+            "--json",
+            input=json.dumps(event) + "\n",
+        )
+        self.assertEqual(exit_code, EXIT_USER_ERROR)
+        self.assertEqual(stderr, "")
+
+        payload = json.loads(stdout)
+        self.assertEqual(payload["errors"][0]["code"], "ANALYSIS_WINDOW_REQUIRES_FILE")
+
+    def test_j1939_dm1_rejects_invalid_max_frames(self) -> None:
+        exit_code, stdout, stderr = run_cli(
+            "j1939",
+            "dm1",
+            str(FIXTURES / "j1939_dm1_tp.candump"),
+            "--max-frames",
+            "0",
+            "--json",
+        )
+        self.assertEqual(exit_code, EXIT_USER_ERROR)
+        self.assertEqual(stderr, "")
+
+        payload = json.loads(stdout)
+        self.assertEqual(payload["errors"][0]["code"], "INVALID_MAX_FRAMES")
+
+    def test_j1939_tp_rejects_invalid_seconds(self) -> None:
+        exit_code, stdout, stderr = run_cli(
+            "j1939",
+            "tp",
+            str(FIXTURES / "j1939_dm1_tp.candump"),
+            "--seconds",
+            "-1",
+            "--json",
+        )
+        self.assertEqual(exit_code, EXIT_USER_ERROR)
+        self.assertEqual(stderr, "")
+
+        payload = json.loads(stdout)
+        self.assertEqual(payload["errors"][0]["code"], "INVALID_ANALYSIS_SECONDS")
+
     def test_j1939_dm1_json_keeps_deprecated_conversion_warning_structured(self) -> None:
         exit_code, stdout, stderr = run_cli(
             "j1939",
@@ -2579,16 +2670,22 @@ class CompletionTests(unittest.TestCase):
         names = [r.strip() for r in results]
         self.assertIn("--file", names)
         self.assertIn("--dbc", names)
+        self.assertIn("--max-frames", names)
+        self.assertIn("--seconds", names)
 
     def test_j1939_decode_flags_include_dbc(self) -> None:
         results = self._completions("j1939 decode ", "")
         names = [r.strip() for r in results]
         self.assertIn("--dbc", names)
+        self.assertIn("--max-frames", names)
+        self.assertIn("--seconds", names)
 
     def test_j1939_dm1_flags_include_dbc(self) -> None:
         results = self._completions("j1939 dm1 tests/fixtures/j1939_dm1_spn175.candump ", "")
         names = [r.strip() for r in results]
         self.assertIn("--dbc", names)
+        self.assertIn("--max-frames", names)
+        self.assertIn("--seconds", names)
 
     def test_session_save_flags_include_interface_and_dbc(self) -> None:
         results = self._completions("session save mylab ", "")

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -104,6 +104,18 @@ class TransportBackendTests(unittest.TestCase):
         self.assertEqual(len(frames), 3)
         self.assertEqual(frames[0].interface, "can0")
 
+    def test_iter_candump_file_respects_max_frames(self) -> None:
+        frames = list(iter_candump_file(FIXTURES / "j1939_heavy_vehicle.candump", max_frames=3))
+
+        self.assertEqual(len(frames), 3)
+        self.assertEqual(frames[-1].timestamp, 0.2)
+
+    def test_iter_candump_file_respects_seconds_window(self) -> None:
+        frames = list(iter_candump_file(FIXTURES / "j1939_heavy_vehicle.candump", seconds=0.15))
+
+        self.assertEqual(len(frames), 2)
+        self.assertEqual([frame.timestamp for frame in frames], [0.0, 0.1])
+
     def test_parse_candump_line_rejects_malformed_lines(self) -> None:
         with self.assertRaises(TransportError) as ctx:
             parse_candump_line(


### PR DESCRIPTION
## Summary
- add shared `--max-frames` and `--seconds` bounds to the file-backed `j1939 decode`, `j1939 pgn`, `j1939 spn`, `j1939 tp`, and `j1939 dm1` commands
- enforce those bounds during candump iteration so they reduce analysis work rather than only trimming final output
- add CLI/transport regression coverage, shell completion updates, changelog entry, and dedicated design/test specs for the new command surface

## Verification
- `uv run pytest tests/test_transport.py tests/test_cli.py -k "j1939 or candump or completion"`
- `uv run pytest tests/test_j1939.py`
- `uv run mkdocs build --strict`

## Notes
- `uv run mkdocs build --strict` passed, with existing informational nav warnings about design/test spec pages not included in `mkdocs.yml` navigation.

Fixes #108