### PR TITLE
feat: decode printable j1939 tp text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * File-backed J1939 decode paths now stream candump input line-by-line instead of reading the whole capture text into memory up front, and the hot `j1939 decode`, `j1939 pgn`, `j1939 spn`, `j1939 tp`, and `j1939 dm1` paths now use single-pass iteration where DBC enrichment does not require a retained frame list.
 * File-backed `j1939 decode`, `j1939 pgn`, `j1939 spn`, `j1939 tp`, and `j1939 dm1` now accept `--max-frames` and `--seconds` bounds so operators can scope large-capture analysis to an initial frame window or time window without scanning the entire file.
 * Added `j1939 summary` for capture reconnaissance, including top PGNs and source addresses, DM1 and TP presence metrics, timestamp coverage, and candidate printable TP payload identifiers when completed sessions contain obvious ASCII text.
+* Enhanced `j1939 tp` to expose heuristic printable-text decoding and known identification-style payload labels alongside the existing raw reassembled TP payload hex.
 
 ### Documentation
 

--- a/docs/design/j1939-expanded-workflows.md
+++ b/docs/design/j1939-expanded-workflows.md
@@ -25,6 +25,8 @@ Heavy-vehicle workflows should remain PGN and SPN first rather than forcing oper
 | `REQ-J1939-03` | Event-driven | When `j1939 tp <file>` is invoked, the system shall summarise BAM-based transport-protocol sessions including reassembled payload data. |
 | `REQ-J1939-04` | Event-driven | When `j1939 dm1 <file>` is invoked, the system shall parse direct and TP-reassembled DM1 messages into structured fault records with lamp status and DTC details. |
 | `REQ-J1939-05` | Ubiquitous | J1939 command output shall present PGN and SPN identifiers rather than raw 29-bit arbitration IDs wherever protocol-aware views are available. |
+| `REQ-J1939-09` | Optional feature | Where a completed `j1939 tp` payload decodes cleanly as printable ASCII text, the system shall include the decoded text alongside the raw reassembled payload and mark it as heuristic. |
+| `REQ-J1939-10` | Optional feature | Where the transferred PGN is known to carry identification-style J1939 data, the system shall include a stable payload label in `j1939 tp` output without removing the raw payload bytes. |
 | `REQ-J1939-06` | Unwanted behaviour | If `j1939 spn` is invoked without `--file`, the system shall return a structured error with code `CAPTURE_FILE_REQUIRED` and exit code 1. |
 | `REQ-J1939-07` | Unwanted behaviour | If `j1939 spn` is invoked with a negative SPN value, the system shall return a structured error with code `INVALID_SPN` and exit code 1. |
 | `REQ-J1939-08` | Unwanted behaviour | If the requested SPN is not in the curated decoder map, the system shall return a structured error with code `J1939_SPN_UNSUPPORTED` and exit code 1. |
@@ -96,6 +98,11 @@ Each session summary includes:
 * `packet_count`
 * `complete`
 * `reassembled_data`
+* `decoded_text` when a completed payload is heuristically printable ASCII
+* `decoded_text_encoding` when `decoded_text` is present
+* `decoded_text_heuristic` to signal that printable-text decoding is a heuristic view
+* `payload_label` when the transferred PGN is known to map to an identification-style payload
+* `payload_label_source` when `payload_label` is present
 
 ## `j1939 dm1`
 
@@ -125,7 +132,7 @@ Each DTC includes:
 
 ## Output Contracts
 
-For `j1939 spn`, `j1939 tp`, and `j1939 dm1`, both `--json` and `--jsonl` emit a single CANarchy result object because these commands return structured observations under `data` rather than event streams. Table output remains protocol-first and summarises SPN observations, TP sessions, and DM1 fault content without dropping to raw-ID-only views.
+For `j1939 spn`, `j1939 tp`, and `j1939 dm1`, both `--json` and `--jsonl` emit a single CANarchy result object because these commands return structured observations under `data` rather than event streams. Table output remains protocol-first and summarises SPN observations, TP sessions, and DM1 fault content without dropping to raw-ID-only views. For `j1939 tp`, raw `reassembled_data` remains authoritative even when heuristic text or payload labels are present.
 
 ## Error Contracts
 

--- a/docs/tests/j1939-expanded-workflows.md
+++ b/docs/tests/j1939-expanded-workflows.md
@@ -28,10 +28,12 @@ Validate that the expanded J1939 workflows preserve protocol-first behavior and 
 | `REQ-J1939-02` | `TEST-J1939-02` |
 | `REQ-J1939-03` | `TEST-J1939-03` |
 | `REQ-J1939-04` | `TEST-J1939-04` |
-| `REQ-J1939-05` | `TEST-J1939-02`, `TEST-J1939-03`, `TEST-J1939-04`, `TEST-J1939-05` |
+| `REQ-J1939-05` | `TEST-J1939-02`, `TEST-J1939-03`, `TEST-J1939-04`, `TEST-J1939-05`, `TEST-J1939-06`, `TEST-J1939-07` |
 | `REQ-J1939-06` | `TEST-J1939-01` |
 | `REQ-J1939-07` | Deferred |
 | `REQ-J1939-08` | Deferred |
+| `REQ-J1939-09` | `TEST-J1939-06`, `TEST-J1939-07` |
+| `REQ-J1939-10` | `TEST-J1939-06`, `TEST-J1939-07` |
 
 ## Representative Test Cases
 
@@ -102,10 +104,38 @@ And    the output shall include DTC summaries for each message
 
 ---
 
+### `TEST-J1939-06` — TP printable identification text
+
+```gherkin
+Given  the fixture `j1939_tp_printable_id.candump` contains a completed TP payload with obvious printable ASCII identification text
+When   the operator runs `canarchy j1939 tp j1939_tp_printable_id.candump --json`
+Then   the returned TP session shall preserve `reassembled_data`
+And    the session shall include `decoded_text` plus a heuristic flag
+And    the session shall include a stable payload label when the transferred PGN is known to be identification-style data
+```
+
+**Fixture:** `tests/fixtures/j1939_tp_printable_id.candump`.
+
+---
+
+### `TEST-J1939-07` — TP table output surfaces printable identification text
+
+```gherkin
+Given  the fixture `j1939_tp_printable_id.candump` contains a printable TP identification payload
+When   the operator runs `canarchy j1939 tp j1939_tp_printable_id.candump --table`
+Then   the operator-facing output shall include the payload label when available
+And    the operator-facing output shall include the decoded printable text without hiding the TP session summary context
+```
+
+**Fixture:** `tests/fixtures/j1939_tp_printable_id.candump`.
+
+---
+
 ## Fixtures And Environment
 
 * existing `sample.candump`
 * `j1939_dm1_tp.candump` for TP and DM1 coverage
+* `j1939_tp_printable_id.candump` for printable TP identification coverage
 
 ## Explicit Non-Coverage
 

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -985,6 +985,42 @@ def _top_counts(counter: Counter[int], *, limit: int = 5) -> list[dict[str, int]
     return [{"value": value, "frame_count": count} for value, count in counter.most_common(limit)]
 
 
+def _tp_payload_label(transfer_pgn: int) -> str | None:
+    labels = {
+        65242: "software_identification",
+        65259: "component_identification",
+        65260: "vehicle_identification",
+    }
+    return labels.get(transfer_pgn)
+
+
+def _enrich_tp_session(session: dict[str, Any]) -> dict[str, Any]:
+    enriched = dict(session)
+    transfer_pgn = int(enriched["transfer_pgn"])
+    enriched["payload_label"] = _tp_payload_label(transfer_pgn)
+    enriched["payload_label_source"] = "known_transfer_pgn" if enriched["payload_label"] is not None else None
+    enriched["decoded_text"] = None
+    enriched["decoded_text_encoding"] = None
+    enriched["decoded_text_heuristic"] = False
+
+    if not bool(enriched.get("complete", False)):
+        return enriched
+
+    try:
+        payload = bytes.fromhex(str(enriched["reassembled_data"]))
+    except ValueError:
+        return enriched
+
+    text = _extract_printable_text(payload)
+    if text is None:
+        return enriched
+
+    enriched["decoded_text"] = text
+    enriched["decoded_text_encoding"] = "ascii"
+    enriched["decoded_text_heuristic"] = True
+    return enriched
+
+
 def _j1939_summary(frames: list[CanFrame], *, file: str, decoder: Any) -> tuple[dict[str, Any], list[str]]:
     if not frames:
         return (
@@ -1023,17 +1059,13 @@ def _j1939_summary(frames: list[CanFrame], *, file: str, decoder: Any) -> tuple[
     interfaces = sorted({frame.interface or "unknown" for frame in frames})
     timestamps = [frame.timestamp for frame in frames]
     dm1_messages = decoder.dm1_messages(frames)
-    tp_sessions = decoder.transport_protocol_sessions(frames)
+    tp_sessions = [_enrich_tp_session(session) for session in decoder.transport_protocol_sessions(frames)]
     session_types = Counter(str(session["session_type"]) for session in tp_sessions)
     printable_identifiers: list[dict[str, object]] = []
     for session in tp_sessions:
         if not bool(session.get("complete", False)):
             continue
-        try:
-            payload = bytes.fromhex(str(session["reassembled_data"]))
-        except ValueError:
-            continue
-        text = _extract_printable_text(payload)
+        text = session.get("decoded_text")
         if text is None:
             continue
         printable_identifiers.append(
@@ -1043,6 +1075,8 @@ def _j1939_summary(frames: list[CanFrame], *, file: str, decoder: Any) -> tuple[
                 "source_address": int(session["source_address"]),
                 "destination_address": session["destination_address"],
                 "session_type": str(session["session_type"]),
+                "payload_label": session.get("payload_label"),
+                "heuristic": bool(session.get("decoded_text_heuristic", False)),
             }
         )
 
@@ -1440,9 +1474,12 @@ def j1939_payload(
         )
     if args.command == "j1939 tp":
         decoder = get_j1939_decoder()
-        sessions = decoder.transport_protocol_sessions(
-            transport.iter_frames_from_file(args.file, **j1939_file_analysis_kwargs(args))
-        )
+        sessions = [
+            _enrich_tp_session(session)
+            for session in decoder.transport_protocol_sessions(
+                transport.iter_frames_from_file(args.file, **j1939_file_analysis_kwargs(args))
+            )
+        ]
         warnings = []
         if not sessions:
             warnings.append("No J1939 transport protocol sessions were found in the capture.")
@@ -2077,6 +2114,10 @@ def format_j1939_table(result: CommandResult) -> list[str]:
         for session in sessions:
             destination = session["destination_address"]
             destination_text = f"0x{destination:02X}" if destination is not None else "broadcast"
+            decoded_text = session.get("decoded_text")
+            decoded_suffix = f" text={decoded_text}" if decoded_text else ""
+            label = session.get("payload_label")
+            label_suffix = f" label={label}" if label else ""
             lines.append(
                 "- "
                 f"type={session['session_type']} "
@@ -2086,6 +2127,8 @@ def format_j1939_table(result: CommandResult) -> list[str]:
                 f"bytes={session['total_bytes']} "
                 f"packets={session['packet_count']}/{session['total_packets']} "
                 f"complete={session['complete']}"
+                f"{label_suffix}"
+                f"{decoded_suffix}"
             )
         return lines
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -539,6 +539,8 @@ class CliTests(unittest.TestCase):
                     "source_address": 0x31,
                     "destination_address": 255,
                     "session_type": "bam",
+                    "payload_label": "component_identification",
+                    "heuristic": True,
                 }
             ],
         )
@@ -785,6 +787,9 @@ class CliTests(unittest.TestCase):
         self.assertTrue(session["complete"])
         self.assertEqual(session["packet_count"], 2)
         self.assertEqual(session["reassembled_data"], "000000006e000501be000702")
+        self.assertIsNone(session["decoded_text"])
+        self.assertFalse(session["decoded_text_heuristic"])
+        self.assertIsNone(session["payload_label"])
 
     def test_j1939_tp_returns_rts_cts_session_summary(self) -> None:
         exit_code, stdout, stderr = run_cli(
@@ -808,6 +813,38 @@ class CliTests(unittest.TestCase):
         self.assertEqual(session["cts_count"], 1)
         self.assertEqual(session["packet_count"], 2)
         self.assertEqual(session["reassembled_data"], "00000000af000501")
+        self.assertIsNone(session["decoded_text"])
+
+    def test_j1939_tp_surfaces_printable_identification_text(self) -> None:
+        exit_code, stdout, stderr = run_cli(
+            "j1939",
+            "tp",
+            str(FIXTURES / "j1939_tp_printable_id.candump"),
+            "--json",
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(stderr, "")
+
+        payload = json.loads(stdout)
+        session = payload["data"]["sessions"][0]
+        self.assertEqual(session["transfer_pgn"], 65259)
+        self.assertEqual(session["payload_label"], "component_identification")
+        self.assertEqual(session["payload_label_source"], "known_transfer_pgn")
+        self.assertEqual(session["decoded_text"], "VIN1234")
+        self.assertEqual(session["decoded_text_encoding"], "ascii")
+        self.assertTrue(session["decoded_text_heuristic"])
+
+    def test_j1939_tp_table_output_shows_printable_text_when_present(self) -> None:
+        exit_code, stdout, stderr = run_cli(
+            "j1939",
+            "tp",
+            str(FIXTURES / "j1939_tp_printable_id.candump"),
+            "--table",
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(stderr, "")
+        self.assertIn("label=component_identification", stdout)
+        self.assertIn("text=VIN1234", stdout)
 
     def test_j1939_dm1_returns_direct_and_transport_messages(self) -> None:
         exit_code, stdout, stderr = run_cli(
@@ -1833,8 +1870,13 @@ class CliTests(unittest.TestCase):
         sessions = [{
             "complete": True,
             "control": 32,
+            "decoded_text": None,
+            "decoded_text_encoding": None,
+            "decoded_text_heuristic": False,
             "destination_address": 255,
             "packet_count": 2,
+            "payload_label": None,
+            "payload_label_source": None,
             "priority": 6,
             "reassembled_data": "000000006e000501be000702",
             "session_type": "bam",


### PR DESCRIPTION
## Summary
- extend `j1939 tp` session output with explicit heuristic printable-text fields while preserving the existing raw `reassembled_data`
- label known identification-style TP payloads from their transferred PGNs, including component/software/vehicle identification cases
- update TP and summary regression coverage plus the existing J1939 TP design/test specs for the enriched output contract

## Verification
- `uv run pytest tests/test_cli.py -k "tp or summary"`
- `uv run pytest tests/test_j1939.py tests/test_transport.py -k "j1939 or candump"`
- `uv run mkdocs build --strict`

## Notes
- `uv run mkdocs build --strict` passed with existing informational nav warnings for spec pages not included in `mkdocs.yml` navigation.

Fixes #111