### PR TITLE
fix(j1939): return null value for J1939 not-available error sentinels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+* J1939 signal decoding now returns `null`/`None` for the `value` field when the raw signal data matches the J1939 not-available pattern (0xFF for 8-bit, 0xFFFF for 16-bit, 0xFFFFFFFF for 32-bit signals) instead of converting the error sentinel into a physically impossible reading. This fix applies to both the curated SPN decoder and the DBC-backed runtime decoder.
+
 ## [0.3.0] - 2026-04-20
 
 ### Fixed

--- a/src/canarchy/dbc_runtime.py
+++ b/src/canarchy/dbc_runtime.py
@@ -207,6 +207,8 @@ def decode_j1939_spn_runtime(frames: list[CanFrame], dbc_path: str, spn: int) ->
         identifier = decompose_arbitration_id(frame.arbitration_id)
         value = normalize_value(decoded[signal.name])
         raw = _signal_raw_hex(message, signal, frame.data)
+        if raw is not None and int(raw, 16) == (1 << signal.length) - 1:
+            value = None
         observations.append(
             {
                 "spn": spn,

--- a/src/canarchy/j1939.py
+++ b/src/canarchy/j1939.py
@@ -113,7 +113,10 @@ def spn_observations(frames: list[CanFrame], spn: int) -> list[dict[str, object]
             continue
         raw = frame.data[definition.start:end]
         raw_value = int.from_bytes(raw, byteorder=definition.byteorder)
-        value = (raw_value * definition.resolution) + definition.offset
+        if raw_value == (1 << (len(raw) * 8)) - 1:
+            value = None
+        else:
+            value = (raw_value * definition.resolution) + definition.offset
         observations.append(
             {
                 "spn": definition.spn,

--- a/src/canarchy/j1939_decoder.py
+++ b/src/canarchy/j1939_decoder.py
@@ -97,7 +97,10 @@ class CanJ1939Decoder:
                 continue
             raw = frame.data[definition.start:end]
             raw_value = int.from_bytes(raw, byteorder=definition.byteorder)
-            value = (raw_value * definition.resolution) + definition.offset
+            if raw_value == (1 << (len(raw) * 8)) - 1:
+                value = None
+            else:
+                value = (raw_value * definition.resolution) + definition.offset
             observations.append(
                 {
                     "spn": definition.spn,

--- a/tests/test_dbc_runtime.py
+++ b/tests/test_dbc_runtime.py
@@ -5,10 +5,12 @@ from pathlib import Path
 from canarchy.dbc import decode_frames, encode_message, inspect_database
 from canarchy.dbc_runtime import (
     decode_frames_runtime,
+    decode_j1939_spn_runtime,
     encode_message_runtime,
     inspect_database_runtime,
     load_runtime_database,
 )
+from canarchy.models import CanFrame
 from canarchy.transport import LocalTransport
 
 
@@ -111,3 +113,31 @@ def test_complex_dbc_fixture_encode_preserves_message_identity() -> None:
 
     assert current_frame.arbitration_id == runtime_frame.arbitration_id
     assert current_frame.dlc == runtime_frame.dlc
+
+
+def test_decode_j1939_spn_runtime_error_value_returns_none() -> None:
+    # j1939_sample.dbc: SPN 175 = EngineOilTemp, signal at bit 8, length 8, (1,-40) degC
+    # 0xFF at byte 1 is the J1939 not-available indicator for an 8-bit signal
+    frame = CanFrame(
+        arbitration_id=0x18FEEE31,
+        data=bytes([0x00, 0xFF, 0x00, 0x00]),
+        timestamp=0.0,
+        is_extended_id=True,
+    )
+    obs = decode_j1939_spn_runtime([frame], str(FIXTURES / "j1939_sample.dbc"), 175)
+    assert len(obs) == 1
+    assert obs[0]["value"] is None
+
+
+def test_decode_j1939_spn_runtime_valid_value_returns_scaled_result() -> None:
+    # j1939_sample.dbc: SPN 175 = EngineOilTemp, signal at bit 8, length 8, (1,-40) degC
+    # raw 0x8C = 140 -> value = 140 * 1 + (-40) = 100.0 degC
+    frame = CanFrame(
+        arbitration_id=0x18FEEE31,
+        data=bytes([0x00, 0x8C, 0x00, 0x00]),
+        timestamp=0.0,
+        is_extended_id=True,
+    )
+    obs = decode_j1939_spn_runtime([frame], str(FIXTURES / "j1939_sample.dbc"), 175)
+    assert len(obs) == 1
+    assert obs[0]["value"] == 100.0

--- a/tests/test_j1939.py
+++ b/tests/test_j1939.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import unittest
 
-from canarchy.j1939 import decompose_arbitration_id
+from canarchy.j1939 import decompose_arbitration_id, spn_observations
+from canarchy.models import CanFrame
 
 
 class J1939Tests(unittest.TestCase):
@@ -24,3 +25,47 @@ class J1939Tests(unittest.TestCase):
     def test_reject_invalid_29bit_identifier(self) -> None:
         with self.assertRaisesRegex(ValueError, "29-bit"):
             decompose_arbitration_id(0x3FFFFFFF)
+
+
+class SpnObservationsTests(unittest.TestCase):
+    # SPN 175 (Engine Oil Temperature 1): PGN 65262, start byte 2, length 2 bytes,
+    # resolution 0.03125, offset -273.0. Frame ID 0x18FEEE31.
+
+    def _make_frame(self, data: bytes) -> CanFrame:
+        return CanFrame(
+            arbitration_id=0x18FEEE31,
+            data=data,
+            timestamp=0.0,
+            is_extended_id=True,
+        )
+
+    def test_16bit_error_value_returns_none(self) -> None:
+        # 0xFFFF is the J1939 not-available indicator for 16-bit signals
+        frame = self._make_frame(bytes([0x00, 0x00, 0xFF, 0xFF]))
+        obs = spn_observations([frame], 175)
+        self.assertEqual(len(obs), 1)
+        self.assertIsNone(obs[0]["value"])
+        self.assertEqual(obs[0]["raw"], "ffff")
+
+    def test_valid_16bit_value_returns_scaled_result(self) -> None:
+        # bytes [0x20, 0x22] little-endian = 0x2220 = 8736
+        # value = 8736 * 0.03125 + (-273.0) = 0.0 degC
+        frame = self._make_frame(bytes([0x00, 0x00, 0x20, 0x22]))
+        obs = spn_observations([frame], 175)
+        self.assertEqual(len(obs), 1)
+        self.assertAlmostEqual(obs[0]["value"], 0.0)
+
+    def test_8bit_error_value_returns_none(self) -> None:
+        # SPN 110 (Engine Coolant Temperature): PGN 65262, start byte 0, length 1 byte
+        # 0xFF is the J1939 not-available indicator for 8-bit signals
+        frame = self._make_frame(bytes([0xFF, 0x00, 0x00, 0x00]))
+        obs = spn_observations([frame], 110)
+        self.assertEqual(len(obs), 1)
+        self.assertIsNone(obs[0]["value"])
+
+    def test_valid_8bit_value_returns_scaled_result(self) -> None:
+        # SPN 110: raw 0x7D = 125, value = 125 * 1.0 + (-40.0) = 85.0 degC
+        frame = self._make_frame(bytes([0x7D, 0x00, 0x00, 0x00]))
+        obs = spn_observations([frame], 110)
+        self.assertEqual(len(obs), 1)
+        self.assertEqual(obs[0]["value"], 85.0)


### PR DESCRIPTION
## Summary

- Detect J1939 not-available/error raw values (0xFF for 8-bit, 0xFFFF for 16-bit, 0xFFFFFFFF for 32-bit) in both the curated SPN decoder (`j1939.py`, `j1939_decoder.py`) and the DBC-backed runtime decoder (`dbc_runtime.py`)
- Set the decoded `value` field to `None` instead of applying the resolution/offset formula to an error sentinel
- Add tests covering 8-bit and 16-bit error detection in both the native and DBC-backed decoders

Fixes #131 — SPN 175 (EngOilTemp1) was displaying 1774.96875°C because `0xFFFF × 0.03125 − 273 = 1774.96875` instead of indicating the sensor is not available.

## Test plan

- [x] `test_j1939.py::SpnObservationsTests::test_16bit_error_value_returns_none` — 0xFFFF raw → value is None
- [x] `test_j1939.py::SpnObservationsTests::test_8bit_error_value_returns_none` — 0xFF raw → value is None
- [x] `test_j1939.py::SpnObservationsTests::test_valid_16bit_value_returns_scaled_result` — valid raw → correct °C
- [x] `test_j1939.py::SpnObservationsTests::test_valid_8bit_value_returns_scaled_result` — valid raw → correct °C
- [x] `test_dbc_runtime.py::test_decode_j1939_spn_runtime_error_value_returns_none` — DBC-backed path, 0xFF → None
- [x] `test_dbc_runtime.py::test_decode_j1939_spn_runtime_valid_value_returns_scaled_result` — DBC-backed path, valid → 100.0°C
- [x] Full test suite: 351 passed, 1 skipped

https://claude.ai/code/session_01HgiuGmtQdh95ii78PZUTuk