### PR TITLE
fix(j1939): include decoded_signals in j1939 pgn JSON event payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+* `j1939 pgn --json` now includes decoded signal values in each event's `decoded_signals` field, matching what the table renderer already showed. Previously the JSON output contained only the raw frame bytes with no signal interpretation.
 * `j1939 summary` and `j1939 dm1` now report `active_dtc_count` as the number of DTCs that represent actual fault conditions (SPN > 0, FMI not 0 or 31) instead of the total count of DTC slots in the DM1 payload. This prevents captures where every DM1 message contains only no-fault filler entries (e.g. SPN=255/FMI=0) from being reported as having hundreds of active faults.
 * J1939 signal decoding now returns `null`/`None` for the `value` field when the raw signal data matches the J1939 not-available pattern (0xFF for 8-bit, 0xFFFF for 16-bit, 0xFFFFFFFF for 32-bit signals) instead of converting the error sentinel into a physically impossible reading. This fix applies to both the curated SPN decoder and the DBC-backed runtime decoder.
 

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -1423,9 +1423,21 @@ def j1939_payload(
             {"mode": "passive", "pgn": args.pgn, "file": args.file},
             matched_frames,
         )
+        describer = pretty_j1939_support.get_describer()
+        serialized: list[dict[str, Any]] = []
+        for event in event_objects:
+            event_dict = event.to_payload()
+            frame_payload = event_dict.get("payload", {}).get("frame")
+            if frame_payload:
+                decoded = pretty_j1939_support.describe_frame(
+                    describer, frame_payload["arbitration_id"], frame_payload["data"]
+                )
+                if decoded:
+                    event_dict["payload"]["decoded_signals"] = decoded
+            serialized.append(event_dict)
         return (
             data,
-            serialize_events(event_objects),
+            serialized,
             dbc_warnings,
         )
     if args.command == "j1939 spn":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2085,6 +2085,27 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["data"]["pgn"], 65262)
         self.assertEqual(payload["data"]["events"][0]["source"], "test.decoder")
 
+    def test_j1939_pgn_json_includes_decoded_signals(self) -> None:
+        # j1939_heavy_vehicle.candump has PGN 65262 frames; the first frame
+        # data 7DFFFFFF decodes Engine Coolant Temperature = 85.0 degC via pretty_j1939.
+        exit_code, stdout, stderr = run_cli(
+            "j1939",
+            "pgn",
+            "65262",
+            "--file",
+            str(FIXTURES / "j1939_heavy_vehicle.candump"),
+            "--json",
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(stderr, "")
+
+        payload = json.loads(stdout)
+        first_event = payload["data"]["events"][0]
+        self.assertIn("decoded_signals", first_event["payload"])
+        decoded = first_event["payload"]["decoded_signals"]
+        self.assertIn("Engine Coolant Temperature", decoded)
+        self.assertIn("85.0", decoded["Engine Coolant Temperature"])
+
     @patch("canarchy.transport._load_user_config", return_value={"CANARCHY_TRANSPORT_BACKEND": "scaffold"})
     def test_generate_fixed_id_and_data_returns_frame_events(self, _mock_cfg) -> None:
         exit_code, stdout, stderr = run_cli(


### PR DESCRIPTION
## Summary

- `j1939 pgn --json` was returning events with raw frame bytes only — no signal values
- The table renderer was already calling `pretty_j1939_support.describe_frame()` to show decoded values (e.g. `Engine Coolant Temperature: 85.0 [deg C]`), but that call was never made for structured output
- The `j1939 pgn` handler now calls `describe_frame()` for each event and adds the result as `decoded_signals` in the event payload
- Frames that `pretty_j1939` cannot decode produce no `decoded_signals` key (clean absence rather than empty dict)

**Before:**
```json
{"event_type": "j1939_pgn", "payload": {"pgn": 65262, "frame": {"data": "7dffffff", ...}}}
```

**After:**
```json
{"event_type": "j1939_pgn", "payload": {"pgn": 65262, "decoded_signals": {"Engine Coolant Temperature": "85.0 [deg C]"}, "frame": {"data": "7dffffff", ...}}}
```

closes #130

## Test plan

- [x] `test_j1939_pgn_json_includes_decoded_signals` — PGN 65262 frame with coolant temp 85°C → `decoded_signals` present and correct in JSON output
- [x] `test_j1939_pgn_routes_through_decoder_abstraction` — fake decoder with `SimpleNamespace` event (no `.frame` attribute) → no crash, output still valid
- [x] All existing `j1939 pgn` tests pass unchanged
- [x] Full test suite: 354 passed, 1 skipped

https://claude.ai/code/session_01HgiuGmtQdh95ii78PZUTuk