### PR TITLE
feat(filter): expand expression engine with dlc>, data~=, extended, standard, && and ||

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+* Expanded the `filter` expression engine with six new operators: `dlc><n>` (DLC threshold), `data~=<hex>` (payload substring), `extended` (29-bit frames), `standard` (11-bit frames), `&&` (AND), and `||` (OR). All new operators are composable; `&&` binds tighter than `||`. Unrecognised expressions now return error code `INVALID_FILTER_EXPRESSION` instead of the old `FILTER_EXPRESSION_UNSUPPORTED`.
+
 ### Fixed
 
 * `j1939 pgn --json` now includes decoded signal values in each event's `decoded_signals` field, matching what the table renderer already showed. Previously the JSON output contained only the raw frame bytes with no signal interpretation.

--- a/src/canarchy/transport.py
+++ b/src/canarchy/transport.py
@@ -10,7 +10,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterator, Protocol
+from typing import Callable, Iterator, NoReturn, Protocol
 
 try:
     import can as python_can
@@ -395,6 +395,66 @@ def build_live_backend(config: TransportBackendConfig | None = None) -> LiveCanB
     )
 
 
+def _compile_filter(expression: str) -> Callable[[CanFrame], bool]:
+    """Compile a filter expression into a frame predicate. && binds tighter than ||."""
+    or_parts = expression.split(" || ")
+    if len(or_parts) > 1:
+        preds = [_compile_filter(p.strip()) for p in or_parts]
+        return lambda frame, ps=preds: any(p(frame) for p in ps)
+    and_parts = expression.split(" && ")
+    if len(and_parts) > 1:
+        preds = [_compile_filter(p.strip()) for p in and_parts]
+        return lambda frame, ps=preds: all(p(frame) for p in ps)
+    return _compile_filter_atom(expression.strip())
+
+
+def _compile_filter_atom(expr: str) -> Callable[[CanFrame], bool]:
+    n = expr.lower()
+    if n == "all":
+        return lambda frame: True
+    if n.startswith("id=="):
+        try:
+            wanted = int(n[4:], 0)
+            return lambda frame, w=wanted: frame.arbitration_id == w
+        except ValueError:
+            pass
+    elif n.startswith("pgn=="):
+        try:
+            wanted = int(n[5:], 0)
+            return lambda frame, w=wanted: (
+                frame.is_extended_id
+                and decompose_arbitration_id(frame.arbitration_id).pgn == w
+            )
+        except ValueError:
+            pass
+    elif n.startswith("dlc>"):
+        try:
+            threshold = int(n[4:])
+            return lambda frame, t=threshold: frame.dlc > t
+        except ValueError:
+            pass
+    elif n.startswith("data~="):
+        try:
+            pattern = bytes.fromhex(n[6:])
+            return lambda frame, p=pattern: p in frame.data
+        except ValueError:
+            pass
+    elif n == "extended":
+        return lambda frame: frame.is_extended_id
+    elif n == "standard":
+        return lambda frame: not frame.is_extended_id
+    _raise_invalid_filter(expr)
+
+
+def _raise_invalid_filter(expr: str) -> NoReturn:
+    raise TransportError(
+        "INVALID_FILTER_EXPRESSION",
+        f"Filter expression '{expr}' is not recognised.",
+        "Supported: all, id==<hex>, pgn==<hex>, dlc><n>, data~=<hex>, extended, standard. "
+        "Combine with && (AND) or || (OR).",
+    )
+
+
 class LocalTransport:
     """Local transport facade that selects a live CAN backend when available."""
 
@@ -491,20 +551,8 @@ class LocalTransport:
     def filter(self, file_name: str, expression: str, frames: list[CanFrame] | None = None) -> list[CanFrame]:
         if frames is None:
             frames = self._frames_for_file(file_name)
-        normalized = expression.strip().lower()
-        if normalized.startswith("id=="):
-            wanted_id = int(normalized.split("==", 1)[1], 0)
-            return [frame for frame in frames if frame.arbitration_id == wanted_id]
-        if normalized.startswith("pgn=="):
-            wanted_pgn = int(normalized.split("==", 1)[1], 0)
-            return [frame for frame in frames if self._pgn(frame) == wanted_pgn]
-        if normalized == "all":
-            return frames
-        raise TransportError(
-            "FILTER_EXPRESSION_UNSUPPORTED",
-            "Filter expression is not supported by the current transport scaffold.",
-            "Use `all`, `id==0x...`, or `pgn==...` until the full filter engine is implemented.",
-        )
+        predicate = _compile_filter(expression)
+        return [frame for frame in frames if predicate(frame)]
 
     def stats(self, file_name: str) -> TransportStats:
         frames = self._frames_for_file(file_name)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -449,6 +449,85 @@ class CliTests(unittest.TestCase):
             payload["data"]["events"][0]["payload"]["frame"]["arbitration_id"], 0x18FEEE31
         )
 
+    def test_filter_dlc_gt_returns_frames_above_threshold(self) -> None:
+        # sample.candump: two 4-byte frames and one 8-byte frame
+        exit_code, stdout, _ = run_cli(
+            "filter", str(FIXTURES / "sample.candump"), "dlc>4", "--json"
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertEqual(len(payload["data"]["events"]), 1)
+        self.assertEqual(payload["data"]["events"][0]["payload"]["frame"]["dlc"], 8)
+
+    def test_filter_data_contains_returns_matching_frame(self) -> None:
+        # Frame 18FEEE31 data is 11223344; pattern 1122 is a substring
+        exit_code, stdout, _ = run_cli(
+            "filter", str(FIXTURES / "sample.candump"), "data~=1122", "--json"
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertEqual(len(payload["data"]["events"]), 1)
+        self.assertEqual(
+            payload["data"]["events"][0]["payload"]["frame"]["arbitration_id"], 0x18FEEE31
+        )
+
+    def test_filter_extended_returns_all_extended_frames(self) -> None:
+        # All frames in sample.candump are extended
+        exit_code, stdout, _ = run_cli(
+            "filter", str(FIXTURES / "sample.candump"), "extended", "--json"
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertEqual(len(payload["data"]["events"]), 3)
+
+    def test_filter_standard_returns_no_frames_from_j1939_capture(self) -> None:
+        # All frames in sample.candump are extended; standard returns none
+        exit_code, stdout, _ = run_cli(
+            "filter", str(FIXTURES / "sample.candump"), "standard", "--json"
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertEqual(len(payload["data"]["events"]), 0)
+
+    def test_filter_and_compound_narrows_results(self) -> None:
+        # extended && dlc>4 should return only the one 8-byte frame
+        exit_code, stdout, _ = run_cli(
+            "filter", str(FIXTURES / "sample.candump"), "extended && dlc>4", "--json"
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertEqual(len(payload["data"]["events"]), 1)
+        self.assertEqual(payload["data"]["events"][0]["payload"]["frame"]["dlc"], 8)
+
+    def test_filter_or_compound_broadens_results(self) -> None:
+        # id==0x18FEEE31 || id==0x18F00431 should return exactly 2 frames
+        exit_code, stdout, _ = run_cli(
+            "filter", str(FIXTURES / "sample.candump"),
+            "id==0x18FEEE31 || id==0x18F00431", "--json"
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertEqual(len(payload["data"]["events"]), 2)
+
+    def test_filter_and_has_higher_precedence_than_or(self) -> None:
+        # (id==0x18FEEE31 && dlc>4) || extended
+        # The AND clause matches nothing (dlc=4, not >4), so only OR arm (all 3 extended) applies
+        exit_code, stdout, _ = run_cli(
+            "filter", str(FIXTURES / "sample.candump"),
+            "id==0x18FEEE31 && dlc>4 || extended", "--json"
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertEqual(len(payload["data"]["events"]), 3)
+
+    def test_filter_unknown_expression_returns_invalid_filter_error(self) -> None:
+        exit_code, stdout, _ = run_cli(
+            "filter", str(FIXTURES / "sample.candump"), "badexpr", "--json"
+        )
+        self.assertEqual(exit_code, EXIT_TRANSPORT_ERROR)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["errors"][0]["code"], "INVALID_FILTER_EXPRESSION")
+
     def test_stats_json_output_returns_summary(self) -> None:
         exit_code, stdout, _ = run_cli("stats", str(FIXTURES / "sample.candump"), "--json")
         self.assertEqual(exit_code, EXIT_OK)
@@ -2754,7 +2833,7 @@ class CliTests(unittest.TestCase):
         self.assertEqual(exit_code, EXIT_TRANSPORT_ERROR)
 
         payload = json.loads(stdout)
-        self.assertEqual(payload["errors"][0]["code"], "FILTER_EXPRESSION_UNSUPPORTED")
+        self.assertEqual(payload["errors"][0]["code"], "INVALID_FILTER_EXPRESSION")
 
     def test_invalid_candump_file_returns_structured_transport_error(self) -> None:
         exit_code, stdout, stderr = run_cli("stats", str(FIXTURES / "invalid.candump"), "--json")


### PR DESCRIPTION
## Summary

Replaces the inline if-chain in `LocalTransport.filter()` with a recursive `_compile_filter()` / `_compile_filter_atom()` pair that compiles an expression string into a frame predicate function.

New atoms (all composable):

| Expression | Matches |
|---|---|
| `dlc><n>` | Frames whose DLC is strictly greater than `n` |
| `data~=<hex>` | Frames whose payload contains the hex byte sequence as a substring |
| `extended` | Frames with a 29-bit extended arbitration ID |
| `standard` | Frames with an 11-bit standard arbitration ID |
| `<a> && <b>` | Frames matching both predicates (`&&` binds tighter than `\|\|`) |
| `<a> \|\| <b>` | Frames matching either predicate |

Existing atoms (`all`, `id==`, `pgn==`) are unchanged.

Error code updated from `FILTER_EXPRESSION_UNSUPPORTED` → `INVALID_FILTER_EXPRESSION` for unrecognised expressions.

closes #47

## Test plan

- [x] `test_filter_dlc_gt_returns_frames_above_threshold` — `dlc>4` returns the one 8-byte frame
- [x] `test_filter_data_contains_returns_matching_frame` — `data~=1122` matches frame with bytes 11 22
- [x] `test_filter_extended_returns_all_extended_frames` — all 3 frames in fixture are extended
- [x] `test_filter_standard_returns_no_frames_from_j1939_capture` — 0 standard frames in fixture
- [x] `test_filter_and_compound_narrows_results` — `extended && dlc>4` → 1 frame
- [x] `test_filter_or_compound_broadens_results` — `id==X || id==Y` → 2 frames
- [x] `test_filter_and_has_higher_precedence_than_or` — `A && B || C` evaluated as `(A && B) || C`
- [x] `test_filter_unknown_expression_returns_invalid_filter_error` — new error code
- [x] Existing filter tests (`id==`, `pgn==`, `all`, stdin JSONL) all pass unchanged
- [x] Full test suite: 362 passed, 1 skipped

https://claude.ai/code/session_01HgiuGmtQdh95ii78PZUTuk