### PR TITLE
fix: clean up --json output for filter and j1939 tp (#127)

### DIFF
--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -2573,9 +2573,30 @@ def _emit_warnings_jsonl(payload: dict[str, Any], result: CommandResult) -> None
         )
 
 
+def _flatten_frame_event(event: dict[str, Any]) -> dict[str, Any]:
+    frame = event.get("payload", {}).get("frame", {})
+    return {
+        "timestamp": event.get("timestamp"),
+        "interface": frame.get("interface"),
+        "arbitration_id": frame.get("arbitration_id"),
+        "data": frame.get("data"),
+        "dlc": frame.get("dlc"),
+        "is_extended_id": frame.get("is_extended_id"),
+    }
+
+
 def emit_result(result: CommandResult, output_format: str) -> None:
     payload = result.to_payload()
+    _J1939_SESSION_COMMANDS = {"j1939 tp", "j1939 dm1", "j1939 summary"}
     if output_format == "json":
+        data = payload.get("data", {})
+        if result.command == "filter":
+            events = data.pop("events", [])
+            flat = [_flatten_frame_event(e) for e in events if e.get("event_type") == "frame"]
+            data["frame_count"] = len(flat)
+            data["frames"] = flat
+        elif result.command in _J1939_SESSION_COMMANDS and "events" in data and not data["events"]:
+            del data["events"]
         print(json.dumps(payload, sort_keys=True))
         return
 

--- a/src/canarchy/j1939_decoder.py
+++ b/src/canarchy/j1939_decoder.py
@@ -191,11 +191,19 @@ class CanJ1939Decoder:
             payload = reassembled[:total_bytes]
             summaries.append(
                 {
-                    **session,
-                    "aborted": bool(session.get("aborted", False)),
-                    "complete": len(payload) >= total_bytes and packet_count >= total_packets,
+                    "session_type": session["session_type"],
+                    "source_address": int(session["source_address"]),
+                    "destination_address": session["destination_address"],
+                    "transfer_pgn": int(session["transfer_pgn"]),
+                    "total_bytes": total_bytes,
+                    "total_packets": total_packets,
                     "packet_count": packet_count,
+                    "complete": len(payload) >= total_bytes and packet_count >= total_packets,
+                    "aborted": bool(session.get("aborted", False)),
+                    "acknowledged": bool(session.get("acknowledged", False)),
+                    "cts_count": int(session.get("cts_count", 0)),
                     "reassembled_data": payload.hex(),
+                    "timestamp": session.get("timestamp"),
                 }
             )
         return summaries

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -444,10 +444,16 @@ class CliTests(unittest.TestCase):
 
         payload = json.loads(stdout)
         self.assertEqual(payload["data"]["mode"], "passive")
-        self.assertEqual(len(payload["data"]["events"]), 1)
-        self.assertEqual(
-            payload["data"]["events"][0]["payload"]["frame"]["arbitration_id"], 0x18FEEE31
-        )
+        self.assertNotIn("events", payload["data"])
+        self.assertEqual(payload["data"]["frame_count"], 1)
+        self.assertEqual(len(payload["data"]["frames"]), 1)
+        frame = payload["data"]["frames"][0]
+        self.assertEqual(frame["arbitration_id"], 0x18FEEE31)
+        self.assertIn("timestamp", frame)
+        self.assertIn("interface", frame)
+        self.assertIn("data", frame)
+        self.assertIn("dlc", frame)
+        self.assertIn("is_extended_id", frame)
 
     def test_stats_json_output_returns_summary(self) -> None:
         exit_code, stdout, _ = run_cli("stats", str(FIXTURES / "sample.candump"), "--json")


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes #127 — JSON output mode produces invalid or incomplete JSON.

- **`filter --json`**: Frame data was buried 3 levels deep at `data.events[i].payload.frame.*`. Output now emits flat frame records under a top-level `data.frames` array with `{timestamp, interface, arbitration_id, data, dlc, is_extended_id}` directly accessible. A `frame_count` field is added. The `--jsonl` output is **unchanged** so existing event-stream pipelines (`filter --jsonl | j1939 decode --stdin`) continue to work.

- **`j1939 tp --json`**: Session dicts leaked internal decoder fields (`control`, `priority`, and RTS/CTS tracking state like `last_cts_window`, `ack_timestamp`, `max_packets_per_cts`) from the in-progress session accumulator. The public session shape is now built explicitly — only user-facing fields are emitted. The spurious `events: []` key that appeared on `tp` / `dm1` / `summary` results (where `sessions` / `messages` are the primary payload) is also stripped from JSON output.

## Before / After

**`filter --json` before:**
```json
{"data": {"events": [{"event_type": "frame", "payload": {"frame": {"arbitration_id": 419360305, ...}}, "source": "transport.filter", "timestamp": 0.0}], ...}}
```

**`filter --json` after:**
```json
{"data": {"frame_count": 1, "frames": [{"arbitration_id": 419360305, "data": "11223344", "dlc": 4, "interface": "can0", "is_extended_id": true, "timestamp": 0.0}], ...}}
```

**`j1939 tp --json` before (session excerpt):**
```json
{"aborted": false, "acknowledged": false, "complete": true, "control": 32, "cts_count": 0, "priority": 6, ...}
```

**`j1939 tp --json` after (session excerpt):**
```json
{"aborted": false, "acknowledged": false, "complete": true, "cts_count": 0, "decoded_text": null, "destination_address": 255, ...}
```

## Test plan

- [x] `test_filter_json_output_returns_matching_frames` updated to assert flat `frames` structure
- [x] All 11 existing `j1939 tp` tests pass without modification (they didn't assert the removed internal fields)
- [x] `test_filter_stdin_jsonl_composition` passes — JSONL pipeline format is preserved
- [x] Full suite: 354 passed, 1 skipped

https://claude.ai/code/session_01ApUExsaVyoJLgeQXZKmqm1
EOF
)