### PR TITLE
fix(mcp): run execute_command in thread pool to prevent event-loop blocking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,24 @@ The only exceptions are:
 * When a release is cut, the `[Unreleased]` section is promoted to a versioned heading. Do not manually create versioned headings outside of the release workflow.
 * The only exceptions are: typo/whitespace-only changes in docs or comments, changes to `.gitignore` or other non-functional config, and MkDocs nav or theme-only changes.
 
+### PR acceptance criteria
+
+**A PR is not ready to merge until all of the following are true.**
+
+This is a hard rule, not a suggestion.
+
+| # | Gate | Notes |
+|---|------|-------|
+| 1 | Issue referenced | Commit message contains `closes #N`, `fixes #N`, or `refs #N` |
+| 2 | Tests pass | All existing tests pass; new behaviour has new tests |
+| 3 | Changelog updated | `[Unreleased]` section reflects the change (see Changelog policy) |
+| 4 | Design spec current | Any touched `docs/design/` spec reflects the implemented behaviour — requirements updated, no stale wording |
+| 5 | Test spec current | Any touched `docs/tests/` spec reflects the actual test coverage — new `TEST-*` IDs added, traceability table updated |
+| 6 | Agent guide current | If the change affects the command surface, MCP tools, output schema, or any workflow an agent would follow, `AGENTS.md` and `docs/agents.md` are updated |
+| 7 | No stale documentation left | Verify that no other doc (architecture docs, tutorials, `command_spec.md`) references old behaviour that the PR changes |
+
+When reviewing your own work before committing or pushing, explicitly check each gate in order. Do not defer documentation updates to a follow-up commit.
+
 ### Other issue rules
 
 * Use GitHub Issues to track planned work rather than ad hoc task lists in docs.
@@ -578,6 +596,7 @@ Each requirement row in the table shall include a `Type` column identifying whic
 * After implementing a feature, verify the test spec in `docs/tests/` matches what was actually tested, includes test IDs (`TEST-<AREA>-NN`), uses Gherkin Given/When/Then, and traces back to the design-spec requirement IDs. Update it if coverage changed.
 * Specs are living documents. Update them when the implementation changes rather than letting them drift.
 * Do not create specs for trivial changes (single-function fixes, minor output tweaks). Reserve them for features that affect the command surface, data model, or module boundaries.
+* Before marking work complete or opening a PR, run through the **PR acceptance criteria** checklist above. Documentation currency (gates 4–7) is a required part of acceptance, not optional follow-up work.
 
 ---
 

--- a/docs/design/mcp-server.md
+++ b/docs/design/mcp-server.md
@@ -30,6 +30,8 @@ Agents that already call tools via MCP (Claude, OpenCode, etc.) can integrate CA
 | `REQ-MCP-08` | Unwanted behaviour | If a `call_tool` request names an unregistered tool, the system shall raise an error indicating the tool is unknown. |
 | `REQ-MCP-09` | Ubiquitous | The `mcp` package shall be declared as a project dependency in `pyproject.toml`. |
 | `REQ-MCP-10` | Ubiquitous | The server shall not expose `shell` or `tui` as MCP tools; those are interactive front-end commands with no RPC equivalent. |
+| `REQ-MCP-11` | Event-driven | The `call_tool` handler shall execute `execute_command` in a thread pool via `asyncio.to_thread` so that the asyncio event loop is not blocked during file I/O or analysis, preventing MCP keepalive timeouts on large captures. |
+| `REQ-MCP-12` | Ubiquitous | File-backed J1939 tools (`j1939_decode`, `j1939_pgn`, `j1939_spn`, `j1939_tp`, `j1939_dm1`, `j1939_summary`) shall expose optional `max_frames` (integer) and `seconds` (number) parameters that bound analysis to the first N frames or first T seconds of the capture, respectively. |
 
 ## Command Surface
 
@@ -65,6 +67,7 @@ The current MCP tool surface is a curated non-interactive subset of the CLI. It 
 | `j1939 spn` | `j1939_spn` |
 | `j1939 tp` | `j1939_tp` |
 | `j1939 dm1` | `j1939_dm1` |
+| `j1939 summary` | `j1939_summary` |
 | `uds scan` | `uds_scan` |
 | `uds trace` | `uds_trace` |
 | `uds services` | `uds_services` |
@@ -95,15 +98,18 @@ Agent / MCP client
 canarchy mcp serve
   └─ mcp_server.py
        ├─ list_tools()     → returns _TOOLS catalogue
-       └─ call_tool(name, args)
+       └─ call_tool(name, args)          [async]
             ├─ _build_argv(name, args) → CLI argv list
-            └─ execute_command(argv)  → CommandResult
-                                          │ .to_payload()
-                                          ▼
-                                     TextContent(JSON)
+            └─ asyncio.to_thread(execute_command, argv)
+                 └─ execute_command(argv)  → CommandResult   [thread pool]
+                                               │ .to_payload()
+                                               ▼
+                                          TextContent(JSON)
 ```
 
 The server delegates directly to `execute_command()` from `cli.py`, so all validation, error handling, and output formatting logic is shared with the CLI. No protocol logic is duplicated.
+
+`execute_command` runs in a thread pool via `asyncio.to_thread` so the asyncio event loop remains live during file I/O. Without this, processing a large capture file would block the event loop, preventing MCP keepalive messages from being handled and causing client-side timeout errors (`-32001`/`-32000`).
 
 ## Responsibilities And Boundaries
 

--- a/docs/tests/mcp-server.md
+++ b/docs/tests/mcp-server.md
@@ -22,6 +22,8 @@
 | REQ-MCP-08 | Unknown tool name raises error | TEST-MCP-09 |
 | REQ-MCP-09 | `mcp` declared in pyproject.toml | TEST-MCP-10 |
 | REQ-MCP-10 | `shell` and `tui` not exposed as MCP tools | TEST-MCP-11 |
+| REQ-MCP-11 | `call_tool` handler runs `execute_command` in a thread pool | TEST-MCP-15 |
+| REQ-MCP-12 | File-backed J1939 tools expose `max_frames` and `seconds` parameters | TEST-MCP-16, TEST-MCP-17 |
 
 ## Representative Test Cases
 
@@ -212,6 +214,53 @@ And    `"--json"` shall be the final element in each case
 Given  the `_build_argv` helper is available
 When   called with `("bad_tool", {})`
 Then   a `ValueError` shall be raised
+```
+
+**Fixture:** none.
+
+---
+
+### `TEST-MCP-15` — `handle_call_tool` does not block the event loop
+
+```gherkin
+Given  the MCP server is initialised
+When   `handle_call_tool` is awaited for any tool that delegates to `execute_command`
+Then   the asyncio event loop shall remain live during execution
+And    a concurrently scheduled coroutine shall be able to run while the tool executes
+```
+
+**Fixture:** none (uses `config_show` which requires no files).
+
+---
+
+### `TEST-MCP-16` — `_build_argv` threads `max_frames` and `seconds` through for J1939 file tools
+
+```gherkin
+Given  the `_build_argv` helper is available
+When   called with a J1939 file tool and `max_frames` set to N
+Then   the returned argv shall contain `["--max-frames", str(N)]`
+
+When   called with a J1939 file tool and `seconds` set to T
+Then   the returned argv shall contain `["--seconds", str(T)]`
+
+When   called with a J1939 file tool and neither limit is supplied
+Then   neither `"--max-frames"` nor `"--seconds"` shall appear in the returned argv
+```
+
+Applies to: `j1939_decode`, `j1939_pgn`, `j1939_spn`, `j1939_tp`, `j1939_dm1`, `j1939_summary`.
+
+**Fixture:** none.
+
+---
+
+### `TEST-MCP-17` — File-backed J1939 tool schemas expose `max_frames` and `seconds`
+
+```gherkin
+Given  the MCP server is initialised
+When   `handle_list_tools()` is called
+Then   for each of `j1939_decode`, `j1939_pgn`, `j1939_spn`, `j1939_tp`, `j1939_dm1`, `j1939_summary`
+       the tool's `inputSchema.properties` shall contain `"max_frames"` of type `"integer"`
+       and `"seconds"` of type `"number"`
 ```
 
 **Fixture:** none.

--- a/src/canarchy/mcp_server.py
+++ b/src/canarchy/mcp_server.py
@@ -223,6 +223,8 @@ _TOOLS: list[types.Tool] = [
             "properties": {
                 "file": {"type": "string", "description": "Path to candump capture file"},
                 "dbc": {"type": "string", "description": "Enrich results with a local DBC path or provider ref (e.g. opendbc:toyota_tnga_k_pt_generated)"},
+                "max_frames": {"type": "integer", "description": "Limit analysis to the first N frames (useful for large captures)"},
+                "seconds": {"type": "number", "description": "Limit analysis to the first T seconds of the capture"},
             },
             "required": ["file"],
         },
@@ -236,6 +238,8 @@ _TOOLS: list[types.Tool] = [
                 "pgn": {"type": "integer", "description": "J1939 PGN value (0–262143)"},
                 "file": {"type": "string", "description": "Path to candump capture file"},
                 "dbc": {"type": "string", "description": "Enrich results with a local DBC path or provider ref"},
+                "max_frames": {"type": "integer", "description": "Limit analysis to the first N frames (useful for large captures)"},
+                "seconds": {"type": "number", "description": "Limit analysis to the first T seconds of the capture"},
             },
             "required": ["pgn", "file"],
         },
@@ -249,6 +253,8 @@ _TOOLS: list[types.Tool] = [
                 "spn": {"type": "integer", "description": "J1939 SPN value (non-negative integer)"},
                 "file": {"type": "string", "description": "Path to candump capture file"},
                 "dbc": {"type": "string", "description": "Enrich results with a local DBC path or provider ref"},
+                "max_frames": {"type": "integer", "description": "Limit analysis to the first N frames (useful for large captures)"},
+                "seconds": {"type": "number", "description": "Limit analysis to the first T seconds of the capture"},
             },
             "required": ["spn", "file"],
         },
@@ -260,6 +266,8 @@ _TOOLS: list[types.Tool] = [
             "type": "object",
             "properties": {
                 "file": {"type": "string", "description": "Path to candump capture file"},
+                "max_frames": {"type": "integer", "description": "Limit analysis to the first N frames (useful for large captures)"},
+                "seconds": {"type": "number", "description": "Limit analysis to the first T seconds of the capture"},
             },
             "required": ["file"],
         },
@@ -272,6 +280,8 @@ _TOOLS: list[types.Tool] = [
             "properties": {
                 "file": {"type": "string", "description": "Path to candump capture file"},
                 "dbc": {"type": "string", "description": "Enrich DM1 DTC names with a local DBC path or provider ref"},
+                "max_frames": {"type": "integer", "description": "Limit analysis to the first N frames (useful for large captures)"},
+                "seconds": {"type": "number", "description": "Limit analysis to the first T seconds of the capture"},
             },
             "required": ["file"],
         },
@@ -283,6 +293,8 @@ _TOOLS: list[types.Tool] = [
             "type": "object",
             "properties": {
                 "file": {"type": "string", "description": "Path to candump capture file"},
+                "max_frames": {"type": "integer", "description": "Limit analysis to the first N frames (useful for large captures)"},
+                "seconds": {"type": "number", "description": "Limit analysis to the first T seconds of the capture"},
             },
             "required": ["file"],
         },
@@ -521,26 +533,52 @@ def _build_argv(tool_name: str, arguments: dict[str, Any]) -> list[str]:
             argv = ["j1939", "decode", a["file"]]
             if a.get("dbc"):
                 argv += ["--dbc", a["dbc"]]
+            if a.get("max_frames") is not None:
+                argv += ["--max-frames", str(a["max_frames"])]
+            if a.get("seconds") is not None:
+                argv += ["--seconds", str(a["seconds"])]
             return argv + ["--json"]
         case "j1939_pgn":
             argv = ["j1939", "pgn", str(a["pgn"]), "--file", a["file"]]
             if a.get("dbc"):
                 argv += ["--dbc", a["dbc"]]
+            if a.get("max_frames") is not None:
+                argv += ["--max-frames", str(a["max_frames"])]
+            if a.get("seconds") is not None:
+                argv += ["--seconds", str(a["seconds"])]
             return argv + ["--json"]
         case "j1939_spn":
             argv = ["j1939", "spn", str(a["spn"]), "--file", a["file"]]
             if a.get("dbc"):
                 argv += ["--dbc", a["dbc"]]
+            if a.get("max_frames") is not None:
+                argv += ["--max-frames", str(a["max_frames"])]
+            if a.get("seconds") is not None:
+                argv += ["--seconds", str(a["seconds"])]
             return argv + ["--json"]
         case "j1939_tp":
-            return ["j1939", "tp", a["file"], "--json"]
+            argv = ["j1939", "tp", a["file"]]
+            if a.get("max_frames") is not None:
+                argv += ["--max-frames", str(a["max_frames"])]
+            if a.get("seconds") is not None:
+                argv += ["--seconds", str(a["seconds"])]
+            return argv + ["--json"]
         case "j1939_dm1":
             argv = ["j1939", "dm1", a["file"]]
             if a.get("dbc"):
                 argv += ["--dbc", a["dbc"]]
+            if a.get("max_frames") is not None:
+                argv += ["--max-frames", str(a["max_frames"])]
+            if a.get("seconds") is not None:
+                argv += ["--seconds", str(a["seconds"])]
             return argv + ["--json"]
         case "j1939_summary":
-            return ["j1939", "summary", a["file"], "--json"]
+            argv = ["j1939", "summary", a["file"]]
+            if a.get("max_frames") is not None:
+                argv += ["--max-frames", str(a["max_frames"])]
+            if a.get("seconds") is not None:
+                argv += ["--seconds", str(a["seconds"])]
+            return argv + ["--json"]
         case "uds_scan":
             return ["uds", "scan", a["interface"], "--json"]
         case "uds_trace":
@@ -606,7 +644,7 @@ async def handle_call_tool(
     if name not in _TOOL_NAMES:
         raise ValueError(f"Unknown tool: {name!r}")
     argv = _build_argv(name, arguments or {})
-    _, result = execute_command(argv)
+    _, result = await asyncio.to_thread(execute_command, argv)
     if result is None:
         payload: dict[str, Any] = {
             "ok": False,

--- a/src/canarchy/mcp_server.py
+++ b/src/canarchy/mcp_server.py
@@ -217,7 +217,7 @@ _TOOLS: list[types.Tool] = [
     ),
     types.Tool(
         name="j1939_decode",
-        description="Decode J1939 frames from a candump capture file.",
+        description="Decode J1939 frames from a candump capture file. Use max_frames or seconds to limit processing on large captures.",
         inputSchema={
             "type": "object",
             "properties": {
@@ -231,7 +231,7 @@ _TOOLS: list[types.Tool] = [
     ),
     types.Tool(
         name="j1939_pgn",
-        description="Inspect a specific J1939 PGN within a capture file.",
+        description="Inspect a specific J1939 PGN within a capture file. Use max_frames or seconds to limit processing on large captures.",
         inputSchema={
             "type": "object",
             "properties": {
@@ -246,7 +246,7 @@ _TOOLS: list[types.Tool] = [
     ),
     types.Tool(
         name="j1939_spn",
-        description="Inspect a specific J1939 SPN within a capture file.",
+        description="Inspect a specific J1939 SPN within a capture file. Use max_frames or seconds to limit processing on large captures.",
         inputSchema={
             "type": "object",
             "properties": {
@@ -261,7 +261,7 @@ _TOOLS: list[types.Tool] = [
     ),
     types.Tool(
         name="j1939_tp",
-        description="Inspect J1939 transport protocol sessions in a capture file.",
+        description="Inspect J1939 transport protocol sessions in a capture file. Use max_frames or seconds to limit processing on large captures.",
         inputSchema={
             "type": "object",
             "properties": {
@@ -274,7 +274,7 @@ _TOOLS: list[types.Tool] = [
     ),
     types.Tool(
         name="j1939_dm1",
-        description="Inspect J1939 DM1 diagnostic messages in a capture file.",
+        description="Inspect J1939 DM1 diagnostic messages in a capture file. Use max_frames or seconds to limit processing on large captures.",
         inputSchema={
             "type": "object",
             "properties": {
@@ -288,7 +288,7 @@ _TOOLS: list[types.Tool] = [
     ),
     types.Tool(
         name="j1939_summary",
-        description="Summarize J1939 capture content: PGN distribution, source addresses, and transport sessions.",
+        description="Summarize J1939 capture content: PGN distribution, source addresses, and transport sessions. Use max_frames or seconds to limit processing on large captures.",
         inputSchema={
             "type": "object",
             "properties": {

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -202,7 +202,7 @@ def test_tool_names_set_matches_tools_list():
     assert _TOOL_NAMES == {tool.name for tool in _TOOLS}
 
 
-# --- TEST-MCP-14: handle_call_tool does not block the event loop -----------
+# --- TEST-MCP-15: handle_call_tool does not block the event loop -----------
 
 def test_handle_call_tool_is_nonblocking():
     """execute_command must run in a thread so the event loop stays alive."""
@@ -223,7 +223,7 @@ def test_handle_call_tool_is_nonblocking():
     assert event_loop_ran.is_set(), "Event loop was blocked during handle_call_tool"
 
 
-# --- TEST-MCP-15: _build_argv threads max_frames and seconds through -------
+# --- TEST-MCP-16: _build_argv threads max_frames and seconds through -------
 
 def test_build_argv_j1939_summary_max_frames():
     argv = _build_argv("j1939_summary", {"file": "big.log", "max_frames": 5000})
@@ -276,7 +276,7 @@ def test_build_argv_j1939_summary_no_limits():
     assert "--seconds" not in argv
 
 
-# --- TEST-MCP-16: file-based J1939 tool schemas expose max_frames/seconds --
+# --- TEST-MCP-17: file-based J1939 tool schemas expose max_frames/seconds --
 
 def test_j1939_tool_schemas_have_frame_limit_params():
     tools_by_name = {t.name: t for t in asyncio.run(handle_list_tools())}

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -200,3 +200,89 @@ def test_call_tool_j1939_monitor_returns_events():
 
 def test_tool_names_set_matches_tools_list():
     assert _TOOL_NAMES == {tool.name for tool in _TOOLS}
+
+
+# --- TEST-MCP-14: handle_call_tool does not block the event loop -----------
+
+def test_handle_call_tool_is_nonblocking():
+    """execute_command must run in a thread so the event loop stays alive."""
+    import threading
+
+    event_loop_ran = threading.Event()
+
+    async def _run():
+        async def _ticker():
+            event_loop_ran.set()
+            await asyncio.sleep(0)
+
+        ticker_task = asyncio.create_task(_ticker())
+        await handle_call_tool("config_show", {})
+        await ticker_task
+
+    asyncio.run(_run())
+    assert event_loop_ran.is_set(), "Event loop was blocked during handle_call_tool"
+
+
+# --- TEST-MCP-15: _build_argv threads max_frames and seconds through -------
+
+def test_build_argv_j1939_summary_max_frames():
+    argv = _build_argv("j1939_summary", {"file": "big.log", "max_frames": 5000})
+    assert "--max-frames" in argv
+    assert "5000" in argv
+    assert argv[-1] == "--json"
+
+
+def test_build_argv_j1939_summary_seconds():
+    argv = _build_argv("j1939_summary", {"file": "big.log", "seconds": 30.0})
+    assert "--seconds" in argv
+    assert "30.0" in argv
+    assert argv[-1] == "--json"
+
+
+def test_build_argv_j1939_decode_max_frames():
+    argv = _build_argv("j1939_decode", {"file": "big.log", "max_frames": 1000})
+    assert "--max-frames" in argv
+    assert "1000" in argv
+
+
+def test_build_argv_j1939_pgn_max_frames():
+    argv = _build_argv("j1939_pgn", {"pgn": 61444, "file": "big.log", "max_frames": 2000})
+    assert "--max-frames" in argv
+    assert "2000" in argv
+
+
+def test_build_argv_j1939_spn_seconds():
+    argv = _build_argv("j1939_spn", {"spn": 190, "file": "big.log", "seconds": 10.0})
+    assert "--seconds" in argv
+    assert "10.0" in argv
+
+
+def test_build_argv_j1939_tp_max_frames():
+    argv = _build_argv("j1939_tp", {"file": "big.log", "max_frames": 500})
+    assert "--max-frames" in argv
+    assert "500" in argv
+
+
+def test_build_argv_j1939_dm1_max_frames():
+    argv = _build_argv("j1939_dm1", {"file": "big.log", "max_frames": 100})
+    assert "--max-frames" in argv
+    assert "100" in argv
+
+
+def test_build_argv_j1939_summary_no_limits():
+    """When no limits provided, no extra flags are added."""
+    argv = _build_argv("j1939_summary", {"file": "small.log"})
+    assert "--max-frames" not in argv
+    assert "--seconds" not in argv
+
+
+# --- TEST-MCP-16: file-based J1939 tool schemas expose max_frames/seconds --
+
+def test_j1939_tool_schemas_have_frame_limit_params():
+    tools_by_name = {t.name: t for t in asyncio.run(handle_list_tools())}
+    file_tools = ["j1939_decode", "j1939_pgn", "j1939_spn", "j1939_tp", "j1939_dm1", "j1939_summary"]
+    for tool_name in file_tools:
+        schema = tools_by_name[tool_name].inputSchema
+        props = schema.get("properties", {})
+        assert "max_frames" in props, f"{tool_name} missing max_frames"
+        assert "seconds" in props, f"{tool_name} missing seconds"


### PR DESCRIPTION
Calling the synchronous execute_command() directly inside the async
handle_call_tool() handler blocked the entire asyncio event loop for the
duration of file processing, preventing MCP keepalive messages from being
handled and causing client-side -32001/-32000 timeout errors on captures
with more than ~10K frames.

Fix: wrap the call with asyncio.to_thread() so the event loop stays alive
while file I/O and analysis run in a worker thread.

Also expose max_frames and seconds on all six file-backed J1939 MCP tool
schemas (j1939_decode, j1939_pgn, j1939_spn, j1939_tp, j1939_dm1,
j1939_summary) and thread them through _build_argv(), giving callers a way
to bound analysis time on very large captures without needing to use the CLI
directly.

Closes #125

https://claude.ai/code/session_01NjfV6Z9dFZpKrZwEBBTNxg