### PR TITLE
fix(mcp): close stdin fd on signal to unblock stdio reader thread

### DIFF
--- a/src/canarchy/mcp_server.py
+++ b/src/canarchy/mcp_server.py
@@ -672,6 +672,13 @@ def run_server() -> None:
             stop_event.set()
             if server_task and not server_task.done():
                 server_task.cancel()
+            # Close stdin fd to unblock stdio_server's blocking stdin reader thread,
+            # which cannot be cancelled via asyncio task cancellation.
+            try:
+                import os
+                os.close(0)
+            except OSError:
+                pass
 
         for sig in (signal.SIGINT, signal.SIGTERM):
             loop.add_signal_handler(sig, signal_handler)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -291,7 +291,7 @@ def test_j1939_tool_schemas_have_frame_limit_params():
 # --- TEST-MCP-18: run_server handles signals without traceback --------------
 
 def test_run_server_handles_sigint():
-    """run_server should not raise AttributeError or traceback on SIGINT."""
+    """run_server should exit cleanly on SIGINT without traceback."""
     import signal
     import subprocess
     import sys
@@ -307,10 +307,13 @@ def test_run_server_handles_sigint():
 
     time.sleep(0.5)
     proc.send_signal(signal.SIGINT)
-    time.sleep(0.5)
 
-    proc.terminate()
-    stdout, stderr = proc.communicate(timeout=5)
+    try:
+        stdout, stderr = proc.communicate(timeout=3)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.communicate()
+        pytest.fail("run_server did not exit within 3s after SIGINT — process hung")
 
     assert "AttributeError" not in stderr, f"Got AttributeError in stderr: {stderr}"
     assert "Traceback" not in stderr, f"Got traceback in stderr: {stderr}"


### PR DESCRIPTION
## Summary

- `canarchy mcp serve` hung on Ctrl-C and could not be exited gracefully
- Root cause: `mcp.server.stdio` reads stdin in a thread via anyio; blocking thread reads cannot be cancelled by asyncio task cancellation, so the process hung even after the signal handler fired and cancelled the server task
- Fix: call `os.close(0)` in the signal handler to close fd 0, which unblocks the blocking `read()` syscall in the stdin reader thread so the process exits cleanly

## Test plan

- Updated `test_run_server_handles_sigint` to actually assert the process exits within 3 seconds after SIGINT, rather than sending SIGTERM as a fallback and only checking for absence of a traceback
- Verified the test passes: process now exits in ~0.9s after SIGINT

🤖 Generated with [Claude Code](https://claude.ai/claude-code)