### PR TITLE
fix(mcp): force exit via os._exit if stdio cleanup blocks on macOS tty

### DIFF
--- a/src/canarchy/mcp_server.py
+++ b/src/canarchy/mcp_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import signal
 from typing import Any
 
@@ -672,10 +673,13 @@ def run_server() -> None:
             stop_event.set()
             if server_task and not server_task.done():
                 server_task.cancel()
-            # Close stdin fd to unblock stdio_server's blocking stdin reader thread,
-            # which cannot be cancelled via asyncio task cancellation.
+            # anyio's to_thread.run_sync uses a shielded cancel scope, so the
+            # stdio_server's stdin reader thread cannot be cancelled — it blocks
+            # on readline() until stdin closes.  On macOS, os.close(0) does not
+            # interrupt a blocking read on a tty (unlike pipes), so we schedule
+            # a forced exit as a fallback in case graceful cleanup stalls.
+            loop.call_later(1.5, os._exit, 0)
             try:
-                import os
                 os.close(0)
             except OSError:
                 pass


### PR DESCRIPTION
The previous fix (os.close(0)) works for pipe-based stdin but not for tty-based stdin on macOS: anyio's to_thread.run_sync wraps thread calls in a shielded cancel scope, so task cancellation blocks waiting for the readline() thread to return. On macOS, closing fd 0 does not interrupt a blocking read() on a tty (POSIX undefined behavior; Linux interrupts but macOS does not).

Schedule os._exit(0) via loop.call_later(1.5) as a guaranteed fallback. If graceful cleanup completes first the fallback never fires; if it hangs on a tty the process exits within 1.5s of receiving SIGINT.