### PR TITLE
Add --max-frames and --seconds to stats, filter, decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Added
 
 * New `capture-info` command returns fast metadata about capture files (frame count, duration, unique IDs, interfaces) without loading the full file into memory. This enables AI agents to inspect large capture files before deciding how to process them.
+* Added `--max-frames` and `--seconds` parameters to `stats`, `filter`, and `decode` commands for working with large capture files. These mirror the existing parameters on J1939 commands.
 * Expanded the `filter` expression engine with six new operators: `dlc><n>` (DLC threshold), `data~=<hex>` (payload substring), `extended` (29-bit frames), `standard` (11-bit frames), `&&` (AND), and `||` (OR). All new operators are composable; `&&` binds tighter than `||`. Unrecognised expressions now return error code `INVALID_FILTER_EXPRESSION` instead of the old `FILTER_EXPRESSION_UNSUPPORTED`.
 
 ### Fixed

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -163,6 +163,20 @@ def add_j1939_file_analysis_arguments(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_file_analysis_arguments(parser: argparse.ArgumentParser) -> None:
+    """Shared --max-frames and --seconds arguments for file-backed commands."""
+    parser.add_argument(
+        "--max-frames",
+        type=int,
+        help="limit analysis to the first N frames (useful for large captures)",
+    )
+    parser.add_argument(
+        "--seconds",
+        type=float,
+        help="limit analysis to the first N seconds from capture start",
+    )
+
+
 def build_parser() -> CanarchyArgumentParser:
     parser = CanarchyArgumentParser(
         prog="canarchy", description="CLI-first CAN security research toolkit"
@@ -222,11 +236,13 @@ def build_parser() -> CanarchyArgumentParser:
     filter_parser.add_argument("file", nargs="?", default=None)
     filter_parser.add_argument("--stdin", action="store_true", help="read JSONL FrameEvents from stdin")
     filter_parser.add_argument("expression")
+    _add_file_analysis_arguments(filter_parser)
     add_output_arguments(filter_parser)
     filter_parser.set_defaults(command="filter")
 
     stats = subparsers.add_parser("stats", help="summarize traffic statistics")
     stats.add_argument("file")
+    _add_file_analysis_arguments(stats)
     add_output_arguments(stats)
     stats.set_defaults(command="stats")
 
@@ -240,6 +256,7 @@ def build_parser() -> CanarchyArgumentParser:
     decode.add_argument("file", nargs="?", default=None)
     decode.add_argument("--stdin", action="store_true", help="read JSONL FrameEvents from stdin")
     decode.add_argument("--dbc", required=True)
+    _add_file_analysis_arguments(decode)
     add_output_arguments(decode)
     decode.set_defaults(command="decode")
 
@@ -1268,7 +1285,7 @@ def transport_payload(
             [],
         )
     if args.command == "filter":
-        frames = frames_from_stdin(command=args.command) if args.stdin else transport.frames_from_file(args.file)
+        frames = frames_from_stdin(command=args.command) if args.stdin else transport.frames_from_file(args.file, max_frames=args.max_frames, seconds=args.seconds)
         return (
             {
                 "mode": "passive",
@@ -1282,7 +1299,7 @@ def transport_payload(
             [],
         )
     if args.command == "stats":
-        stats = transport.stats(args.file)
+        stats = transport.stats(args.file, max_frames=args.max_frames, seconds=args.seconds)
         return (
             {
                 "mode": "passive",
@@ -1576,7 +1593,7 @@ def dbc_payload(args: argparse.Namespace) -> tuple[dict[str, Any], list[dict[str
     dbc_source = _build_dbc_source(resolution)
 
     if args.command == "decode":
-        frames = frames_from_stdin(command=args.command) if args.stdin else transport.frames_from_file(args.file)
+        frames = frames_from_stdin(command=args.command) if args.stdin else transport.frames_from_file(args.file, max_frames=args.max_frames, seconds=args.seconds)
 
         events = decode_frames(frames, dbc_path)
         warnings = []

--- a/src/canarchy/mcp_server.py
+++ b/src/canarchy/mcp_server.py
@@ -99,6 +99,8 @@ _TOOLS: list[types.Tool] = [
             "properties": {
                 "file": {"type": "string", "description": "Path to candump capture file"},
                 "expression": {"type": "string", "description": "Filter expression (e.g. id==0x123 or dlc>4)"},
+                "max_frames": {"type": "integer", "description": "Limit analysis to the first N frames (useful for large captures)"},
+                "seconds": {"type": "number", "description": "Limit analysis to the first N seconds from capture start"},
             },
             "required": ["file", "expression"],
         },
@@ -110,6 +112,8 @@ _TOOLS: list[types.Tool] = [
             "type": "object",
             "properties": {
                 "file": {"type": "string", "description": "Path to candump capture file"},
+                "max_frames": {"type": "integer", "description": "Limit analysis to the first N frames (useful for large captures)"},
+                "seconds": {"type": "number", "description": "Limit analysis to the first N seconds from capture start"},
             },
             "required": ["file"],
         },
@@ -133,6 +137,8 @@ _TOOLS: list[types.Tool] = [
             "properties": {
                 "file": {"type": "string", "description": "Path to candump capture file"},
                 "dbc": {"type": "string", "description": "Path to DBC file"},
+                "max_frames": {"type": "integer", "description": "Limit analysis to the first N frames (useful for large captures)"},
+                "seconds": {"type": "number", "description": "Limit analysis to the first N seconds from capture start"},
             },
             "required": ["file", "dbc"],
         },
@@ -504,13 +510,28 @@ def _build_argv(tool_name: str, arguments: dict[str, Any]) -> list[str]:
                 argv += ["--rate", str(a["rate"])]
             return argv + ["--json"]
         case "filter":
-            return ["filter", a["file"], a["expression"], "--json"]
+            argv = ["filter", a["file"], a["expression"]]
+            if a.get("max_frames") is not None:
+                argv += ["--max-frames", str(a["max_frames"])]
+            if a.get("seconds") is not None:
+                argv += ["--seconds", str(a["seconds"])]
+            return argv + ["--json"]
         case "stats":
-            return ["stats", a["file"], "--json"]
+            argv = ["stats", a["file"]]
+            if a.get("max_frames") is not None:
+                argv += ["--max-frames", str(a["max_frames"])]
+            if a.get("seconds") is not None:
+                argv += ["--seconds", str(a["seconds"])]
+            return argv + ["--json"]
         case "capture_info":
             return ["capture-info", a["file"], "--json"]
         case "decode":
-            return ["decode", a["file"], "--dbc", a["dbc"], "--json"]
+            argv = ["decode", a["file"], "--dbc", a["dbc"]]
+            if a.get("max_frames") is not None:
+                argv += ["--max-frames", str(a["max_frames"])]
+            if a.get("seconds") is not None:
+                argv += ["--seconds", str(a["seconds"])]
+            return argv + ["--json"]
         case "encode":
             argv = ["encode", "--dbc", a["dbc"], a["message"]]
             argv += a.get("signals", [])

--- a/src/canarchy/transport.py
+++ b/src/canarchy/transport.py
@@ -574,8 +574,8 @@ class LocalTransport:
         predicate = _compile_filter(expression)
         return [frame for frame in frames if predicate(frame)]
 
-    def stats(self, file_name: str) -> TransportStats:
-        frames = self._frames_for_file(file_name)
+    def stats(self, file_name: str, *, max_frames: int | None = None, seconds: float | None = None) -> TransportStats:
+        frames = self.frames_from_file(file_name, max_frames=max_frames, seconds=seconds)
         return TransportStats(
             total_frames=len(frames),
             unique_arbitration_ids=len({frame.arbitration_id for frame in frames}),


### PR DESCRIPTION
## Summary
Adds `--max-frames` and `--seconds` parameters to `stats`, `filter`, and `decode` commands for working with large capture files.

## Changes
- Added `_add_file_analysis_arguments()` helper for shared params
- Updated CLI parsers for `stats`, `filter`, `decode` commands  
- Updated `transport.stats()` to accept limits
- Updated CLI handlers to pass limits to transport
- Updated MCP tool schemas for `stats`, `filter`, `decode`
- Updated `_build_argv` to pass limits to CLI

## Example usage
```bash
canarchy stats large.log --max-frames 100000
canarchy filter large.log "id==0x123" --seconds 60
canarchy decode large.log --dbc truck.dbc --max-frames 50000
```

## Related
- Closes #146