### PR TITLE
feat: add --offset parameter to file-backed commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+* Added `--offset` parameter to all file-backed commands (`filter`, `stats`, `decode`, `j1939 decode`, `j1939 pgn`, `j1939 spn`, `j1939 tp`, `j1939 dm1`, `j1939 summary`) to skip the first N frames before processing. Works alongside `--max-frames` to define a processing window.
 * New `capture-info` command returns fast metadata about capture files (frame count, duration, unique IDs, interfaces) without loading the full file into memory. This enables AI agents to inspect large capture files before deciding how to process them.
 * Added `--max-frames` and `--seconds` parameters to `stats`, `filter`, and `decode` commands for working with large capture files. These mirror the existing parameters on J1939 commands.
 * Expanded the `filter` expression engine with six new operators: `dlc><n>` (DLC threshold), `data~=<hex>` (payload substring), `extended` (29-bit frames), `standard` (11-bit frames), `&&` (AND), and `||` (OR). All new operators are composable; `&&` binds tighter than `||`. Unrecognised expressions now return error code `INVALID_FILTER_EXPRESSION` instead of the old `FILTER_EXPRESSION_UNSUPPORTED`.

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -152,6 +152,12 @@ def add_active_ack_argument(parser: argparse.ArgumentParser) -> None:
 
 def add_j1939_file_analysis_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="skip the first N frames from the capture file",
+    )
+    parser.add_argument(
         "--max-frames",
         type=int,
         help="limit analysis to the first N frames from the capture file",
@@ -164,7 +170,13 @@ def add_j1939_file_analysis_arguments(parser: argparse.ArgumentParser) -> None:
 
 
 def _add_file_analysis_arguments(parser: argparse.ArgumentParser) -> None:
-    """Shared --max-frames and --seconds arguments for file-backed commands."""
+    """Shared --offset, --max-frames, and --seconds arguments for file-backed commands."""
+    parser.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="skip the first N frames from the capture file",
+    )
     parser.add_argument(
         "--max-frames",
         type=int,
@@ -991,6 +1003,7 @@ def frames_from_stdin(*, command: str) -> list[CanFrame]:
 
 def j1939_file_analysis_kwargs(args: argparse.Namespace) -> dict[str, int | float | None]:
     return {
+        "offset": getattr(args, "offset", 0),
         "max_frames": getattr(args, "max_frames", None),
         "seconds": getattr(args, "seconds", None),
     }
@@ -1285,7 +1298,7 @@ def transport_payload(
             [],
         )
     if args.command == "filter":
-        frames = frames_from_stdin(command=args.command) if args.stdin else transport.frames_from_file(args.file, max_frames=args.max_frames, seconds=args.seconds)
+        frames = frames_from_stdin(command=args.command) if args.stdin else transport.frames_from_file(args.file, offset=args.offset, max_frames=args.max_frames, seconds=args.seconds)
         return (
             {
                 "mode": "passive",
@@ -1299,7 +1312,7 @@ def transport_payload(
             [],
         )
     if args.command == "stats":
-        stats = transport.stats(args.file, max_frames=args.max_frames, seconds=args.seconds)
+        stats = transport.stats(args.file, offset=args.offset, max_frames=args.max_frames, seconds=args.seconds)
         return (
             {
                 "mode": "passive",
@@ -1593,7 +1606,7 @@ def dbc_payload(args: argparse.Namespace) -> tuple[dict[str, Any], list[dict[str
     dbc_source = _build_dbc_source(resolution)
 
     if args.command == "decode":
-        frames = frames_from_stdin(command=args.command) if args.stdin else transport.frames_from_file(args.file, max_frames=args.max_frames, seconds=args.seconds)
+        frames = frames_from_stdin(command=args.command) if args.stdin else transport.frames_from_file(args.file, offset=args.offset, max_frames=args.max_frames, seconds=args.seconds)
 
         events = decode_frames(frames, dbc_path)
         warnings = []

--- a/src/canarchy/completion.py
+++ b/src/canarchy/completion.py
@@ -55,7 +55,7 @@ SUBCOMMANDS: dict[str, list[str]] = {
 
 # Output format flags shared by every command.
 _OUTPUT = ["--json", "--jsonl", "--raw", "--table"]
-_J1939_FILE_BOUNDS = ["--max-frames", "--seconds"]
+_J1939_FILE_BOUNDS = ["--offset", "--max-frames", "--seconds"]
 
 # Per-command (or per-subcommand) flag lists.
 # Keys for subcommand groups use the "group subcommand" form.

--- a/src/canarchy/mcp_server.py
+++ b/src/canarchy/mcp_server.py
@@ -99,6 +99,7 @@ _TOOLS: list[types.Tool] = [
             "properties": {
                 "file": {"type": "string", "description": "Path to candump capture file"},
                 "expression": {"type": "string", "description": "Filter expression (e.g. id==0x123 or dlc>4)"},
+                "offset": {"type": "integer", "description": "Skip the first N frames from the capture file"},
                 "max_frames": {"type": "integer", "description": "Limit analysis to the first N frames (useful for large captures)"},
                 "seconds": {"type": "number", "description": "Limit analysis to the first N seconds from capture start"},
             },
@@ -112,6 +113,7 @@ _TOOLS: list[types.Tool] = [
             "type": "object",
             "properties": {
                 "file": {"type": "string", "description": "Path to candump capture file"},
+                "offset": {"type": "integer", "description": "Skip the first N frames from the capture file"},
                 "max_frames": {"type": "integer", "description": "Limit analysis to the first N frames (useful for large captures)"},
                 "seconds": {"type": "number", "description": "Limit analysis to the first N seconds from capture start"},
             },
@@ -137,6 +139,7 @@ _TOOLS: list[types.Tool] = [
             "properties": {
                 "file": {"type": "string", "description": "Path to candump capture file"},
                 "dbc": {"type": "string", "description": "Path to DBC file"},
+                "offset": {"type": "integer", "description": "Skip the first N frames from the capture file"},
                 "max_frames": {"type": "integer", "description": "Limit analysis to the first N frames (useful for large captures)"},
                 "seconds": {"type": "number", "description": "Limit analysis to the first N seconds from capture start"},
             },
@@ -242,6 +245,7 @@ _TOOLS: list[types.Tool] = [
             "properties": {
                 "file": {"type": "string", "description": "Path to candump capture file"},
                 "dbc": {"type": "string", "description": "Enrich results with a local DBC path or provider ref (e.g. opendbc:toyota_tnga_k_pt_generated)"},
+                "offset": {"type": "integer", "description": "Skip the first N frames from the capture file"},
                 "max_frames": {"type": "integer", "description": "Limit analysis to the first N frames (useful for large captures)"},
                 "seconds": {"type": "number", "description": "Limit analysis to the first T seconds of the capture"},
             },
@@ -257,6 +261,7 @@ _TOOLS: list[types.Tool] = [
                 "pgn": {"type": "integer", "description": "J1939 PGN value (0–262143)"},
                 "file": {"type": "string", "description": "Path to candump capture file"},
                 "dbc": {"type": "string", "description": "Enrich results with a local DBC path or provider ref"},
+                "offset": {"type": "integer", "description": "Skip the first N frames from the capture file"},
                 "max_frames": {"type": "integer", "description": "Limit analysis to the first N frames (useful for large captures)"},
                 "seconds": {"type": "number", "description": "Limit analysis to the first T seconds of the capture"},
             },
@@ -272,6 +277,7 @@ _TOOLS: list[types.Tool] = [
                 "spn": {"type": "integer", "description": "J1939 SPN value (non-negative integer)"},
                 "file": {"type": "string", "description": "Path to candump capture file"},
                 "dbc": {"type": "string", "description": "Enrich results with a local DBC path or provider ref"},
+                "offset": {"type": "integer", "description": "Skip the first N frames from the capture file"},
                 "max_frames": {"type": "integer", "description": "Limit analysis to the first N frames (useful for large captures)"},
                 "seconds": {"type": "number", "description": "Limit analysis to the first T seconds of the capture"},
             },
@@ -285,6 +291,7 @@ _TOOLS: list[types.Tool] = [
             "type": "object",
             "properties": {
                 "file": {"type": "string", "description": "Path to candump capture file"},
+                "offset": {"type": "integer", "description": "Skip the first N frames from the capture file"},
                 "max_frames": {"type": "integer", "description": "Limit analysis to the first N frames (useful for large captures)"},
                 "seconds": {"type": "number", "description": "Limit analysis to the first T seconds of the capture"},
             },
@@ -299,6 +306,7 @@ _TOOLS: list[types.Tool] = [
             "properties": {
                 "file": {"type": "string", "description": "Path to candump capture file"},
                 "dbc": {"type": "string", "description": "Enrich DM1 DTC names with a local DBC path or provider ref"},
+                "offset": {"type": "integer", "description": "Skip the first N frames from the capture file"},
                 "max_frames": {"type": "integer", "description": "Limit analysis to the first N frames (useful for large captures)"},
                 "seconds": {"type": "number", "description": "Limit analysis to the first T seconds of the capture"},
             },
@@ -312,6 +320,7 @@ _TOOLS: list[types.Tool] = [
             "type": "object",
             "properties": {
                 "file": {"type": "string", "description": "Path to candump capture file"},
+                "offset": {"type": "integer", "description": "Skip the first N frames from the capture file"},
                 "max_frames": {"type": "integer", "description": "Limit analysis to the first N frames (useful for large captures)"},
                 "seconds": {"type": "number", "description": "Limit analysis to the first T seconds of the capture"},
             },
@@ -511,6 +520,8 @@ def _build_argv(tool_name: str, arguments: dict[str, Any]) -> list[str]:
             return argv + ["--json"]
         case "filter":
             argv = ["filter", a["file"], a["expression"]]
+            if a.get("offset") is not None and a["offset"] > 0:
+                argv += ["--offset", str(a["offset"])]
             if a.get("max_frames") is not None:
                 argv += ["--max-frames", str(a["max_frames"])]
             if a.get("seconds") is not None:
@@ -518,6 +529,8 @@ def _build_argv(tool_name: str, arguments: dict[str, Any]) -> list[str]:
             return argv + ["--json"]
         case "stats":
             argv = ["stats", a["file"]]
+            if a.get("offset") is not None and a["offset"] > 0:
+                argv += ["--offset", str(a["offset"])]
             if a.get("max_frames") is not None:
                 argv += ["--max-frames", str(a["max_frames"])]
             if a.get("seconds") is not None:
@@ -527,6 +540,8 @@ def _build_argv(tool_name: str, arguments: dict[str, Any]) -> list[str]:
             return ["capture-info", a["file"], "--json"]
         case "decode":
             argv = ["decode", a["file"], "--dbc", a["dbc"]]
+            if a.get("offset") is not None and a["offset"] > 0:
+                argv += ["--offset", str(a["offset"])]
             if a.get("max_frames") is not None:
                 argv += ["--max-frames", str(a["max_frames"])]
             if a.get("seconds") is not None:
@@ -569,6 +584,8 @@ def _build_argv(tool_name: str, arguments: dict[str, Any]) -> list[str]:
             argv = ["j1939", "decode", a["file"]]
             if a.get("dbc"):
                 argv += ["--dbc", a["dbc"]]
+            if a.get("offset") is not None and a["offset"] > 0:
+                argv += ["--offset", str(a["offset"])]
             if a.get("max_frames") is not None:
                 argv += ["--max-frames", str(a["max_frames"])]
             if a.get("seconds") is not None:
@@ -578,6 +595,8 @@ def _build_argv(tool_name: str, arguments: dict[str, Any]) -> list[str]:
             argv = ["j1939", "pgn", str(a["pgn"]), "--file", a["file"]]
             if a.get("dbc"):
                 argv += ["--dbc", a["dbc"]]
+            if a.get("offset") is not None and a["offset"] > 0:
+                argv += ["--offset", str(a["offset"])]
             if a.get("max_frames") is not None:
                 argv += ["--max-frames", str(a["max_frames"])]
             if a.get("seconds") is not None:
@@ -587,6 +606,8 @@ def _build_argv(tool_name: str, arguments: dict[str, Any]) -> list[str]:
             argv = ["j1939", "spn", str(a["spn"]), "--file", a["file"]]
             if a.get("dbc"):
                 argv += ["--dbc", a["dbc"]]
+            if a.get("offset") is not None and a["offset"] > 0:
+                argv += ["--offset", str(a["offset"])]
             if a.get("max_frames") is not None:
                 argv += ["--max-frames", str(a["max_frames"])]
             if a.get("seconds") is not None:
@@ -594,6 +615,8 @@ def _build_argv(tool_name: str, arguments: dict[str, Any]) -> list[str]:
             return argv + ["--json"]
         case "j1939_tp":
             argv = ["j1939", "tp", a["file"]]
+            if a.get("offset") is not None and a["offset"] > 0:
+                argv += ["--offset", str(a["offset"])]
             if a.get("max_frames") is not None:
                 argv += ["--max-frames", str(a["max_frames"])]
             if a.get("seconds") is not None:
@@ -603,6 +626,8 @@ def _build_argv(tool_name: str, arguments: dict[str, Any]) -> list[str]:
             argv = ["j1939", "dm1", a["file"]]
             if a.get("dbc"):
                 argv += ["--dbc", a["dbc"]]
+            if a.get("offset") is not None and a["offset"] > 0:
+                argv += ["--offset", str(a["offset"])]
             if a.get("max_frames") is not None:
                 argv += ["--max-frames", str(a["max_frames"])]
             if a.get("seconds") is not None:
@@ -610,6 +635,8 @@ def _build_argv(tool_name: str, arguments: dict[str, Any]) -> list[str]:
             return argv + ["--json"]
         case "j1939_summary":
             argv = ["j1939", "summary", a["file"]]
+            if a.get("offset") is not None and a["offset"] > 0:
+                argv += ["--offset", str(a["offset"])]
             if a.get("max_frames") is not None:
                 argv += ["--max-frames", str(a["max_frames"])]
             if a.get("seconds") is not None:

--- a/src/canarchy/transport.py
+++ b/src/canarchy/transport.py
@@ -574,8 +574,8 @@ class LocalTransport:
         predicate = _compile_filter(expression)
         return [frame for frame in frames if predicate(frame)]
 
-    def stats(self, file_name: str, *, max_frames: int | None = None, seconds: float | None = None) -> TransportStats:
-        frames = self.frames_from_file(file_name, max_frames=max_frames, seconds=seconds)
+    def stats(self, file_name: str, *, offset: int = 0, max_frames: int | None = None, seconds: float | None = None) -> TransportStats:
+        frames = self.frames_from_file(file_name, offset=offset, max_frames=max_frames, seconds=seconds)
         return TransportStats(
             total_frames=len(frames),
             unique_arbitration_ids=len({frame.arbitration_id for frame in frames}),
@@ -590,21 +590,23 @@ class LocalTransport:
         self,
         file_name: str,
         *,
+        offset: int = 0,
         max_frames: int | None = None,
         seconds: float | None = None,
     ) -> list[CanFrame]:
-        return list(self.iter_frames_from_file(file_name, max_frames=max_frames, seconds=seconds))
+        return list(self.iter_frames_from_file(file_name, offset=offset, max_frames=max_frames, seconds=seconds))
 
     def iter_frames_from_file(
         self,
         file_name: str,
         *,
+        offset: int = 0,
         max_frames: int | None = None,
         seconds: float | None = None,
     ) -> Iterator[CanFrame]:
         path = self._capture_file_path(file_name)
         try:
-            yield from iter_candump_file(path, max_frames=max_frames, seconds=seconds)
+            yield from iter_candump_file(path, offset=offset, max_frames=max_frames, seconds=seconds)
         except OSError as exc:
             raise TransportError(
                 "CAPTURE_SOURCE_UNAVAILABLE",
@@ -919,6 +921,7 @@ class LocalTransport:
 def iter_candump_file(
     path: Path,
     *,
+    offset: int = 0,
     max_frames: int | None = None,
     seconds: float | None = None,
 ) -> Iterator[CanFrame]:
@@ -928,6 +931,8 @@ def iter_candump_file(
         for line_number, raw_line in enumerate(handle, start=1):
             stripped = raw_line.strip()
             if not stripped:
+                continue
+            if line_number <= offset:
                 continue
             frame = parse_candump_line(stripped, path=path, line_number=line_number)
             if start_timestamp is None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1157,6 +1157,25 @@ class CliTests(unittest.TestCase):
         payload = json.loads(stdout)
         self.assertEqual(len(payload["data"]["events"]), 3)
 
+    def test_j1939_decode_offset_skips_initial_frames(self) -> None:
+        exit_code, stdout, stderr = run_cli(
+            "j1939",
+            "decode",
+            str(FIXTURES / "j1939_heavy_vehicle.candump"),
+            "--offset",
+            "3",
+            "--max-frames",
+            "3",
+            "--json",
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(stderr, "")
+
+        payload = json.loads(stdout)
+        self.assertEqual(len(payload["data"]["events"]), 3)
+        first_timestamp = payload["data"]["events"][0]["timestamp"]
+        self.assertGreaterEqual(first_timestamp, 0.3)
+
     def test_j1939_tp_seconds_limits_analysis_window(self) -> None:
         exit_code, stdout, stderr = run_cli(
             "j1939",

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -110,6 +110,18 @@ class TransportBackendTests(unittest.TestCase):
         self.assertEqual(len(frames), 3)
         self.assertEqual(frames[-1].timestamp, 0.2)
 
+    def test_iter_candump_file_respects_offset(self) -> None:
+        frames = list(iter_candump_file(FIXTURES / "j1939_heavy_vehicle.candump", offset=2))
+
+        self.assertEqual(len(frames), 6)
+        self.assertEqual(frames[0].timestamp, 0.2)
+
+    def test_iter_candump_file_respects_offset_and_max_frames(self) -> None:
+        frames = list(iter_candump_file(FIXTURES / "j1939_heavy_vehicle.candump", offset=2, max_frames=2))
+
+        self.assertEqual(len(frames), 2)
+        self.assertEqual(frames[0].timestamp, 0.2)
+
     def test_iter_candump_file_respects_seconds_window(self) -> None:
         frames = list(iter_candump_file(FIXTURES / "j1939_heavy_vehicle.candump", seconds=0.15))
 


### PR DESCRIPTION
## Summary
- Adds `--offset` parameter to all file-backed commands to skip the first N frames before processing
- Works alongside `--max-frames` to define a processing window (e.g., `--offset 1000000 --max-frames 100000`)
- Applied to: `filter`, `stats`, `decode`, `j1939 decode/pgn/spn/tp/dm1/summary`
- Also added to MCP server tools for AI agent access

## Changes
- **transport.py**: Core `iter_candump_file` now accepts `offset` parameter
- **cli.py**: Added `--offset` to `add_j1939_file_analysis_arguments` and `_add_file_analysis_arguments`
- **mcp_server.py**: Added `offset` to all file-backed tool schemas and `_build_argv`
- **completion.py**: Added `--offset` to `_J1939_FILE_BOUNDS`
- **tests**: Added offset tests for transport iterator and CLI integration

Closes #147