### PR TITLE
feat: add --compact output format for filter command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Added
 
 * Added `--offset` parameter to all file-backed commands (`filter`, `stats`, `decode`, `j1939 decode`, `j1939 pgn`, `j1939 spn`, `j1939 tp`, `j1939 dm1`, `j1939 summary`) to skip the first N frames before processing. Works alongside `--max-frames` to define a processing window.
+* Added `--compact` output format to `filter` command for easy data extraction. Emits one JSON object per line with flat frame data (timestamp, interface, arbitration_id, data) without wrapping metadata.
 
 ### Fixed
 

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -520,7 +520,7 @@ def requested_output_format(argv: Sequence[str] | None) -> str:
     if argv is None:
         return "table"
 
-    for name in ("json", "jsonl", "table", "raw"):
+    for name in ("json", "jsonl", "compact", "table", "raw"):
         if f"--{name}" in argv:
             return name
     return "table"
@@ -2651,6 +2651,9 @@ def emit_result(result: CommandResult, output_format: str) -> None:
 
     if output_format == "compact":
         if result.command == "filter":
+            if not result.ok:
+                print(json.dumps(payload, sort_keys=True))
+                return
             events = payload.get("data", {}).get("events", [])
             flat = [_flatten_frame_event(e) for e in events if e.get("event_type") == "frame"]
             for frame in flat:

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -138,6 +138,7 @@ def add_output_arguments(parser: argparse.ArgumentParser) -> None:
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--json", action="store_true", help="emit JSON output")
     group.add_argument("--jsonl", action="store_true", help="emit JSONL output")
+    group.add_argument("--compact", action="store_true", help="emit compact JSON with frame data only")
     group.add_argument("--table", action="store_true", help="emit table output")
     group.add_argument("--raw", action="store_true", help="emit raw output")
 
@@ -509,7 +510,7 @@ def build_parser() -> CanarchyArgumentParser:
 
 
 def format_name(args: argparse.Namespace) -> str:
-    for name in ("json", "jsonl", "table", "raw"):
+    for name in ("json", "jsonl", "compact", "table", "raw"):
         if getattr(args, name, False):
             return name
     return "table"
@@ -2645,6 +2646,27 @@ def emit_result(result: CommandResult, output_format: str) -> None:
             data["frames"] = flat
         elif result.command in _J1939_SESSION_COMMANDS and "events" in data and not data["events"]:
             del data["events"]
+        print(json.dumps(payload, sort_keys=True))
+        return
+
+    if output_format == "compact":
+        if result.command == "filter":
+            events = payload.get("data", {}).get("events", [])
+            flat = [_flatten_frame_event(e) for e in events if e.get("event_type") == "frame"]
+            for frame in flat:
+                print(json.dumps(frame, sort_keys=True))
+            for warning in payload["warnings"]:
+                print(
+                    json.dumps(
+                        AlertEvent(
+                            level="warning",
+                            message=warning,
+                            source=f"cli.{result.command}",
+                        ).to_event().to_payload(),
+                        sort_keys=True,
+                    )
+                )
+            return
         print(json.dumps(payload, sort_keys=True))
         return
 

--- a/src/canarchy/completion.py
+++ b/src/canarchy/completion.py
@@ -67,7 +67,7 @@ FLAGS: dict[str, list[str]] = {
     "decode": ["--dbc", "--file"] + _OUTPUT,
     "encode": ["--dbc"] + _OUTPUT,
     "export": _OUTPUT,
-    "filter": ["--file"] + _OUTPUT,
+    "filter": ["--file", "--compact"] + _OUTPUT,
     "gateway": [
         "--ack-active",
         "--bidirectional",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -455,7 +455,18 @@ class CliTests(unittest.TestCase):
         self.assertIn("dlc", frame)
         self.assertIn("is_extended_id", frame)
 
-    def test_filter_dlc_gt_returns_frames_above_threshold(self) -> None:
+    def test_filter_compact_output_returns_one_frame_per_line(self) -> None:
+        exit_code, stdout, _ = run_cli(
+            "filter", "extended", "--file", str(FIXTURES / "sample.candump"), "--compact"
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        lines = stdout.strip().split("\n")
+        self.assertEqual(len(lines), 3)
+        for line in lines:
+            frame = json.loads(line)
+            self.assertIn("timestamp", frame)
+            self.assertIn("interface", frame)
+            self.assertIn("data", frame)
         exit_code, stdout, _ = run_cli(
             "filter", "dlc>4", "--file", str(FIXTURES / "sample.candump"), "--json"
         )


### PR DESCRIPTION
## Summary
- Added `--compact` output format to `filter` command for easy data extraction
- Emits one JSON object per line with flat frame data (timestamp, interface, arbitration_id, data)
- No wrapping metadata - each line is directly parseable as a frame object
- Warnings are shown as separate JSON lines

## Example
```bash
# Compact output - one frame per line
$ canarchy filter "id==0x18FEEE31" --file capture.candump --compact
{"timestamp": 0.0, "interface": "can0", "arbitration_id": 419360305, "data": "11223344", ...}

# Standard JSON output - wrapped in metadata
$ canarchy filter "id==0x18FEEE31" --file capture.candump --json
{"command": "filter", "data": {"frames": [...], ...}, ...}
```

Closes #128