### PR TITLE
feat: complete capture-info workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,10 +168,11 @@ Every important workflow must be reachable as a non-interactive command.
 Examples:
 
 * `canarchy capture can0 --jsonl`
-* `canarchy decode capture.log --dbc truck.dbc --json`
+* `canarchy capture-info --file capture.log --json`
+* `canarchy decode --file capture.log --dbc truck.dbc --json`
 * `canarchy j1939 monitor --pgn 65262 --json`
 * `canarchy uds scan can0 --json`
-* `canarchy replay drive.log --rate 0.5`
+* `canarchy replay --file drive.log --rate 0.5`
 
 ### REPL
 
@@ -396,6 +397,7 @@ Suggested JSON error shape:
 ```text
 canarchy
   capture
+  capture-info
   send
   replay
   filter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * Added `--offset` parameter to all file-backed commands (`filter`, `stats`, `decode`, `j1939 decode`, `j1939 pgn`, `j1939 spn`, `j1939 tp`, `j1939 dm1`, `j1939 summary`) to skip the first N frames before processing. Works alongside `--max-frames` to define a processing window.
 * Added `--compact` output format to `filter` command for easy data extraction. Emits one JSON object per line with flat frame data (timestamp, interface, arbitration_id, data) without wrapping metadata.
 * Added J1939 performance benchmarks with defined budgets and automated tests (`tests/test_j1939_performance.py`). Benchmark fixture generated via `scripts/generate_benchmark_fixture.py`. All J1939 commands meet budget targets on 10k frame capture.
+* Added `capture-info` and the `capture_info` MCP tool for fast capture reconnaissance. They return frame count, first/last timestamps, duration, unique IDs, interfaces, and suggested `max_frames`/`seconds` bounds without loading decoded frame data into memory.
 
 ### Fixed
 
@@ -19,7 +20,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * Unparseable candump lines are now silently skipped instead of causing an error, allowing analysis to proceed with valid frames only.
 * Added validation for `--max-frames` and `--seconds` on all file-backed commands (`filter`, `stats`, `decode`) to match J1939 command behavior. Invalid values now return `INVALID_MAX_FRAMES` or `INVALID_ANALYSIS_SECONDS` errors.
 * `--stdin` mode now rejects `--max-frames` and `--seconds` flags with `ANALYSIS_WINDOW_REQUIRES_FILE` error, since these bounds cannot be applied to stdin input.
-* New `capture-info` command returns fast metadata about capture files (frame count, duration, unique IDs, interfaces) without loading the full file into memory. This enables AI agents to inspect large capture files before deciding how to process them.
 * Added `--max-frames` and `--seconds` parameters to `stats`, `filter`, and `decode` commands for working with large capture files. These mirror the existing parameters on J1939 commands.
 * Expanded the `filter` expression engine with six new operators: `dlc><n>` (DLC threshold), `data~=<hex>` (payload substring), `extended` (29-bit frames), `standard` (11-bit frames), `&&` (AND), and `||` (OR). All new operators are composable; `&&` binds tighter than `||`. Unrecognised expressions now return error code `INVALID_FILTER_EXPRESSION` instead of the old `FILTER_EXPRESSION_UNSUPPORTED`.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -56,6 +56,7 @@ The current MCP surface exposes a curated non-interactive subset of the CLI. Spa
 | `replay` | `canarchy replay` |
 | `filter` | `canarchy filter` |
 | `stats` | `canarchy stats` |
+| `capture_info` | `canarchy capture-info` |
 | `decode` | `canarchy decode` |
 | `encode` | `canarchy encode` |
 | `dbc_inspect` | `canarchy dbc inspect` |

--- a/docs/command_spec.md
+++ b/docs/command_spec.md
@@ -121,7 +121,7 @@ Notes:
 Filter a capture source by a simple expression.
 
 ```bash
-canarchy filter <file> <expression> [--stdin] [--json|--jsonl|--table|--raw]
+canarchy filter <expression> (--file <path> | --stdin) [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json|--jsonl|--compact|--table|--raw]
 ```
 
 Supported expressions today:
@@ -134,12 +134,31 @@ Notes:
 
 * `--stdin` reads JSONL `frame` events from standard input instead of a positional capture file
 
+### capture-info
+
+Inspect a candump capture quickly before running deeper analysis.
+
+```bash
+canarchy capture-info --file <path> [--json|--jsonl|--table|--raw]
+```
+
+Returns capture metadata only:
+
+* `frame_count`
+* `first_timestamp`
+* `last_timestamp`
+* `duration_seconds`
+* `unique_ids`
+* `interfaces`
+* `suggested_max_frames`
+* `suggested_seconds`
+
 ### stats
 
 Summarize a capture source.
 
 ```bash
-canarchy stats <file> [--json|--jsonl|--table|--raw]
+canarchy stats --file <path> [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json|--jsonl|--table|--raw]
 ```
 
 ### generate
@@ -169,13 +188,13 @@ Notes:
 Replay a capture source with deterministic timing derived from relative frame timestamps.
 
 ```bash
-canarchy replay <file> [--rate <factor>] [--json|--jsonl|--table|--raw]
+canarchy replay --file <path> [--rate <factor>] [--json|--jsonl|--table|--raw]
 ```
 
 Example:
 
 ```bash
-canarchy replay tests/fixtures/sample.candump --rate 2.0 --json
+canarchy replay --file tests/fixtures/sample.candump --rate 2.0 --json
 ```
 
 ### gateway
@@ -711,13 +730,19 @@ canarchy capture can0 --json
 ### Transport Stats
 
 ```bash
-canarchy stats tests/fixtures/sample.candump --json
+canarchy stats --file tests/fixtures/sample.candump --json
+```
+
+### Capture Metadata
+
+```bash
+canarchy capture-info --file tests/fixtures/sample.candump --json
 ```
 
 ### Deterministic Replay
 
 ```bash
-canarchy replay tests/fixtures/sample.candump --rate 0.5 --json
+canarchy replay --file tests/fixtures/sample.candump --rate 0.5 --json
 ```
 
 ### J1939 Monitor
@@ -735,7 +760,7 @@ canarchy j1939 monitor --pgn 65262 --json
 ### DBC Decode
 
 ```bash
-canarchy decode tests/fixtures/sample.candump --dbc tests/fixtures/sample.dbc --json
+canarchy decode --file tests/fixtures/sample.candump --dbc tests/fixtures/sample.dbc --json
 ```
 
 ### DBC Provider Search

--- a/docs/design/mcp-server.md
+++ b/docs/design/mcp-server.md
@@ -54,6 +54,7 @@ The current MCP tool surface is a curated non-interactive subset of the CLI. It 
 | `replay` | `replay` |
 | `filter` | `filter` |
 | `stats` | `stats` |
+| `capture-info` | `capture_info` |
 | `decode` | `decode` |
 | `encode` | `encode` |
 | `dbc inspect` | `dbc_inspect` |

--- a/docs/design/transport-core-commands.md
+++ b/docs/design/transport-core-commands.md
@@ -5,39 +5,41 @@
 | Field | Value |
 |-------|-------|
 | Status | Implemented |
-| Command surface | `canarchy capture`, `send`, `filter`, `stats` |
+| Command surface | `canarchy capture`, `send`, `filter`, `stats`, `capture-info` |
 | Primary area | CLI, transport |
 
 ## Goal
 
-Provide the foundational transport-facing CAN workflows for passive observation, active transmit, file-backed filtering, and capture summary statistics.
+Provide the foundational transport-facing CAN workflows for passive observation, active transmit, file-backed filtering, capture summary statistics, and low-cost capture reconnaissance.
 
 ## User-Facing Motivation
 
-Operators need a stable base command set that supports passive live observation, intentional active transmit, and deterministic file-backed analysis without leaving the CLI.
+Operators need a stable base command set that supports passive live observation, intentional active transmit, deterministic file-backed analysis, and fast preflight inspection of large captures without leaving the CLI.
 
 ## Requirements
 
 | ID | Type | Requirement |
 |----|------|-------------|
-| `REQ-TRANSPORT-01` | Ubiquitous | The system shall provide `capture`, `send`, `filter`, and `stats` commands as the foundational transport command set. |
+| `REQ-TRANSPORT-01` | Ubiquitous | The system shall provide `capture`, `send`, `filter`, `stats`, and `capture-info` commands as the foundational transport command set. |
 | `REQ-TRANSPORT-02` | Event-driven | When `capture <interface>` is invoked, the system shall stream frame events through the live capture path for all output formats. |
 | `REQ-TRANSPORT-03` | Event-driven | When `send <interface> <frame-id> <data>` is invoked, the system shall emit a preflight active-transmit warning to `stderr` and then transmit the specified frame. |
-| `REQ-TRANSPORT-04` | Event-driven | When `filter <file> <expression>` is invoked, the system shall return only the frame events from the capture file that satisfy the expression. |
-| `REQ-TRANSPORT-05` | Event-driven | When `stats <file>` is invoked, the system shall return a deterministic summary including total frame count and unique arbitration ID count. |
+| `REQ-TRANSPORT-04` | Event-driven | When `filter <expression> --file <path>` is invoked, the system shall return only the frame events from the capture file that satisfy the expression. |
+| `REQ-TRANSPORT-05` | Event-driven | When `stats --file <path>` is invoked, the system shall return a deterministic summary including total frame count and unique arbitration ID count. |
 | `REQ-TRANSPORT-06` | Event-driven | When `capture` or `send` is invoked, the system shall expose the effective transport backend name and configuration metadata in the result. |
 | `REQ-TRANSPORT-07` | Unwanted behaviour | If a transport interface is unavailable or a backend open fails, the system shall return a structured error with code `TRANSPORT_UNAVAILABLE` and exit code 2. |
 | `REQ-TRANSPORT-08` | Unwanted behaviour | If a capture file cannot be parsed, the system shall return a structured error with code `CAPTURE_SOURCE_INVALID` and exit code 2. |
 | `REQ-TRANSPORT-09` | Unwanted behaviour | If a capture file format is unsupported, the system shall return a structured error with code `CAPTURE_FORMAT_UNSUPPORTED` and exit code 2. |
-| `REQ-TRANSPORT-10` | Unwanted behaviour | If `filter` receives an unsupported expression, the system shall return a structured error with code `FILTER_EXPRESSION_UNSUPPORTED` and exit code 2. |
+| `REQ-TRANSPORT-10` | Unwanted behaviour | If `filter` receives an invalid expression, the system shall return a structured error with code `INVALID_FILTER_EXPRESSION` and exit code 2. |
+| `REQ-TRANSPORT-11` | Event-driven | When `capture-info --file <path>` is invoked, the system shall return capture metadata including frame count, first and last timestamps, duration, unique IDs, interfaces, and suggested `max_frames` and `seconds` bounds for follow-on analysis. |
 
 ## Command Surface
 
 ```text
 canarchy capture <interface> [--candump] [--json] [--jsonl] [--table] [--raw]
 canarchy send <interface> <frame-id> <hex-data> [--ack-active] [--json] [--jsonl] [--table] [--raw]
-canarchy filter <file> <expression> [--json] [--jsonl] [--table] [--raw]
-canarchy stats <file> [--json] [--jsonl] [--table] [--raw]
+canarchy filter <expression> --file <path> [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json] [--jsonl] [--table] [--raw]
+canarchy stats --file <path> [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json] [--jsonl] [--table] [--raw]
+canarchy capture-info --file <path> [--json] [--jsonl] [--table] [--raw]
 ```
 
 ## Responsibilities And Boundaries
@@ -50,6 +52,7 @@ In scope:
 * optional confirmation prompts for explicitly acknowledged active transmit commands
 * file-backed filtering by simple expressions
 * file-backed capture summary statistics
+* file-backed metadata reconnaissance for large captures
 
 Out of scope:
 
@@ -69,6 +72,17 @@ Relevant shared fields include:
 * `python_can_interface` when applicable
 * `status`
 * `implementation`
+
+`capture-info` additionally returns:
+
+* `frame_count`
+* `first_timestamp`
+* `last_timestamp`
+* `duration_seconds`
+* `unique_ids`
+* `interfaces`
+* `suggested_max_frames`
+* `suggested_seconds`
 
 Current backend note:
 
@@ -96,7 +110,7 @@ Event-producing commands emit one event per line. Event-less success and error p
 | `TRANSPORT_UNAVAILABLE` | interface or backend open/send fails | 2 |
 | `ACTIVE_ACK_REQUIRED` | active acknowledgement is required but `--ack-active` was omitted | 1 |
 | `ACTIVE_CONFIRMATION_DECLINED` | `--ack-active` was supplied but the confirmation response was not `YES` | 1 |
-| `FILTER_EXPRESSION_UNSUPPORTED` | `filter` receives an unsupported expression | 2 |
+| `INVALID_FILTER_EXPRESSION` | `filter` receives an invalid expression | 2 |
 | `CAPTURE_SOURCE_INVALID` | capture file cannot be parsed | 2 |
 | `CAPTURE_FORMAT_UNSUPPORTED` | file format is unsupported | 2 |
 

--- a/docs/tests/mcp-server.md
+++ b/docs/tests/mcp-server.md
@@ -15,7 +15,7 @@
 | REQ-MCP-01 | `mcp serve` subcommand starts MCP server | TEST-MCP-01 |
 | REQ-MCP-02 | Each selected CLI command surfaces as an MCP tool | TEST-MCP-02, TEST-MCP-03 |
 | REQ-MCP-03 | Input schemas derived from argparse definitions | TEST-MCP-04 |
-| REQ-MCP-04 | Tool responses use canonical event envelope | TEST-MCP-05, TEST-MCP-06 |
+| REQ-MCP-04 | Tool responses use canonical event envelope | TEST-MCP-05, TEST-MCP-06, TEST-MCP-19 |
 | REQ-MCP-05 | Invalid inputs return same error codes as CLI | TEST-MCP-07, TEST-MCP-08 |
 | REQ-MCP-06 | Tool discovery returns all registered MCP tools with metadata | TEST-MCP-02, TEST-MCP-03 |
 | REQ-MCP-07 | stdio transport only | TEST-MCP-01 |
@@ -45,7 +45,7 @@ And    `canarchy mcp serve --help` shall exit with code `0`
 ```gherkin
 Given  the MCP server is initialised
 When   `handle_list_tools()` is called
-Then   the returned set shall contain at minimum: `capture`, `send`, `filter`, `stats`, `decode`, `encode`, `dbc_inspect`, `j1939_monitor`, `j1939_decode`, `j1939_pgn`, `j1939_spn`, `j1939_tp`, `j1939_dm1`, `uds_scan`, `uds_trace`, `uds_services`, `config_show`, `replay`, `gateway`, `generate`, `export`, `session_save`, `session_load`, `session_show`
+Then   the returned set shall contain at minimum: `capture`, `send`, `filter`, `stats`, `capture_info`, `decode`, `encode`, `dbc_inspect`, `j1939_monitor`, `j1939_decode`, `j1939_pgn`, `j1939_spn`, `j1939_tp`, `j1939_dm1`, `uds_scan`, `uds_trace`, `uds_services`, `config_show`, `replay`, `gateway`, `generate`, `export`, `session_save`, `session_load`, `session_show`
 ```
 
 **Fixture:** none.
@@ -57,7 +57,7 @@ Then   the returned set shall contain at minimum: `capture`, `send`, `filter`, `
 ```gherkin
 Given  the MCP server is initialised
 When   `handle_list_tools()` is called
-Then   at least 24 tools shall be returned — one per registered MCP tool in the current curated surface
+Then   at least 25 tools shall be returned — one per registered MCP tool in the current curated surface
 ```
 
 **Fixture:** none.
@@ -101,6 +101,20 @@ And    `data.service_count` shall be greater than `0`
 ```
 
 **Fixture:** none.
+
+---
+
+### `TEST-MCP-19` — `capture_info` returns capture metadata
+
+```gherkin
+Given  the MCP server is initialised
+When   `handle_call_tool("capture_info", {"file": "tests/fixtures/sample.candump"})` is called
+Then   the response `text` shall parse as JSON with `ok` equal to `true`
+And    `command` shall equal `"capture-info"`
+And    `data.frame_count` and `data.unique_ids` shall both be greater than `0`
+```
+
+**Fixture:** `tests/fixtures/sample.candump`.
 
 ---
 
@@ -189,6 +203,9 @@ And    `"re_match_dbc"` shall not appear in the set of tool names
 Given  the `_build_argv` helper is available
 When   called with `("capture", {"interface": "can0"})`
 Then   the result shall equal `["capture", "can0", "--json"]`
+
+When   called with `("capture_info", {"file": "trace.candump"})`
+Then   the result shall equal `["capture-info", "--file", "trace.candump", "--json"]`
 
 When   called with `("j1939_monitor", {"interface": "can0", "pgn": 60160})`
 Then   the result shall contain `["j1939", "monitor", "can0", "--pgn", "60160"]` in order

--- a/docs/tests/transport-core-commands.md
+++ b/docs/tests/transport-core-commands.md
@@ -19,13 +19,14 @@ Validate the shipped passive, active, and file-backed transport workflows, inclu
 * default `python-can` and scaffold capture streaming paths
 * filter matching behavior
 * stats summary behavior
+* capture metadata reconnaissance behavior
 * structured transport/file errors
 
 ## Requirement Traceability
 
 | Requirement ID | Covered by test IDs |
 |----------------|---------------------|
-| `REQ-TRANSPORT-01` | `TEST-TRANSPORT-01`, `TEST-TRANSPORT-02`, `TEST-TRANSPORT-05`, `TEST-TRANSPORT-06` |
+| `REQ-TRANSPORT-01` | `TEST-TRANSPORT-01`, `TEST-TRANSPORT-02`, `TEST-TRANSPORT-05`, `TEST-TRANSPORT-06`, `TEST-TRANSPORT-13` |
 | `REQ-TRANSPORT-02` | `TEST-TRANSPORT-01`, `TEST-TRANSPORT-03`, `TEST-TRANSPORT-04`, `TEST-TRANSPORT-08`, `TEST-TRANSPORT-09` |
 | `REQ-TRANSPORT-03` | `TEST-TRANSPORT-02` |
 | `REQ-TRANSPORT-04` | `TEST-TRANSPORT-05` |
@@ -35,6 +36,7 @@ Validate the shipped passive, active, and file-backed transport workflows, inclu
 | `REQ-TRANSPORT-08` | `TEST-TRANSPORT-11` |
 | `REQ-TRANSPORT-09` | `TEST-TRANSPORT-12` |
 | `REQ-TRANSPORT-10` | `TEST-TRANSPORT-10` |
+| `REQ-TRANSPORT-11` | `TEST-TRANSPORT-13`, `TEST-TRANSPORT-14` |
 
 ## Representative Test Cases
 
@@ -93,7 +95,7 @@ Then   the system shall emit one serialized frame event per output line
 
 ```gherkin
 Given  the file `tests/fixtures/sample.candump` is available
-When   the operator runs `canarchy filter sample.candump id==0x18FEEE31 --json`
+When   the operator runs `canarchy filter id==0x18FEEE31 --file tests/fixtures/sample.candump --json`
 Then   the result shall contain exactly one frame event matching arbitration ID `0x18FEEE31`
 ```
 
@@ -105,7 +107,7 @@ Then   the result shall contain exactly one frame event matching arbitration ID 
 
 ```gherkin
 Given  the file `tests/fixtures/sample.candump` is available
-When   the operator runs `canarchy stats sample.candump --json`
+When   the operator runs `canarchy stats --file tests/fixtures/sample.candump --json`
 Then   the result shall include deterministic summary fields
 And    the summary shall include a total frame count and an arbitration-ID count
 ```
@@ -155,9 +157,9 @@ Then   the system shall render each special frame type correctly in candump form
 
 ```gherkin
 Given  the file `tests/fixtures/sample.candump` is available
-When   the operator runs `canarchy filter sample.candump unsupported_expr --json`
+When   the operator runs `canarchy filter unsupported_expr --file tests/fixtures/sample.candump --json`
 Then   the command shall exit with code `2`
-And    `errors[0].code` shall equal `"FILTER_EXPRESSION_UNSUPPORTED"`
+And    `errors[0].code` shall equal `"INVALID_FILTER_EXPRESSION"`
 ```
 
 **Fixture:** `tests/fixtures/sample.candump`.
@@ -168,7 +170,7 @@ And    `errors[0].code` shall equal `"FILTER_EXPRESSION_UNSUPPORTED"`
 
 ```gherkin
 Given  the file `tests/fixtures/invalid.candump` contains unparseable content
-When   the operator runs `canarchy stats invalid.candump --json`
+When   the operator runs `canarchy stats --file tests/fixtures/invalid.candump --json`
 Then   the command shall exit with code `2`
 And    `errors[0].code` shall equal `"CAPTURE_SOURCE_INVALID"`
 ```
@@ -181,12 +183,38 @@ And    `errors[0].code` shall equal `"CAPTURE_SOURCE_INVALID"`
 
 ```gherkin
 Given  a file with an unsupported extension is present
-When   the operator runs `canarchy stats file.xyz --json`
+When   the operator runs `canarchy stats --file file.xyz --json`
 Then   the command shall exit with code `2`
 And    `errors[0].code` shall equal `"CAPTURE_FORMAT_UNSUPPORTED"`
 ```
 
 **Fixture:** file with an unsupported format suffix.
+
+---
+
+### `TEST-TRANSPORT-13` — Capture-info returns fast capture metadata
+
+```gherkin
+Given  the file `tests/fixtures/sample.candump` is available
+When   the operator runs `canarchy capture-info --file tests/fixtures/sample.candump --json`
+Then   the result shall include `frame_count`, `first_timestamp`, `last_timestamp`, `duration_seconds`, `unique_ids`, and `interfaces`
+And    the result shall include suggested `max_frames` and `seconds` bounds for follow-on analysis
+```
+
+**Fixture:** `tests/fixtures/sample.candump`.
+
+---
+
+### `TEST-TRANSPORT-14` — Capture-info reports invalid capture files consistently
+
+```gherkin
+Given  the file `tests/fixtures/invalid.candump` contains no valid candump frames
+When   the operator runs `canarchy capture-info --file tests/fixtures/invalid.candump --json`
+Then   the command shall exit with code `2`
+And    `errors[0].code` shall equal `"CAPTURE_SOURCE_INVALID"`
+```
+
+**Fixture:** `tests/fixtures/invalid.candump`.
 
 ---
 

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -261,7 +261,6 @@ def build_parser() -> CanarchyArgumentParser:
 
     capture_info = subparsers.add_parser("capture-info", help="show capture file metadata without loading frames")
     capture_info.add_argument("--file", required=True, help="path to candump capture file")
-    capture_info.add_argument("--sample", action="store_true", help="quick sample only (first/last 1000 lines)")
     add_output_arguments(capture_info)
     capture_info.set_defaults(command="capture-info")
 
@@ -1326,9 +1325,10 @@ def transport_payload(
             [],
         )
     if args.command == "capture-info":
-        metadata = transport.capture_info(args.file, sample=args.sample)
+        metadata = transport.capture_info(args.file)
         return (
             {
+                "mode": "passive",
                 "file": args.file,
                 "status": "implemented",
                 "implementation": "fast-metadata-scan",

--- a/src/canarchy/completion.py
+++ b/src/canarchy/completion.py
@@ -61,7 +61,7 @@ _J1939_FILE_BOUNDS = ["--offset", "--max-frames", "--seconds"]
 # Keys for subcommand groups use the "group subcommand" form.
 FLAGS: dict[str, list[str]] = {
     "capture": ["--candump"] + _OUTPUT,
-    "capture-info": ["--file", "--sample"] + _OUTPUT,
+    "capture-info": ["--file"] + _OUTPUT,
     "config show": _OUTPUT,
     "dbc inspect": ["--message", "--signals-only"] + _OUTPUT,
     "decode": ["--dbc", "--file"] + _OUTPUT,

--- a/src/canarchy/mcp_server.py
+++ b/src/canarchy/mcp_server.py
@@ -539,7 +539,7 @@ def _build_argv(tool_name: str, arguments: dict[str, Any]) -> list[str]:
                 argv += ["--seconds", str(a["seconds"])]
             return argv + ["--json"]
         case "capture_info":
-            return ["capture-info", a["file"], "--json"]
+            return ["capture-info", "--file", a["file"], "--json"]
         case "decode":
             argv = ["decode", a["file"], "--dbc", a["dbc"]]
             if a.get("offset") is not None and a["offset"] > 0:

--- a/src/canarchy/transport.py
+++ b/src/canarchy/transport.py
@@ -56,10 +56,12 @@ class TransportStats:
 class CaptureMetadata:
     frame_count: int
     duration_seconds: float
-    unique_arbitration_ids: int
+    unique_ids: int
     interfaces: list[str]
     first_timestamp: float
     last_timestamp: float
+    suggested_max_frames: int
+    suggested_seconds: float
 
     def to_payload(self) -> dict[str, int | float | list[str]]:
         return {
@@ -68,7 +70,9 @@ class CaptureMetadata:
             "frame_count": self.frame_count,
             "interfaces": self.interfaces,
             "last_timestamp": self.last_timestamp,
-            "unique_arbitration_ids": self.unique_arbitration_ids,
+            "suggested_max_frames": self.suggested_max_frames,
+            "suggested_seconds": self.suggested_seconds,
+            "unique_ids": self.unique_ids,
         }
 
 
@@ -91,6 +95,8 @@ CANDUMP_FD_LINE_RE = re.compile(
 SUPPORTED_CAPTURE_SUFFIXES = {".candump", ".log"}
 CAN_ERR_FLAG = 0x20000000
 SUPPORTED_CANDUMP_FD_FLAGS = 0x3
+CAPTURE_INFO_MAX_FRAMES_HINT = 500_000
+CAPTURE_INFO_MAX_SECONDS_HINT = 3600.0
 
 
 @dataclass(slots=True, frozen=True)
@@ -582,9 +588,9 @@ class LocalTransport:
             interfaces=sorted({frame.interface or "unknown" for frame in frames}),
         )
 
-    def capture_info(self, file_name: str, *, sample: bool = False) -> CaptureMetadata:
+    def capture_info(self, file_name: str) -> CaptureMetadata:
         path = self._capture_file_path(file_name)
-        return capture_metadata(path, sample=sample)
+        return capture_metadata(path)
 
     def frames_from_file(
         self,
@@ -957,75 +963,37 @@ def load_candump_file(path: Path) -> list[CanFrame]:
     return frames
 
 
-def capture_metadata(path: Path, *, sample: bool = False) -> CaptureMetadata:
-    timestamp_re = re.compile(r"^\((\d+\.\d+)\) (\w+) ([0-9A-Fa-f]+)#")
+def _capture_info_suggestions(frame_count: int, duration_seconds: float) -> tuple[int, float]:
+    return (
+        min(frame_count, CAPTURE_INFO_MAX_FRAMES_HINT),
+        min(duration_seconds, CAPTURE_INFO_MAX_SECONDS_HINT),
+    )
 
+
+def capture_metadata(path: Path) -> CaptureMetadata:
     first_timestamp: float | None = None
     last_timestamp: float | None = None
     interfaces: set[str] = set()
     arbitration_ids: set[int] = set()
     frame_count = 0
 
-    if sample:
-        sample_size = 1000
-        with path.open(encoding="utf-8") as handle:
-            lines = list(handle)[:sample_size]
-        for line in lines:
-            stripped = line.strip()
-            if not stripped:
-                continue
-            match = timestamp_re.match(stripped)
-            if not match:
-                continue
-            if first_timestamp is None:
-                first_timestamp = float(match.group(1))
-            frame_count += 1
-            interfaces.add(match.group(2))
-            arbitration_ids.add(int(match.group(3), 16))
-
-        with path.open(encoding="utf-8") as handle:
-            handle.seek(0)
-            last_lines = list(handle)[-sample_size:]
-        for line in reversed(last_lines):
-            stripped = line.strip()
-            if not stripped:
-                continue
-            match = timestamp_re.match(stripped)
-            if not match:
-                continue
-            last_timestamp = float(match.group(1))
-            break
-
-        duration = (last_timestamp - first_timestamp) if first_timestamp and last_timestamp else 0
-        return CaptureMetadata(
-            frame_count=frame_count,
-            duration_seconds=duration,
-            unique_arbitration_ids=len(arbitration_ids),
-            interfaces=sorted(interfaces),
-            first_timestamp=first_timestamp or 0,
-            last_timestamp=last_timestamp or 0,
-        )
-
     with path.open(encoding="utf-8") as handle:
-        for line in handle:
+        for line_number, line in enumerate(handle, start=1):
             stripped = line.strip()
             if not stripped:
                 continue
-            match = timestamp_re.match(stripped)
-            if not match:
+
+            try:
+                frame = parse_candump_line(stripped, path=path, line_number=line_number)
+            except TransportError:
                 continue
 
-            ts = float(match.group(1))
-            interface = match.group(2)
-            arbitration_id = int(match.group(3), 16)
-
             if first_timestamp is None:
-                first_timestamp = ts
-            last_timestamp = ts
+                first_timestamp = frame.timestamp
+            last_timestamp = frame.timestamp
             frame_count += 1
-            if interface:
-                interfaces.add(interface)
-            arbitration_ids.add(arbitration_id)
+            interfaces.add(frame.interface or "unknown")
+            arbitration_ids.add(frame.arbitration_id)
 
     if first_timestamp is None or last_timestamp is None:
         raise TransportError(
@@ -1034,13 +1002,18 @@ def capture_metadata(path: Path, *, sample: bool = False) -> CaptureMetadata:
             "Verify the file is in candump format.",
         )
 
+    duration_seconds = max(0.0, last_timestamp - first_timestamp)
+    suggested_max_frames, suggested_seconds = _capture_info_suggestions(frame_count, duration_seconds)
+
     return CaptureMetadata(
         frame_count=frame_count,
-        duration_seconds=last_timestamp - first_timestamp,
-        unique_arbitration_ids=len(arbitration_ids),
+        duration_seconds=duration_seconds,
+        unique_ids=len(arbitration_ids),
         interfaces=sorted(interfaces),
         first_timestamp=first_timestamp,
         last_timestamp=last_timestamp,
+        suggested_max_frames=suggested_max_frames,
+        suggested_seconds=suggested_seconds,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -543,6 +543,37 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["data"]["total_frames"], 3)
         self.assertEqual(payload["data"]["unique_arbitration_ids"], 3)
 
+    def test_capture_info_json_output_returns_fast_metadata(self) -> None:
+        exit_code, stdout, stderr = run_cli(
+            "capture-info", "--file", str(FIXTURES / "sample.candump"), "--json"
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(stderr, "")
+
+        payload = json.loads(stdout)
+        self.assertEqual(payload["command"], "capture-info")
+        self.assertEqual(payload["data"]["mode"], "passive")
+        self.assertEqual(payload["data"]["implementation"], "fast-metadata-scan")
+        self.assertEqual(payload["data"]["frame_count"], 3)
+        self.assertEqual(payload["data"]["unique_ids"], 3)
+        self.assertEqual(payload["data"]["interfaces"], ["can0", "can1"])
+        self.assertEqual(payload["data"]["first_timestamp"], 0.0)
+        self.assertEqual(payload["data"]["last_timestamp"], 0.2)
+        self.assertEqual(payload["data"]["duration_seconds"], 0.2)
+        self.assertEqual(payload["data"]["suggested_max_frames"], 3)
+        self.assertEqual(payload["data"]["suggested_seconds"], 0.2)
+
+    def test_capture_info_invalid_capture_returns_structured_error(self) -> None:
+        exit_code, stdout, stderr = run_cli(
+            "capture-info", "--file", str(FIXTURES / "invalid.candump"), "--json"
+        )
+        self.assertEqual(exit_code, EXIT_TRANSPORT_ERROR)
+        self.assertEqual(stderr, "")
+
+        payload = json.loads(stdout)
+        self.assertEqual(payload["command"], "capture-info")
+        self.assertEqual(payload["errors"][0]["code"], "CAPTURE_SOURCE_INVALID")
+
     def test_nested_j1939_command_works(self) -> None:
         exit_code, stdout, _ = run_cli("j1939", "monitor", "--pgn", "65262", "--raw")
         self.assertEqual(exit_code, EXIT_OK)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -12,7 +12,7 @@ from canarchy.mcp_server import _TOOL_NAMES, _TOOLS, _build_argv, handle_call_to
 FIXTURES = Path(__file__).parent / "fixtures"
 
 _EXPECTED_TOOLS = {
-    "capture", "send", "generate", "gateway", "replay", "filter", "stats",
+    "capture", "send", "generate", "gateway", "replay", "filter", "stats", "capture_info",
     "decode", "encode", "dbc_inspect", "export",
     "session_save", "session_load", "session_show",
     "j1939_monitor", "j1939_decode", "j1939_pgn", "j1939_spn", "j1939_tp", "j1939_dm1",
@@ -37,7 +37,7 @@ def test_list_tools_returns_expected_names():
 
 def test_list_tools_count():
     tools = asyncio.run(handle_list_tools())
-    assert len(tools) >= 24
+    assert len(tools) >= 25
 
 
 # --- TEST-MCP-04: tool metadata validity -----------------------------------
@@ -69,6 +69,18 @@ def test_call_tool_uds_services():
     payload = json.loads(results[0].text)
     assert payload["ok"] is True
     assert payload["data"]["service_count"] > 0
+
+
+def test_call_tool_capture_info():
+    results = asyncio.run(
+        handle_call_tool("capture_info", {"file": str(FIXTURES / "sample.candump")})
+    )
+    assert len(results) == 1
+    payload = json.loads(results[0].text)
+    assert payload["ok"] is True
+    assert payload["command"] == "capture-info"
+    assert payload["data"]["frame_count"] == 3
+    assert payload["data"]["unique_ids"] == 3
 
 
 # --- TEST-MCP-07: invalid frame_id returns structured error ----------------
@@ -120,6 +132,11 @@ def test_shell_and_tui_not_exposed():
 def test_build_argv_capture():
     argv = _build_argv("capture", {"interface": "can0"})
     assert argv == ["capture", "can0", "--json"]
+
+
+def test_build_argv_capture_info():
+    argv = _build_argv("capture_info", {"file": "trace.candump"})
+    assert argv == ["capture-info", "--file", "trace.candump", "--json"]
 
 
 def test_build_argv_j1939_monitor_with_pgn():


### PR DESCRIPTION
## Summary
- complete the `capture-info` workflow so it returns fast capture metadata plus suggested analysis bounds for follow-on commands
- fix the `capture_info` MCP adapter to use the current `--file` CLI contract and cover it with CLI/MCP tests
- update changelog, command reference, transport specs, MCP specs, and agent docs to reflect the shipped command surface

## Verification
- uv run pytest tests/test_cli.py
- uv run pytest tests/test_mcp.py
- uv run mkdocs build --strict

Closes #145