### PR TITLE
fix(site): prefix doc links with /canarchy base path

### DIFF
--- a/src/homepage/site-brutalist.jsx
+++ b/src/homepage/site-brutalist.jsx
@@ -15,6 +15,7 @@ const bColors = {
 const bDisplay = "'Archivo Black', 'Archivo', ui-sans-serif, system-ui";
 const bBody = "'Archivo', ui-sans-serif, system-ui";
 const bMono = "'JetBrains Mono', 'IBM Plex Mono', ui-monospace, monospace";
+const siteBase = '/canarchy';
 
 function CautionStripe({ h = 24, flip = false }) {
   return (
@@ -26,10 +27,10 @@ function CautionStripe({ h = 24, flip = false }) {
 }
 
 const navLinks = [
-  { label: 'DOCS',     href: '/docs/' },
-  { label: 'COMMANDS', href: '/docs/command_spec' },
-  { label: 'J1939',    href: '/docs/j1939' },
-  { label: 'AGENTS',   href: '/docs/agents' },
+  { label: 'DOCS',     href: siteBase + '/docs/getting_started' },
+  { label: 'COMMANDS', href: siteBase + '/docs/command_spec' },
+  { label: 'J1939',    href: siteBase + '/docs/tutorials/j1939_heavy_vehicle' },
+  { label: 'AGENTS',   href: siteBase + '/docs/agents' },
   { label: 'GITHUB',   href: 'https://github.com/hexsecs/canarchy' },
 ];
 
@@ -145,7 +146,10 @@ function BrutHero() {
         >
           pip install canarchy →
         </a>
-        <a href="/docs/" style={{
+<a href={siteBase + '/docs/getting_started'} style={{
+=======
+        <a href={siteBase + '/docs/getting_started'} style={{
+>>>>>>> e85df0b (fix(site): prefix all /docs/ links with /canarchy base path)
           background: bColors.yellow, color: bColors.ink, padding: '22px 30px',
           fontFamily: bDisplay, fontSize: 20, letterSpacing: 1, textDecoration: 'none',
           border: `4px solid ${bColors.ink}`, borderLeft: 'none', textTransform: 'uppercase',
@@ -711,28 +715,28 @@ function BrutInstall() {
 
 const footerLinks = {
   DOCS: [
-    { label: 'Getting Started', href: '/docs/' },
-    { label: 'Command Spec',    href: '/docs/command_spec' },
-    { label: 'Event Schema',    href: '/docs/event_schema' },
-    { label: 'Matrix',          href: '/docs/command_matrix' },
+    { label: 'Getting Started', href: siteBase + '/docs/getting_started' },
+    { label: 'Command Spec',    href: siteBase + '/docs/command_spec' },
+    { label: 'Event Schema',    href: siteBase + '/docs/event-schema' },
+    { label: 'Matrix',          href: siteBase + '/docs/feature-matrix' },
   ],
   GUIDE: [
-    { label: 'Backends',   href: '/docs/backends' },
-    { label: 'J1939',      href: '/docs/j1939' },
-    { label: 'UDS',        href: '/docs/uds' },
-    { label: 'Tutorials',  href: '/docs/tutorials' },
+    { label: 'Backends',   href: siteBase + '/docs/backends' },
+    { label: 'J1939',      href: siteBase + '/docs/tutorials/j1939_heavy_vehicle' },
+    { label: 'UDS',        href: siteBase + '/docs/tutorials' },
+    { label: 'Tutorials',  href: siteBase + '/docs/tutorials' },
   ],
   DEV: [
-    { label: 'Architecture', href: '/docs/architecture' },
-    { label: 'Design',        href: '/docs/design' },
-    { label: 'Release',        href: '/docs/release' },
-    { label: 'TUI',           href: '/docs/tui' },
+    { label: 'Architecture', href: siteBase + '/docs/architecture' },
+    { label: 'Design',        href: siteBase + '/docs/overview' },
+    { label: 'Release',        href: siteBase + '/docs/release' },
+    { label: 'TUI',           href: siteBase + '/docs/tui_plan' },
   ],
   SOCIAL: [
     { label: 'GitHub',      href: 'https://github.com/hexsecs/canarchy' },
     { label: 'Issues',      href: 'https://github.com/hexsecs/canarchy/issues' },
     { label: 'Discussions', href: 'https://github.com/hexsecs/canarchy/discussions' },
-    { label: 'Agents',      href: '/docs/agents' },
+    { label: 'Agents',      href: siteBase + '/docs/agents' },
   ],
 };
 


### PR DESCRIPTION
## Summary

The GitHub Pages site deploys at `/canarchy/`, not `/`. All homepage links were using absolute paths like `/docs/` which resolved to `hexsecs.github.io/docs/` instead of `hexsecs.github.io/canarchy/docs/`.

**Fix:** Added a `siteBase = '/canarchy'` constant used by every internal link, so all doc links are correctly prefixed.

Also corrected broken doc paths discovered during review:
- Getting Started: `/docs/getting_started` (was `/docs/`)
- Event Schema: `/docs/event-schema` (was `/docs/event_schema`)
- Matrix: `/docs/feature-matrix` (was `/docs/command_matrix`)
- J1939: `/docs/tutorials/j1939_heavy_vehicle` (was `/docs/j1939`)
- Design: `/docs/overview` (was `/docs/design`)
- TUI: `/docs/tui_plan` (was `/docs/tui`)

---

refs #170