### PR TITLE
fix(site): remove leftover merge conflict markers

### DIFF
--- a/src/homepage/site-brutalist.jsx
+++ b/src/homepage/site-brutalist.jsx
@@ -147,9 +147,6 @@ function BrutHero() {
           pip install canarchy →
         </a>
 <a href={siteBase + '/docs/getting_started'} style={{
-=======
-        <a href={siteBase + '/docs/getting_started'} style={{
->>>>>>> e85df0b (fix(site): prefix all /docs/ links with /canarchy base path)
           background: bColors.yellow, color: bColors.ink, padding: '22px 30px',
           fontFamily: bDisplay, fontSize: 20, letterSpacing: 1, textDecoration: 'none',
           border: `4px solid ${bColors.ink}`, borderLeft: 'none', textTransform: 'uppercase',


### PR DESCRIPTION
## Summary

The `site-brutalist.jsx` file was deployed with leftover merge conflict markers (`<<<<<<< HEAD`, `=======`, `>>>>>>>`) from an incomplete cherry-pick resolution in PR #174. This caused React to fail to render, leaving only the SVG thumbnail visible.

**Fix:** Removed the conflict markers from the JSX file so Babel can parse it correctly.

---

refs #170