### PR TITLE
fix(release): correct changelog and dev version policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,15 @@ The only exceptions are:
 * When a release is cut, the `[Unreleased]` section is promoted to a versioned heading. Do not manually create versioned headings outside of the release workflow.
 * The only exceptions are: typo/whitespace-only changes in docs or comments, changes to `.gitignore` or other non-functional config, and MkDocs nav or theme-only changes.
 
+### Versioning after release
+
+**This is a hard rule, not a suggestion.**
+
+* After cutting release `X.Y.Z`, advance `src/canarchy/__init__.py` on `main` to `X.Y.(Z+1).dev0` unless a different next-version target is explicitly planned and documented.
+* Do not leave `main` on the released version once unreleased work resumes.
+* Keep release tags on the stable release version only, such as `v0.4.0`.
+* If the next intended release is a minor or major bump instead of the next patch version, document that decision explicitly and set the `.dev0` version accordingly.
+
 ### PR acceptance criteria
 
 **A PR is not ready to merge until all of the following are true.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 * GitHub Pages now publishes the custom repository-root homepage at `/`, while the MkDocs documentation site is built and published under `/docs/` so the existing docs home remains available as the documentation landing page.
 * Homepage nav and footer links are now real `<a>` tags instead of plain styled divs. The source lives in `src/homepage/` (`index.html` + `site-brutalist.jsx`) and is copied to the site root by the Pages build script — no more binary blob patching.
+* The package version has advanced to `0.4.1.dev0` on `main` so post-`0.4.0` work is identified as development builds until the next release is cut.
+
+### Fixed
+
+* The GitHub Pages root homepage now collapses oversized navigation, hero, CTA, content-grid, and footer layouts for mobile viewports so the base page remains readable and usable on phones.
+* The GitHub Pages root homepage now scales marquee text, major section headings, selected card titles, and command/transcript blocks down further for common phone widths including iPhone 16 Pro-sized viewports.
+* The GitHub Pages root homepage now uses a compact hamburger menu for mobile navigation while preserving the full inline top nav on larger viewports.
 
 ### Documentation
 
@@ -36,10 +43,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * Standardized CLI argument ordering: file-backed commands now use `--file` flag for capture file input instead of positional arguments. The `--file` argument is required for file-only commands (`stats`, `capture-info`, `replay`, `j1939 tp`, `j1939 dm1`, `j1939 summary`) to prevent unstructured crashes. Commands with stdin support (`filter`, `decode`, `j1939 decode`) can alternatively use `--stdin`.
 
 ### Fixed
-
-* The GitHub Pages root homepage now collapses oversized navigation, hero, CTA, content-grid, and footer layouts for mobile viewports so the base page remains readable and usable on phones.
-* The GitHub Pages root homepage now scales marquee text, major section headings, selected card titles, and command/transcript blocks down further for common phone widths including iPhone 16 Pro-sized viewports.
-* The GitHub Pages root homepage now uses a compact hamburger menu for mobile navigation while preserving the full inline top nav on larger viewports.
 
 * `uds scan` and `uds trace` now reassemble ISO-TP multi-frame UDS responses, ignore flow-control frames, and mark partial transactions with `complete=false` when a segmented response is truncated or arrives out of order.
 * `--offset` now counts successfully parsed frames rather than file lines, correctly handling files with blank lines, comments, or malformed entries.

--- a/docs/release.md
+++ b/docs/release.md
@@ -26,10 +26,27 @@ For the first public release, use TestPyPI first.
 2. Move relevant entries from `CHANGELOG.md` `Unreleased` into a new versioned release section.
 3. Commit the release preparation changes.
 4. Tag the release with `vX.Y.Z`.
-5. Build and verify artifacts locally.
-6. Publish to TestPyPI first if this is the first release or if the release workflow changed.
-7. Publish to PyPI.
-8. Create the GitHub release notes from the changelog.
+5. After the release commit lands on `main`, advance `src/canarchy/__init__.py` to the next development version.
+6. Build and verify artifacts locally.
+7. Publish to TestPyPI first if this is the first release or if the release workflow changed.
+8. Publish to PyPI.
+9. Create the GitHub release notes from the changelog.
+
+## Development Version Naming
+
+After cutting release `X.Y.Z`, `main` shall advance immediately to `X.Y.(Z+1).dev0` unless a different next-version target is explicitly planned and documented before or as part of the release.
+
+Examples:
+
+* after `0.4.0`, set `src/canarchy/__init__.py` to `0.4.1.dev0`
+* after `1.2.3`, set `src/canarchy/__init__.py` to `1.2.4.dev0`
+
+Rules:
+
+* keep release tags on the stable version only, such as `v0.4.0`
+* keep unreleased work on `main` on a `.devN` version string
+* update the version metadata in the same commit or immediate follow-up commit that reopens development after a release
+* if the next planned release target is a minor or major bump instead of the next patch version, document that decision explicitly and set the `.dev0` version accordingly
 
 ## Local Verification
 

--- a/src/canarchy/__init__.py
+++ b/src/canarchy/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.0"
+__version__ = "0.4.1.dev0"


### PR DESCRIPTION
## Summary
- move the post-0.4.0 homepage mobile-fix entries out of the released `0.4.0` changelog section and back under `[Unreleased]`
- document the post-release development-version rule for `main` in the release workflow and agent policy
- advance `src/canarchy/__init__.py` to `0.4.1.dev0` so unreleased work is no longer labeled as the shipped `0.4.0` release

## Verification
- `uv run --group docs mkdocs build --strict`
- `uv run canarchy --version`

Fixes #184