### PR TITLE
fix homepage: align CTA buttons vertically on desktop

### DIFF
--- a/src/homepage/site-brutalist.jsx
+++ b/src/homepage/site-brutalist.jsx
@@ -213,7 +213,7 @@ function BrutHero({ viewport }) {
         </div>
       </div>
 
-      <div style={{ display: 'flex', gap: 0, marginTop: 50, flexWrap: 'wrap' }}>
+      <div style={{ display: 'flex', gap: 0, marginTop: 50, flexWrap: 'wrap', alignItems: 'stretch' }}>
         <a
           href="#"
           onClick={e => { e.preventDefault(); navigator.clipboard?.writeText('pip install canarchy'); }}


### PR DESCRIPTION
## Summary
- Adds `alignItems: stretch` to the button container so the three CTAs stay vertically aligned
- Fixes misalignment where buttons could have different effective heights due to border rendering

## Testing
- Built locally with `scripts/build_pages_site.sh`