### PR TITLE
chore: prep release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-25
+
 ### Added
 
 * Added `canarchy j1939 inventory` and the `j1939_inventory` MCP tool for building source-address inventories from recorded J1939 captures, including top PGNs, component-identification strings, vehicle-identification strings, and per-node DM1 presence.

--- a/src/canarchy/__init__.py
+++ b/src/canarchy/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.1.dev0"
+__version__ = "0.5.0"


### PR DESCRIPTION
## Summary

- Bumps version from `0.4.1.dev0` to `0.5.0` in `src/canarchy/__init__.py`
- Promotes the `[Unreleased]` changelog section to `[0.5.0] - 2026-04-25`

## Pre-release verification

- 370 tests, 0 failures (1 skipped — multicast network config)
- `uv build` + `twine check` — both artifacts passed
- `mkdocs build --strict` — docs built cleanly

---
_Generated by [Claude Code](https://claude.ai/code/session_01LavXbXnEeKFmTmrYRaUWni)_