### PR TITLE
feat: large-file performance for capture-info and j1939 analysis (#163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 * Added `canarchy j1939 compare` for multi-capture comparison of J1939 PGNs, source addresses, DM1 fault changes, and printable TP identification payloads across two or more recorded captures.
 * Implemented `canarchy re correlate <file> --reference <ref>` to correlate candidate bit fields against a reference time series. Accepts JSON (array or named object with `name`+`samples`) and JSONL reference formats. Each candidate reports `pearson_r`, `spearman_r`, `sample_count`, and `lag_ms` (optimal time offset in [-500, +500] ms). Candidates are ranked by `|pearson_r|` descending. Structured errors are returned for missing `--reference` (`RE_REFERENCE_REQUIRED`), invalid or short reference files (`INVALID_REFERENCE_FILE`), and insufficient capture/reference time-range overlap (`INSUFFICIENT_OVERLAP`). Also exposed as the `re_correlate` MCP tool. Closes #52.
+* Added fast-scan path to `capture-info` for large candump files (> 50 MB). The first and last 64 KB are parsed for timestamps and interface/ID samples; frame count is estimated from file size and average line length. The response payload now includes `scan_mode: "full"` (exact) or `scan_mode: "estimated"` (large-file approximation). Closes #163.
+* Added automatic frame cap for `j1939 summary`, `j1939 dm1`, `j1939 faults`, `j1939 inventory`, and `j1939 compare` on captures exceeding 50 MB when no `--max-frames` or `--seconds` limit is specified. Analysis is capped at 500,000 frames and a warning is included in the response. Use `--max-frames` or `--seconds` to override. Closes #163.
 
 ### Documentation
 

--- a/docs/design/j1939-bounded-analysis.md
+++ b/docs/design/j1939-bounded-analysis.md
@@ -27,6 +27,7 @@ Large heavy-vehicle captures often contain millions of frames. Analysts need to 
 | `REQ-J1939WIN-04` | Unwanted behaviour | If `--max-frames` is less than `1`, the system shall return a structured user error with code `INVALID_MAX_FRAMES`. |
 | `REQ-J1939WIN-05` | Unwanted behaviour | If `--seconds` is negative, the system shall return a structured user error with code `INVALID_ANALYSIS_SECONDS`. |
 | `REQ-J1939WIN-06` | Unwanted behaviour | If bounded-analysis flags are used with `j1939 decode --stdin`, the system shall return a structured user error with code `ANALYSIS_WINDOW_REQUIRES_FILE`. |
+| `REQ-J1939WIN-07` | Performance | When `j1939 summary`, `j1939 dm1`, `j1939 faults`, `j1939 inventory`, or `j1939 compare` is invoked on a file larger than 50 MB without an explicit `--max-frames` or `--seconds` bound, the system shall automatically cap analysis at 500,000 frames and include a warning in the response instructing the operator to use `--max-frames` or `--seconds` to override. |
 
 ## Command Surface
 

--- a/docs/design/transport-core-commands.md
+++ b/docs/design/transport-core-commands.md
@@ -31,6 +31,7 @@ Operators need a stable base command set that supports passive live observation,
 | `REQ-TRANSPORT-09` | Unwanted behaviour | If a capture file format is unsupported, the system shall return a structured error with code `CAPTURE_FORMAT_UNSUPPORTED` and exit code 2. |
 | `REQ-TRANSPORT-10` | Unwanted behaviour | If `filter` receives an invalid expression, the system shall return a structured error with code `INVALID_FILTER_EXPRESSION` and exit code 2. |
 | `REQ-TRANSPORT-11` | Event-driven | When `capture-info --file <path>` is invoked, the system shall return capture metadata including frame count, first and last timestamps, duration, unique IDs, interfaces, and suggested `max_frames` and `seconds` bounds for follow-on analysis. |
+| `REQ-TRANSPORT-12` | Performance | When `capture-info` is invoked on a file larger than 50 MB, the system shall use a fast head+tail scan to estimate metadata rather than parsing every frame, and shall set `scan_mode` to `"estimated"` in the response. |
 
 ## Command Surface
 
@@ -83,6 +84,7 @@ Relevant shared fields include:
 * `interfaces`
 * `suggested_max_frames`
 * `suggested_seconds`
+* `scan_mode` — `"full"` for files ≤ 50 MB (exact counts); `"estimated"` for larger files (head+tail heuristic, approximate frame count and unique_ids)
 
 Current backend note:
 

--- a/docs/tests/j1939-bounded-analysis.md
+++ b/docs/tests/j1939-bounded-analysis.md
@@ -18,6 +18,7 @@
 | `REQ-J1939WIN-04` | Invalid `--max-frames` returns structured error | `TEST-J1939WIN-03` |
 | `REQ-J1939WIN-05` | Invalid `--seconds` returns structured error | `TEST-J1939WIN-06` |
 | `REQ-J1939WIN-06` | Bounded analysis is rejected with `j1939 decode --stdin` | `TEST-J1939WIN-07` |
+| `REQ-J1939WIN-07` | Auto-cap for j1939 summary/dm1/faults/inventory/compare on large files | `TEST-J1939WIN-08`, `TEST-J1939WIN-09`, `TEST-J1939WIN-10`, `TEST-J1939WIN-11`, `TEST-J1939WIN-12`, `TEST-J1939WIN-13` |
 
 ## Test Cases
 
@@ -110,10 +111,92 @@ And    `errors[0].code` shall equal `"ANALYSIS_WINDOW_REQUIRES_FILE"`
 
 **Fixture:** mocked stdin JSONL frame event stream.
 
+### TEST-J1939WIN-08 — j1939 summary auto-caps on large files
+
+```gherkin
+Given  a capture file larger than 50 MB (threshold patched to 1 byte in test)
+And    no `--max-frames` or `--seconds` flag is provided
+When   the operator runs `canarchy j1939 summary --file <large-file> --json`
+Then   the response shall include a warning containing "Large file"
+And    the warning shall mention 500,000 frames
+```
+
+**Fixture:** `tests/fixtures/j1939_heavy_vehicle.candump` with threshold patched.
+
+---
+
+### TEST-J1939WIN-09 — j1939 summary does not auto-cap when --max-frames is set
+
+```gherkin
+Given  a capture file larger than 50 MB (threshold patched to 1 byte in test)
+And    `--max-frames 100` is provided
+When   the operator runs `canarchy j1939 summary --file <large-file> --max-frames 100 --json`
+Then   the response warnings shall not include any "Large file" auto-cap message
+```
+
+**Fixture:** `tests/fixtures/j1939_heavy_vehicle.candump` with threshold patched.
+
+---
+
+### TEST-J1939WIN-10 — j1939 dm1 auto-caps on large files
+
+```gherkin
+Given  a capture file larger than 50 MB (threshold patched to 1 byte in test)
+And    no `--max-frames` or `--seconds` flag is provided
+When   the operator runs `canarchy j1939 dm1 --file <large-file> --json`
+Then   the response shall include a warning containing "Large file"
+```
+
+**Fixture:** `tests/fixtures/j1939_dm1_spn175.candump` with threshold patched.
+
+---
+
+### TEST-J1939WIN-11 — j1939 faults auto-caps on large files
+
+```gherkin
+Given  a capture file larger than 50 MB (threshold patched to 1 byte in test)
+And    no `--max-frames` or `--seconds` flag is provided
+When   the operator runs `canarchy j1939 faults --file <large-file> --json`
+Then   the response shall include a warning containing "Large file"
+```
+
+**Fixture:** `tests/fixtures/j1939_dm1_spn175.candump` with threshold patched.
+
+---
+
+### TEST-J1939WIN-12 — j1939 inventory auto-caps on large files
+
+```gherkin
+Given  a capture file larger than 50 MB (threshold patched to 1 byte in test)
+And    no `--max-frames` or `--seconds` flag is provided
+When   the operator runs `canarchy j1939 inventory --file <large-file> --json`
+Then   the response shall include a warning containing "Large file"
+```
+
+**Fixture:** `tests/fixtures/j1939_inventory.candump` with threshold patched.
+
+---
+
+### TEST-J1939WIN-13 — j1939 compare auto-caps on large files
+
+```gherkin
+Given  two capture files larger than 50 MB (threshold patched to 1 byte in test)
+And    no `--max-frames` or `--seconds` flag is provided
+When   the operator runs `canarchy j1939 compare <file1> <file2> --json`
+Then   the response shall include a warning containing "Large file"
+```
+
+**Fixture:** `tests/fixtures/j1939_inventory.candump` and `tests/fixtures/j1939_compare_shifted.candump` with threshold patched.
+
+---
+
 ## Fixtures And Environment
 
 * `tests/fixtures/j1939_heavy_vehicle.candump`
 * `tests/fixtures/j1939_dm1_tp.candump`
+* `tests/fixtures/j1939_dm1_spn175.candump`
+* `tests/fixtures/j1939_inventory.candump`
+* `tests/fixtures/j1939_compare_shifted.candump`
 * mocked stdin JSONL frame event input for the file-only validation path
 
 ## Explicit Non-Coverage

--- a/docs/tests/transport-core-commands.md
+++ b/docs/tests/transport-core-commands.md
@@ -37,6 +37,7 @@ Validate the shipped passive, active, and file-backed transport workflows, inclu
 | `REQ-TRANSPORT-09` | `TEST-TRANSPORT-12` |
 | `REQ-TRANSPORT-10` | `TEST-TRANSPORT-10` |
 | `REQ-TRANSPORT-11` | `TEST-TRANSPORT-13`, `TEST-TRANSPORT-14` |
+| `REQ-TRANSPORT-12` | `TEST-TRANSPORT-15`, `TEST-TRANSPORT-16` |
 
 ## Representative Test Cases
 
@@ -215,6 +216,32 @@ And    `errors[0].code` shall equal `"CAPTURE_SOURCE_INVALID"`
 ```
 
 **Fixture:** `tests/fixtures/invalid.candump`.
+
+---
+
+### `TEST-TRANSPORT-15` — Capture-info uses full scan for small files and sets scan_mode=full
+
+```gherkin
+Given  a small capture file (under 50 MB)
+When   the operator runs `canarchy capture-info --file <small-file> --json`
+Then   `data.scan_mode` shall equal `"full"`
+And    `data.frame_count` shall be the exact frame count
+```
+
+**Fixture:** `tests/fixtures/sample.candump`.
+
+---
+
+### `TEST-TRANSPORT-16` — Capture-info uses estimated scan for large files and sets scan_mode=estimated
+
+```gherkin
+Given  a capture file larger than 50 MB (or threshold patched to 1 byte in test)
+When   the operator runs `canarchy capture-info --file <large-file> --json`
+Then   `data.scan_mode` shall equal `"estimated"`
+And    `data.first_timestamp` and `data.last_timestamp` shall be parseable from head/tail bytes
+```
+
+**Fixture:** `tests/fixtures/sample.candump` with threshold patched.
 
 ---
 

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -1092,12 +1092,34 @@ def frames_from_stdin(*, command: str) -> list[CanFrame]:
     return frames
 
 
+LARGE_FILE_AUTO_CAP_BYTES = 50 * 1024 * 1024
+LARGE_FILE_AUTO_CAP_FRAMES = 500_000
+
+
 def j1939_file_analysis_kwargs(args: argparse.Namespace) -> dict[str, int | float | None]:
     return {
         "offset": getattr(args, "offset", 0),
         "max_frames": getattr(args, "max_frames", None),
         "seconds": getattr(args, "seconds", None),
     }
+
+
+def _large_file_kwargs(args: argparse.Namespace, file: str, warnings: list[str]) -> dict[str, int | float | None]:
+    """Apply auto-cap when the file exceeds the large-file threshold and no limit is set."""
+    kwargs = j1939_file_analysis_kwargs(args)
+    if kwargs["max_frames"] is None and kwargs["seconds"] is None:
+        try:
+            size = Path(file).stat().st_size
+        except OSError:
+            return kwargs
+        if size >= LARGE_FILE_AUTO_CAP_BYTES:
+            kwargs["max_frames"] = LARGE_FILE_AUTO_CAP_FRAMES
+            warnings.append(
+                f"Large file detected ({size // (1024 * 1024)} MB); analysis capped at "
+                f"{LARGE_FILE_AUTO_CAP_FRAMES:,} frames. "
+                "Use --max-frames or --seconds to override."
+            )
+    return kwargs
 
 
 def _extract_printable_text(payload: bytes) -> str | None:
@@ -2205,11 +2227,12 @@ def j1939_payload(
             [],
         )
     if args.command == "j1939 dm1":
+        auto_warnings: list[str] = []
         decoder = get_j1939_decoder()
         messages = decoder.dm1_messages(
-            transport.iter_frames_from_file(args.file, **j1939_file_analysis_kwargs(args))
+            transport.iter_frames_from_file(args.file, **_large_file_kwargs(args, args.file, auto_warnings))
         )
-        warnings = dm1_warnings(messages)
+        warnings = auto_warnings + dm1_warnings(messages)
         data, dbc_warnings = enrich_dm1_with_dbc(
             {
                 "mode": "passive",
@@ -2227,11 +2250,12 @@ def j1939_payload(
             warnings,
         )
     if args.command == "j1939 faults":
+        auto_warnings = []
         decoder = get_j1939_decoder()
         messages = decoder.dm1_messages(
-            transport.iter_frames_from_file(args.file, **j1939_file_analysis_kwargs(args))
+            transport.iter_frames_from_file(args.file, **_large_file_kwargs(args, args.file, auto_warnings))
         )
-        warnings = dm1_warnings(messages)
+        warnings = auto_warnings + dm1_warnings(messages)
         enriched_data, dbc_warnings = enrich_dm1_with_dbc(
             {
                 "mode": "passive",
@@ -2253,28 +2277,31 @@ def j1939_payload(
             warnings,
         )
     if args.command == "j1939 summary":
+        auto_warnings = []
         decoder = get_j1939_decoder()
         data, warnings = _j1939_summary(
-            transport.frames_from_file(args.file, **j1939_file_analysis_kwargs(args)),
+            transport.frames_from_file(args.file, **_large_file_kwargs(args, args.file, auto_warnings)),
             file=args.file,
             decoder=decoder,
         )
-        return (data, [], warnings)
+        return (data, [], auto_warnings + warnings)
     if args.command == "j1939 inventory":
+        auto_warnings = []
         decoder = get_j1939_decoder()
         data, warnings = _j1939_inventory(
-            transport.frames_from_file(args.file, **j1939_file_analysis_kwargs(args)),
+            transport.frames_from_file(args.file, **_large_file_kwargs(args, args.file, auto_warnings)),
             file=args.file,
             decoder=decoder,
         )
-        return (data, [], warnings)
+        return (data, [], auto_warnings + warnings)
     if args.command == "j1939 compare":
         decoder = get_j1939_decoder()
         captures: list[dict[str, Any]] = []
         warnings: list[str] = []
         for file in args.files:
+            file_kwargs = _large_file_kwargs(args, file, warnings)
             capture_data, capture_warnings = _j1939_compare_capture(
-                transport.frames_from_file(file, **j1939_file_analysis_kwargs(args)),
+                transport.frames_from_file(file, **file_kwargs),
                 file=file,
                 decoder=decoder,
             )

--- a/src/canarchy/transport.py
+++ b/src/canarchy/transport.py
@@ -62,14 +62,16 @@ class CaptureMetadata:
     last_timestamp: float
     suggested_max_frames: int
     suggested_seconds: float
+    scan_mode: str = "full"
 
-    def to_payload(self) -> dict[str, int | float | list[str]]:
+    def to_payload(self) -> dict[str, int | float | list[str] | str]:
         return {
             "duration_seconds": self.duration_seconds,
             "first_timestamp": self.first_timestamp,
             "frame_count": self.frame_count,
             "interfaces": self.interfaces,
             "last_timestamp": self.last_timestamp,
+            "scan_mode": self.scan_mode,
             "suggested_max_frames": self.suggested_max_frames,
             "suggested_seconds": self.suggested_seconds,
             "unique_ids": self.unique_ids,
@@ -97,6 +99,9 @@ CAN_ERR_FLAG = 0x20000000
 SUPPORTED_CANDUMP_FD_FLAGS = 0x3
 CAPTURE_INFO_MAX_FRAMES_HINT = 500_000
 CAPTURE_INFO_MAX_SECONDS_HINT = 3600.0
+FAST_SCAN_THRESHOLD_BYTES = 50 * 1024 * 1024  # 50 MB
+FAST_SCAN_HEAD_BYTES = 65_536  # 64 KB
+FAST_SCAN_TAIL_BYTES = 65_536
 
 
 @dataclass(slots=True, frozen=True)
@@ -970,7 +975,79 @@ def _capture_info_suggestions(frame_count: int, duration_seconds: float) -> tupl
     )
 
 
-def capture_metadata(path: Path) -> CaptureMetadata:
+def _fast_capture_metadata(path: Path) -> CaptureMetadata:
+    """Estimate metadata for large files by parsing head+tail bytes only.
+
+    Frame count is estimated from file size divided by average sampled line length.
+    unique_ids reflects only the sampled head and tail regions, not the full file.
+    scan_mode is "estimated" to signal that counts are approximations.
+    """
+    file_size = path.stat().st_size
+
+    with path.open("rb") as fh:
+        head_bytes = fh.read(FAST_SCAN_HEAD_BYTES)
+        tail_offset = max(0, file_size - FAST_SCAN_TAIL_BYTES)
+        fh.seek(tail_offset)
+        tail_bytes = fh.read()
+
+    head_lines = [line.strip() for line in head_bytes.decode("utf-8", errors="replace").splitlines() if line.strip()]
+    tail_lines = [line.strip() for line in tail_bytes.decode("utf-8", errors="replace").splitlines() if line.strip()]
+
+    first_timestamp: float | None = None
+    interfaces: set[str] = set()
+    arbitration_ids: set[int] = set()
+    total_head_bytes = 0
+    valid_head_count = 0
+
+    for line in head_lines:
+        try:
+            frame = parse_candump_line(line, path=path, line_number=0)
+        except TransportError:
+            continue
+        if first_timestamp is None:
+            first_timestamp = frame.timestamp
+        interfaces.add(frame.interface or "unknown")
+        arbitration_ids.add(frame.arbitration_id)
+        total_head_bytes += len(line.encode("utf-8")) + 1
+        valid_head_count += 1
+
+    if first_timestamp is None:
+        return _full_capture_metadata(path)
+
+    avg_line_bytes = total_head_bytes / valid_head_count
+    estimated_frame_count = max(1, int(file_size / avg_line_bytes))
+
+    last_timestamp: float | None = None
+    for line in reversed(tail_lines):
+        try:
+            frame = parse_candump_line(line, path=path, line_number=0)
+        except TransportError:
+            continue
+        last_timestamp = frame.timestamp
+        interfaces.add(frame.interface or "unknown")
+        arbitration_ids.add(frame.arbitration_id)
+        break
+
+    if last_timestamp is None:
+        last_timestamp = first_timestamp
+
+    duration_seconds = max(0.0, last_timestamp - first_timestamp)
+    suggested_max_frames, suggested_seconds = _capture_info_suggestions(estimated_frame_count, duration_seconds)
+
+    return CaptureMetadata(
+        frame_count=estimated_frame_count,
+        duration_seconds=duration_seconds,
+        unique_ids=len(arbitration_ids),
+        interfaces=sorted(interfaces),
+        first_timestamp=first_timestamp,
+        last_timestamp=last_timestamp,
+        suggested_max_frames=suggested_max_frames,
+        suggested_seconds=suggested_seconds,
+        scan_mode="estimated",
+    )
+
+
+def _full_capture_metadata(path: Path) -> CaptureMetadata:
     first_timestamp: float | None = None
     last_timestamp: float | None = None
     interfaces: set[str] = set()
@@ -1015,6 +1092,12 @@ def capture_metadata(path: Path) -> CaptureMetadata:
         suggested_max_frames=suggested_max_frames,
         suggested_seconds=suggested_seconds,
     )
+
+
+def capture_metadata(path: Path) -> CaptureMetadata:
+    if path.stat().st_size >= FAST_SCAN_THRESHOLD_BYTES:
+        return _fast_capture_metadata(path)
+    return _full_capture_metadata(path)
 
 
 def parse_candump_line(line: str, *, path: Path, line_number: int) -> CanFrame:

--- a/src/canarchy/transport.py
+++ b/src/canarchy/transport.py
@@ -1023,10 +1023,10 @@ def _fast_capture_metadata(path: Path) -> CaptureMetadata:
             frame = parse_candump_line(line, path=path, line_number=0)
         except TransportError:
             continue
-        last_timestamp = frame.timestamp
+        if last_timestamp is None:
+            last_timestamp = frame.timestamp
         interfaces.add(frame.interface or "unknown")
         arbitration_ids.add(frame.arbitration_id)
-        break
 
     if last_timestamp is None:
         last_timestamp = first_timestamp

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -562,6 +562,16 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["data"]["duration_seconds"], 0.2)
         self.assertEqual(payload["data"]["suggested_max_frames"], 3)
         self.assertEqual(payload["data"]["suggested_seconds"], 0.2)
+        self.assertEqual(payload["data"]["scan_mode"], "full")
+
+    def test_capture_info_large_file_reports_estimated_scan_mode(self) -> None:
+        with patch("canarchy.transport.FAST_SCAN_THRESHOLD_BYTES", 1):
+            exit_code, stdout, stderr = run_cli(
+                "capture-info", "--file", str(FIXTURES / "sample.candump"), "--json"
+            )
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["data"]["scan_mode"], "estimated")
 
     def test_capture_info_invalid_capture_returns_structured_error(self) -> None:
         exit_code, stdout, stderr = run_cli(
@@ -693,6 +703,53 @@ class CliTests(unittest.TestCase):
         self.assertIn("printable_identifiers:", stdout)
         self.assertIn("text=VIN1234", stdout)
 
+    def test_j1939_summary_large_file_emits_auto_cap_warning(self) -> None:
+        with patch("canarchy.cli.LARGE_FILE_AUTO_CAP_BYTES", 1):
+            exit_code, stdout, _ = run_cli(
+                "j1939", "summary", "--file", str(FIXTURES / "j1939_heavy_vehicle.candump"), "--json"
+            )
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertTrue(any("Large file" in w for w in payload["warnings"]))
+        self.assertTrue(any("500,000" in w for w in payload["warnings"]))
+
+    def test_j1939_summary_explicit_max_frames_suppresses_auto_cap_warning(self) -> None:
+        with patch("canarchy.cli.LARGE_FILE_AUTO_CAP_BYTES", 1):
+            exit_code, stdout, _ = run_cli(
+                "j1939", "summary", "--file", str(FIXTURES / "j1939_heavy_vehicle.candump"),
+                "--max-frames", "100", "--json"
+            )
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertFalse(any("Large file" in w for w in payload["warnings"]))
+
+    def test_j1939_dm1_large_file_emits_auto_cap_warning(self) -> None:
+        with patch("canarchy.cli.LARGE_FILE_AUTO_CAP_BYTES", 1):
+            exit_code, stdout, _ = run_cli(
+                "j1939", "dm1", "--file", str(FIXTURES / "j1939_dm1_spn175.candump"), "--json"
+            )
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertTrue(any("Large file" in w for w in payload["warnings"]))
+
+    def test_j1939_faults_large_file_emits_auto_cap_warning(self) -> None:
+        with patch("canarchy.cli.LARGE_FILE_AUTO_CAP_BYTES", 1):
+            exit_code, stdout, _ = run_cli(
+                "j1939", "faults", "--file", str(FIXTURES / "j1939_dm1_spn175.candump"), "--json"
+            )
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertTrue(any("Large file" in w for w in payload["warnings"]))
+
+    def test_j1939_inventory_large_file_emits_auto_cap_warning(self) -> None:
+        with patch("canarchy.cli.LARGE_FILE_AUTO_CAP_BYTES", 1):
+            exit_code, stdout, _ = run_cli(
+                "j1939", "inventory", "--file", str(FIXTURES / "j1939_inventory.candump"), "--json"
+            )
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertTrue(any("Large file" in w for w in payload["warnings"]))
+
     def test_j1939_inventory_json_builds_source_address_inventory(self) -> None:
         exit_code, stdout, stderr = run_cli(
             "j1939",
@@ -795,6 +852,18 @@ class CliTests(unittest.TestCase):
         vehicle_values = {entry["file"]: entry["values"] for entry in vehicle_difference["captures"]}
         self.assertEqual(vehicle_values[str(FIXTURES / "j1939_inventory.candump")], ["VIN1234"])
         self.assertEqual(vehicle_values[str(FIXTURES / "j1939_compare_shifted.candump")], ["VIN5678"])
+
+    def test_j1939_compare_large_file_emits_auto_cap_warning(self) -> None:
+        with patch("canarchy.cli.LARGE_FILE_AUTO_CAP_BYTES", 1):
+            exit_code, stdout, _ = run_cli(
+                "j1939", "compare",
+                str(FIXTURES / "j1939_inventory.candump"),
+                str(FIXTURES / "j1939_compare_shifted.candump"),
+                "--json",
+            )
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertTrue(any("Large file" in w for w in payload["warnings"]))
 
     def test_j1939_compare_table_output_is_pretty_printed(self) -> None:
         exit_code, stdout, stderr = run_cli(

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -13,12 +13,15 @@ from unittest.mock import patch
 
 from canarchy.models import CanFrame, UdsTransactionEvent
 from canarchy.transport import (
+    FAST_SCAN_THRESHOLD_BYTES,
     LocalTransport,
     PythonCanBackend,
     ScaffoldCanBackend,
     TransportBackendConfig,
     TransportError,
+    _fast_capture_metadata,
     build_live_backend,
+    capture_metadata,
     iter_candump_file,
     load_candump_file,
     parse_candump_line,
@@ -636,6 +639,53 @@ class TransportBackendTests(unittest.TestCase):
         self.assertEqual(frames[0].arbitration_id, 0x123)
         self.assertEqual(frames[0].data, bytes.fromhex("11223344"))
         self.assertEqual(frames[0].interface, interface)
+
+
+class CaptureMetadataTests(unittest.TestCase):
+    def test_full_scan_returns_exact_counts(self) -> None:
+        meta = capture_metadata(FIXTURES / "sample.candump")
+        self.assertEqual(meta.scan_mode, "full")
+        self.assertEqual(meta.frame_count, 3)
+        self.assertEqual(meta.unique_ids, 3)
+        self.assertEqual(meta.interfaces, ["can0", "can1"])
+        self.assertAlmostEqual(meta.first_timestamp, 0.0)
+        self.assertAlmostEqual(meta.last_timestamp, 0.2)
+        self.assertAlmostEqual(meta.duration_seconds, 0.2)
+
+    def test_fast_scan_returns_estimated_mode(self) -> None:
+        meta = _fast_capture_metadata(FIXTURES / "sample.candump")
+        self.assertEqual(meta.scan_mode, "estimated")
+        self.assertAlmostEqual(meta.first_timestamp, 0.0)
+        self.assertAlmostEqual(meta.last_timestamp, 0.2)
+        self.assertAlmostEqual(meta.duration_seconds, 0.2)
+        self.assertGreater(meta.frame_count, 0)
+        self.assertGreater(meta.unique_ids, 0)
+        self.assertIn("can0", meta.interfaces)
+
+    def test_fast_scan_includes_interfaces_from_head_and_tail(self) -> None:
+        meta = _fast_capture_metadata(FIXTURES / "sample.candump")
+        self.assertIn("can1", meta.interfaces)
+
+    def test_capture_metadata_dispatches_to_fast_path_for_large_files(self) -> None:
+        with patch("canarchy.transport.FAST_SCAN_THRESHOLD_BYTES", 1):
+            meta = capture_metadata(FIXTURES / "sample.candump")
+        self.assertEqual(meta.scan_mode, "estimated")
+
+    def test_capture_metadata_uses_full_path_for_small_files(self) -> None:
+        with patch("canarchy.transport.FAST_SCAN_THRESHOLD_BYTES", 10 * 1024 * 1024):
+            meta = capture_metadata(FIXTURES / "sample.candump")
+        self.assertEqual(meta.scan_mode, "full")
+
+    def test_to_payload_includes_scan_mode(self) -> None:
+        meta = capture_metadata(FIXTURES / "sample.candump")
+        payload = meta.to_payload()
+        self.assertIn("scan_mode", payload)
+        self.assertEqual(payload["scan_mode"], "full")
+
+    def test_fast_scan_to_payload_includes_estimated_scan_mode(self) -> None:
+        meta = _fast_capture_metadata(FIXTURES / "sample.candump")
+        payload = meta.to_payload()
+        self.assertEqual(payload["scan_mode"], "estimated")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- capture-info: dispatch to fast head+tail scan for files > 50 MB; frame
  count estimated from file size / average line length; scan_mode field
  added to CaptureMetadata.to_payload() as "full" or "estimated"
- j1939 summary/dm1/faults/inventory/compare: auto-cap at 500,000 frames
  when file > 50 MB and no --max-frames/--seconds limit given; warning
  included in response directing operator to override with explicit flag
- 13 new tests: 7 transport-level (CaptureMetadataTests), 6 CLI-level
  (large-file dispatch and auto-cap for all 5 j1939 commands)
- Updated design specs (REQ-TRANSPORT-12, REQ-J1939WIN-07) and test
  specs (TEST-TRANSPORT-15/16, TEST-J1939WIN-08–13)

Closes #163

https://claude.ai/code/session_01LFgj8SPHT9FqA5N8A5wtz7