### PR TITLE
fix(mcp): align j1939_tp argv with tp sessions refs #203

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * Clarified the agent workflow policy so non-trivial work is expected to happen on dedicated branches and be delivered through pull requests by default rather than direct pushes to `main`.
 * Added dedicated current-state design and test specs for `j1939 monitor` and `config show`, and aligned the surrounding J1939 spec language with the current `j1939 tp sessions` command surface.
 
+### Fixed
+
+* Fixed the MCP `j1939_tp` tool to invoke the current `j1939 tp sessions --file <file>` CLI surface instead of the older bare `j1939 tp <file>` form, and tightened MCP argv coverage around that mapping.
+
 ### Added
 
 * Added `canarchy j1939 compare` for multi-capture comparison of J1939 PGNs, source addresses, DM1 fault changes, and printable TP identification payloads across two or more recorded captures.

--- a/src/canarchy/mcp_server.py
+++ b/src/canarchy/mcp_server.py
@@ -642,7 +642,7 @@ def _build_argv(tool_name: str, arguments: dict[str, Any]) -> list[str]:
                 argv += ["--seconds", str(a["seconds"])]
             return argv + ["--json"]
         case "j1939_tp":
-            argv = ["j1939", "tp", a["file"]]
+            argv = ["j1939", "tp", "sessions", "--file", a["file"]]
             if a.get("offset") is not None and a["offset"] > 0:
                 argv += ["--offset", str(a["offset"])]
             if a.get("max_frames") is not None:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -285,8 +285,12 @@ def test_build_argv_j1939_spn_seconds():
 
 def test_build_argv_j1939_tp_max_frames():
     argv = _build_argv("j1939_tp", {"file": "big.log", "max_frames": 500})
-    assert "--max-frames" in argv
-    assert "500" in argv
+    assert argv == ["j1939", "tp", "sessions", "--file", "big.log", "--max-frames", "500", "--json"]
+
+
+def test_build_argv_j1939_tp_seconds_and_offset():
+    argv = _build_argv("j1939_tp", {"file": "big.log", "offset": 12, "seconds": 10.0})
+    assert argv == ["j1939", "tp", "sessions", "--file", "big.log", "--offset", "12", "--seconds", "10.0", "--json"]
 
 
 def test_build_argv_j1939_dm1_max_frames():


### PR DESCRIPTION
## Summary
- fix the MCP `j1939_tp` tool to invoke `canarchy j1939 tp sessions --file <file>`
- tighten MCP argv tests so they assert the exact tp-sessions command shape
- add an `[Unreleased]` changelog entry for the fix

## Verification
- `uv run pytest tests/test_mcp.py -k "j1939_tp or j1939_tool_schemas_have_frame_limit_params"`

## Issue
- refs #203
