### PR TITLE
docs(skills): define manifest schema refs #168

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 * Clarified the agent workflow policy so non-trivial work is expected to happen on dedicated branches and be delivered through pull requests by default rather than direct pushes to `main`.
 * Added dedicated current-state design and test specs for `j1939 monitor` and `config show`, and aligned the surrounding J1939 spec language with the current `j1939 tp sessions` command surface.
+* Defined the first version of the CANarchy skill manifest schema, added matching test-spec coverage, and added canonical example manifests so future skills provider and MCP work can build against a stable contract.
 
 ### Fixed
 

--- a/docs/design/skill-manifest-schema.md
+++ b/docs/design/skill-manifest-schema.md
@@ -1,0 +1,222 @@
+# Design Spec: Skill Manifest Schema
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| Status | Implemented |
+| Command surface | none yet; repository-backed skill manifest contract |
+| Primary area | agent integration, MCP, documentation |
+| Related specs | `docs/design/mcp-server.md`, `docs/design/dbc-provider-workflows.md`, `docs/design/plugin-model.md` |
+
+## Goal
+
+Define a stable, versioned manifest schema for CANarchy skills so repository-backed skill providers, future cache workflows, and future MCP or agent integration all build against one inspectable contract instead of repository-specific conventions.
+
+## User-Facing Motivation
+
+Operators and agents need skills to be discoverable and reproducible. A provider should be able to answer basic questions without fetching arbitrary content: what the skill is called, which provider published it, what revision it came from, what files form the skill body, what domains it applies to, and what context or tools it expects.
+
+## Requirements
+
+| ID | Type | Requirement |
+|----|------|-------------|
+| `REQ-SKILLMAN-01` | Ubiquitous | The system shall define a versioned manifest schema for CANarchy skills. |
+| `REQ-SKILLMAN-02` | Ubiquitous | The manifest schema shall distinguish identity fields, provenance fields, and content-entry fields. |
+| `REQ-SKILLMAN-03` | Ubiquitous | Each manifest shall identify one skill with a stable provider-facing reference composed from provider identity and skill name. |
+| `REQ-SKILLMAN-04` | Ubiquitous | Each manifest shall describe at minimum the skill name, summary, content entry file, domain tags, compatibility metadata, and provenance metadata needed for repository-backed provider workflows. |
+| `REQ-SKILLMAN-05` | Optional feature | Where optional metadata is included, the manifest schema shall allow examples, dependencies, supported capture types, required tools, and deprecation metadata without changing the meaning of the required core fields. |
+| `REQ-SKILLMAN-06` | Unwanted behaviour | If a manifest omits required identity, provenance, compatibility, or content-entry fields, the future validation path shall reject it as invalid rather than guessing missing metadata. |
+| `REQ-SKILLMAN-07` | Ubiquitous | The schema shall be suitable for repository-backed providers, catalog search, fetch/cache provenance reporting, and future MCP or agent discovery workflows without exposing provider-specific runtime objects. |
+| `REQ-SKILLMAN-08` | State-driven | While only schema documentation exists and no runtime validator has landed yet, the project shall provide canonical example manifests that future provider and validation work can test against. |
+
+## Command Surface
+
+```text
+No direct CLI command is introduced in this phase.
+This schema is a contract for future `skills` provider/catalog/fetch/cache workflows.
+```
+
+## Responsibilities And Boundaries
+
+In scope:
+
+* a versioned manifest format for one skill per manifest
+* required versus optional field definitions
+* a clear split between identity, provenance, compatibility, and content-entry metadata
+* example manifests suitable for future provider and validation tests
+
+Out of scope:
+
+* provider transport, cloning, fetch, or cache implementation
+* runtime skill execution or MCP tool exposure
+* repository authentication or trust policy
+* plugin execution semantics outside the skill metadata contract
+
+## Data Model
+
+The canonical manifest format for phase 1 is YAML.
+
+### Top-level fields
+
+Required fields:
+
+* `schema_version`
+* `skill`
+* `provider`
+* `provenance`
+* `compatibility`
+* `entry`
+
+Optional fields:
+
+* `inputs`
+* `outputs`
+* `examples`
+* `dependencies`
+* `required_tools`
+* `supported_capture_types`
+* `deprecation`
+* `metadata`
+
+### Identity fields
+
+The `skill` object defines what the skill is independent of where it was fetched from.
+
+Required identity fields:
+
+* `skill.name`
+* `skill.summary`
+* `skill.description`
+* `skill.tags`
+
+Optional identity fields:
+
+* `skill.domains`
+* `skill.capabilities`
+
+### Provider fields
+
+The `provider` object identifies the source namespace expected to publish the skill.
+
+Required provider fields:
+
+* `provider.name`
+* `provider.kind`
+
+Phase-1 allowed provider kinds:
+
+* `repository`
+
+### Provenance fields
+
+The `provenance` object answers where this specific manifest revision came from.
+
+Required provenance fields:
+
+* `provenance.source_ref`
+* `provenance.revision`
+* `provenance.manifest_path`
+
+Optional provenance fields:
+
+* `provenance.version`
+* `provenance.published_at`
+* `provenance.sha256`
+
+### Compatibility fields
+
+The `compatibility` object describes whether a future CANarchy runtime or agent client should consider the skill usable.
+
+Required compatibility fields:
+
+* `compatibility.canarchy`
+
+Optional compatibility fields:
+
+* `compatibility.mcp`
+* `compatibility.platforms`
+* `compatibility.python`
+
+### Content-entry fields
+
+The `entry` object identifies the local content file that represents the skill body.
+
+Required content-entry fields:
+
+* `entry.path`
+* `entry.format`
+
+Phase-1 allowed entry formats:
+
+* `markdown`
+
+### Inputs and outputs
+
+The schema supports summary-level workflow expectations without encoding a full executable interface.
+
+Suggested input/output fields:
+
+* `inputs.requires_context`
+* `inputs.accepted_artifacts`
+* `outputs.expected_artifacts`
+* `outputs.response_style`
+
+## Output Contracts
+
+No CLI output mode is introduced in this phase. Future provider and cache commands shall surface manifest-derived metadata through the standard CANarchy result envelope.
+
+## Error Contracts
+
+No runtime error codes are implemented in this phase. The future validation path should reserve structured errors for invalid manifests rather than silently tolerating missing required fields.
+
+Suggested future validation codes:
+
+| Code | Trigger | Exit code |
+|------|---------|-----------|
+| `SKILL_MANIFEST_INVALID` | required manifest fields are missing or malformed | 3 |
+| `SKILL_SCHEMA_UNSUPPORTED` | manifest `schema_version` is unsupported | 3 |
+| `SKILL_ENTRY_UNSUPPORTED` | manifest `entry.format` is unsupported | 3 |
+
+## Example Manifest
+
+```yaml
+schema_version: "canarchy.skill.v1"
+skill:
+  name: "j1939_compare_triage"
+  summary: "Compare multiple J1939 captures for PGN, source-address, and fault drift."
+  description: "Guides an analyst through multi-capture J1939 triage using the canonical compare workflow."
+  tags: ["j1939", "triage", "heavy-vehicle"]
+  domains: ["j1939", "reverse-engineering"]
+  capabilities: ["file-analysis", "comparison"]
+provider:
+  name: "canarchy-labs"
+  kind: "repository"
+provenance:
+  source_ref: "github:hexsecs/canarchy-skills"
+  revision: "4f2a9c1"
+  manifest_path: "skills/j1939_compare_triage/skill.yaml"
+  version: "0.1.0"
+compatibility:
+  canarchy: ">=0.5.0"
+  mcp: false
+entry:
+  path: "skills/j1939_compare_triage/SKILL.md"
+  format: "markdown"
+inputs:
+  requires_context: ["capture_files"]
+  accepted_artifacts: ["candump"]
+outputs:
+  expected_artifacts: ["triage_summary"]
+  response_style: "structured_markdown"
+required_tools: ["j1939_compare", "j1939_summary"]
+examples:
+  - prompt: "Compare two captures from before and after engine start."
+```
+
+## Deferred Decisions
+
+* whether multiple entry files should be supported in one manifest
+* whether provider kinds beyond `repository` should be standardized in v1
+* whether compatibility metadata should include model-family or agent-family targeting
+* whether a future JSON Schema artifact should be generated mechanically from this document or maintained separately

--- a/docs/tests/skill-manifest-schema.md
+++ b/docs/tests/skill-manifest-schema.md
@@ -1,0 +1,78 @@
+# Test Spec: Skill Manifest Schema
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| Status | Implemented |
+| Design doc | `docs/design/skill-manifest-schema.md` |
+| Test file | future schema validation tests; current fixtures live under `tests/fixtures/skills/` |
+
+## Requirement Traceability
+
+| REQ ID | Description summary | TEST IDs |
+|--------|--------------------|----------|
+| `REQ-SKILLMAN-01` | Schema is versioned | `TEST-SKILLMAN-01`, `TEST-SKILLMAN-02` |
+| `REQ-SKILLMAN-02` | Identity, provenance, and content-entry fields are distinct | `TEST-SKILLMAN-01` |
+| `REQ-SKILLMAN-03` | Each manifest identifies one skill with provider-facing identity | `TEST-SKILLMAN-01` |
+| `REQ-SKILLMAN-04` | Required core metadata is present | `TEST-SKILLMAN-01`, `TEST-SKILLMAN-02` |
+| `REQ-SKILLMAN-05` | Optional metadata can be present without redefining required fields | `TEST-SKILLMAN-01`, `TEST-SKILLMAN-03` |
+| `REQ-SKILLMAN-06` | Missing required fields will be rejected by future validation | `TEST-SKILLMAN-02` |
+| `REQ-SKILLMAN-07` | Schema is suitable for provider/catalog/cache and future MCP workflows | `TEST-SKILLMAN-01`, `TEST-SKILLMAN-03` |
+| `REQ-SKILLMAN-08` | Canonical example manifests exist while runtime validation is absent | `TEST-SKILLMAN-01`, `TEST-SKILLMAN-03` |
+
+## Test Cases
+
+### TEST-SKILLMAN-01 — Canonical manifest fixture expresses the full core contract
+
+```gherkin
+Given  a canonical example skill manifest fixture exists
+When   the manifest is inspected against the documented schema
+Then   the system shall expose a schema version
+And    the manifest shall include distinct identity, provider, provenance, compatibility, and content-entry sections
+And    optional workflow metadata may also be present without changing the required core fields
+```
+
+**Fixture:** `tests/fixtures/skills/j1939_compare_triage.skill.yaml`.
+
+---
+
+### TEST-SKILLMAN-02 — Invalid manifest fixture demonstrates required-field rejection targets
+
+```gherkin
+Given  an intentionally incomplete skill manifest fixture exists
+When   a future schema validator checks that manifest
+Then   the system shall reject the manifest as invalid
+And    the failure shall be attributable to missing required identity, provenance, compatibility, or content-entry fields rather than inferred defaults
+```
+
+**Fixture:** `tests/fixtures/skills/invalid_missing_entry.skill.yaml`.
+
+---
+
+### TEST-SKILLMAN-03 — Minimal manifest fixture remains provider-friendly
+
+```gherkin
+Given  a minimal valid skill manifest fixture exists
+When   the manifest is inspected against the documented schema
+Then   the system shall expose enough metadata for provider catalog listing and fetch provenance
+And    optional metadata such as examples or dependencies may be absent without invalidating the manifest
+```
+
+**Fixture:** `tests/fixtures/skills/uds_trace_minimal.skill.yaml`.
+
+## Fixtures And Environment
+
+Current fixtures for this issue are documentation and future-validation artifacts only:
+
+* `tests/fixtures/skills/j1939_compare_triage.skill.yaml`
+* `tests/fixtures/skills/uds_trace_minimal.skill.yaml`
+* `tests/fixtures/skills/invalid_missing_entry.skill.yaml`
+
+No runtime validator exists yet in this phase.
+
+## Explicit Non-Coverage
+
+* provider fetch, refresh, and cache behavior, which belong to `#166`
+* MCP or agent execution behavior, which belongs to `#167`
+* runtime YAML parsing or schema enforcement code, which is deferred until provider implementation work lands

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ nav:
           - Expanded J1939 Workflows: design/j1939-expanded-workflows.md
           - J1939 Monitor Command: design/j1939-monitor-command.md
           - Scapy Diagnostic Integration: design/scapy-diagnostic-integration.md
+          - Skill Manifest Schema: design/skill-manifest-schema.md
           - Composition: design/composition.md
           - MCP Server: design/mcp-server.md
           - Reverse-Engineering Helpers: design/reverse-engineering-helpers.md
@@ -119,6 +120,7 @@ nav:
           - Expanded J1939 Workflows: tests/j1939-expanded-workflows.md
           - J1939 Monitor Command: tests/j1939-monitor-command.md
           - Scapy Diagnostic Integration: tests/scapy-diagnostic-integration.md
+          - Skill Manifest Schema: tests/skill-manifest-schema.md
           - MCP Server: tests/mcp-server.md
           - Reverse-Engineering Helpers: tests/reverse-engineering-helpers.md
           - Replay Command: tests/replay-command.md

--- a/tests/fixtures/skills/invalid_missing_entry.skill.yaml
+++ b/tests/fixtures/skills/invalid_missing_entry.skill.yaml
@@ -1,0 +1,15 @@
+schema_version: "canarchy.skill.v1"
+skill:
+  name: "invalid_skill"
+  summary: "Intentionally incomplete manifest."
+  description: "Fixture used to document future validation failures."
+  tags: ["invalid"]
+provider:
+  name: "canarchy-labs"
+  kind: "repository"
+provenance:
+  source_ref: "github:hexsecs/canarchy-skills"
+  revision: "deadbee"
+  manifest_path: "skills/invalid_skill/skill.yaml"
+compatibility:
+  canarchy: ">=0.5.0"

--- a/tests/fixtures/skills/j1939_compare_triage.skill.yaml
+++ b/tests/fixtures/skills/j1939_compare_triage.skill.yaml
@@ -1,0 +1,31 @@
+schema_version: "canarchy.skill.v1"
+skill:
+  name: "j1939_compare_triage"
+  summary: "Compare multiple J1939 captures for PGN, source-address, and fault drift."
+  description: "Guides an analyst through multi-capture J1939 triage using the canonical compare workflow."
+  tags: ["j1939", "triage", "heavy-vehicle"]
+  domains: ["j1939", "reverse-engineering"]
+  capabilities: ["file-analysis", "comparison"]
+provider:
+  name: "canarchy-labs"
+  kind: "repository"
+provenance:
+  source_ref: "github:hexsecs/canarchy-skills"
+  revision: "4f2a9c1"
+  manifest_path: "skills/j1939_compare_triage/skill.yaml"
+  version: "0.1.0"
+compatibility:
+  canarchy: ">=0.5.0"
+  mcp: false
+entry:
+  path: "skills/j1939_compare_triage/SKILL.md"
+  format: "markdown"
+inputs:
+  requires_context: ["capture_files"]
+  accepted_artifacts: ["candump"]
+outputs:
+  expected_artifacts: ["triage_summary"]
+  response_style: "structured_markdown"
+required_tools: ["j1939_compare", "j1939_summary"]
+examples:
+  - prompt: "Compare two captures from before and after engine start."

--- a/tests/fixtures/skills/uds_trace_minimal.skill.yaml
+++ b/tests/fixtures/skills/uds_trace_minimal.skill.yaml
@@ -1,0 +1,18 @@
+schema_version: "canarchy.skill.v1"
+skill:
+  name: "uds_trace_summary"
+  summary: "Summarize traced UDS request and response exchanges."
+  description: "Provides a compact interpretation layer for the canonical UDS trace workflow."
+  tags: ["uds", "diagnostics"]
+provider:
+  name: "canarchy-labs"
+  kind: "repository"
+provenance:
+  source_ref: "github:hexsecs/canarchy-skills"
+  revision: "aa83d11"
+  manifest_path: "skills/uds_trace_summary/skill.yaml"
+compatibility:
+  canarchy: ">=0.5.0"
+entry:
+  path: "skills/uds_trace_summary/SKILL.md"
+  format: "markdown"


### PR DESCRIPTION
## Summary
- add a versioned CANarchy skill manifest schema design spec
- add a matching test spec for future validation and traceability
- add canonical example manifests for rich, minimal, and intentionally invalid cases
- update docs nav and the `[Unreleased]` changelog entry

## Verification
- `uv run --group docs mkdocs build --strict`

## Notes
- this issue intentionally stays schema-only; provider transport/fetch/cache work remains for #166 and MCP/agent integration remains for #167

## Issue
- refs #168
