### PR TITLE
Define skills agent and MCP integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Documentation
 
+* Defined the phase-1 agent and MCP integration model for CANarchy skills, including the decision to keep skills CLI-discovered and out of the MCP tool/resource/prompt surface while documenting how agents should select, fetch, and reference skill provenance.
 * Clarified the agent workflow policy so non-trivial work is expected to happen on dedicated branches and be delivered through pull requests by default rather than direct pushes to `main`.
 * Added dedicated current-state design and test specs for `j1939 monitor` and `config show`, and aligned the surrounding J1939 spec language with the current `j1939 tp sessions` command surface.
 * Defined the first version of the CANarchy skill manifest schema, added matching test-spec coverage, and added canonical example manifests so future skills provider and MCP work can build against a stable contract.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -70,6 +70,7 @@ The current MCP surface exposes a curated non-interactive subset of the CLI. Spa
 | `j1939_spn` | `canarchy j1939 spn` |
 | `j1939_tp` | `canarchy j1939 tp sessions` |
 | `j1939_dm1` | `canarchy j1939 dm1` |
+| `j1939_summary` | `canarchy j1939 summary` |
 | `j1939_inventory` | `canarchy j1939 inventory` |
 | `uds_scan` | `canarchy uds scan` |
 | `uds_trace` | `canarchy uds trace` |
@@ -83,6 +84,30 @@ Current exclusions:
 * CLI-only workflows such as `j1939 compare` that are not yet exposed as MCP tools
 * reverse-engineering helpers such as `re signals`, `re counters`, `re entropy`, `re match-dbc`, and `re shortlist-dbc`
 * interactive or service commands such as `shell`, `tui`, and `mcp serve`
+
+### Skills Workflow
+
+CANarchy skills are phase-1 workflow descriptors, not MCP tools. Agents should discover and fetch skills through the CLI provider workflow, inspect the cached manifest and entry file, then run the referenced CANarchy commands explicitly through either the CLI or the MCP tools that already exist.
+
+Recommended flow:
+
+1. Run `canarchy skills search <domain-or-task> --json`.
+2. Select a provider-qualified reference such as `github:j1939_compare_triage`.
+3. Run `canarchy skills fetch <provider>:<skill> --json`.
+4. Read `local_manifest_path` and `local_entry_path` from the fetch result.
+5. Check `compatibility`, `required_tools`, `inputs`, `outputs`, `skill.tags`, and `skill.domains` before applying the workflow.
+6. Run required CANarchy commands explicitly and record the selected skill reference plus provenance in the final analysis.
+
+Example:
+
+```bash
+canarchy skills search j1939 --provider github --json
+canarchy skills fetch github:j1939_compare_triage --json
+canarchy j1939 summary --file baseline.candump --json
+canarchy j1939 compare --file baseline.candump --file after-start.candump --json
+```
+
+If MCP is available, agents may use MCP for commands that are already exposed as tools, such as `j1939_summary`. The skill itself is still selected and fetched through the CLI in phase 1, and `compatibility.mcp=false` means the agent should not assume MCP invocation is supported for the skill workflow.
 
 ### Response Format
 

--- a/docs/command_spec.md
+++ b/docs/command_spec.md
@@ -424,7 +424,8 @@ Notes:
 
 * the first provider implementation is GitHub-backed and consumes `.skill.yaml` manifests that follow the CANarchy skill manifest schema
 * `skills fetch` returns both the cached manifest path and the cached skill entry path
-* skills provider/cache commands are currently CLI-only and are not yet exposed as MCP tools
+* skills provider/cache commands are currently CLI-only and are not exposed as MCP tools, resources, or prompts in phase 1
+* agents should use skills as workflow descriptors: search, fetch, inspect compatibility/provenance, then run referenced CANarchy commands explicitly
 
 ### session save
 

--- a/docs/design/mcp-server.md
+++ b/docs/design/mcp-server.md
@@ -41,7 +41,7 @@ canarchy mcp serve
 
 The `serve` subcommand accepts no positional arguments or output flags. The server runs until the stdio transport closes (client disconnect or EOF).
 
-The current MCP tool surface is a curated non-interactive subset of the CLI. It intentionally excludes interactive commands and some newer command families that do not yet have MCP adapters.
+The current MCP tool surface is a curated non-interactive subset of the CLI. It intentionally excludes interactive commands and some newer command families that do not yet have MCP adapters. Skills are not exposed as MCP tools, resources, or prompts in phase 1; agents discover and fetch skills through the CLI provider workflow before optionally using MCP for individual referenced commands that are already exposed.
 
 ## Tool Naming Convention
 
@@ -128,3 +128,4 @@ Out of scope:
 * authentication or access control
 * plugin or custom tool registration
 * exposing every implemented CLI command automatically
+* exposing CANarchy skills as MCP tools, resources, prompts, or a separate MCP discovery surface in phase 1

--- a/docs/design/skills-agent-mcp-integration.md
+++ b/docs/design/skills-agent-mcp-integration.md
@@ -1,0 +1,169 @@
+# Design Spec: Skills Agent MCP Integration
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| Status | Planned |
+| Command surface | `canarchy skills provider list`, `skills search`, `skills fetch`, `skills cache list`, `skills cache refresh`; `canarchy mcp serve` |
+| Primary area | agent integration, MCP, skills provider |
+| Related specs | `docs/design/skill-manifest-schema.md`, `docs/design/skills-provider-workflows.md`, `docs/design/mcp-server.md` |
+
+## Goal
+
+Define the first-phase integration model between CANarchy skills, agent workflows, and the MCP surface so agents can discover and reference repository-backed skills consistently without treating skills as executable MCP tools yet.
+
+## User-Facing Motivation
+
+Operators and agents need a repeatable way to select the right CANarchy skill for a capture or protocol task. The first integration phase should make skill identity, provenance, compatibility, required context, and expected outputs inspectable while preserving the CLI as the contract and avoiding premature runtime skill execution semantics.
+
+## Requirements
+
+| ID | Type | Requirement |
+|----|------|-------------|
+| `REQ-SKILLAGENT-01` | Ubiquitous | The system shall treat CANarchy skills as repository-backed workflow descriptors in phase 1 rather than executable MCP tools. |
+| `REQ-SKILLAGENT-02` | Ubiquitous | The system shall keep skill discovery, fetch, and cache operations on the CLI surface in phase 1. |
+| `REQ-SKILLAGENT-03` | Ubiquitous | The system shall communicate skill identity using the provider-qualified reference `<provider>:<skill>`. |
+| `REQ-SKILLAGENT-04` | Ubiquitous | The system shall communicate skill provenance using manifest-derived provider, source reference, revision, version, manifest path, and local cache paths where available. |
+| `REQ-SKILLAGENT-05` | Ubiquitous | The system shall communicate skill compatibility using manifest-derived CANarchy version constraints, MCP compatibility flags, required tools, accepted artifacts, and domain tags where available. |
+| `REQ-SKILLAGENT-06` | Event-driven | When an agent needs to select a skill, the agent workflow shall search skills by protocol domain, fetch the selected provider-qualified skill, inspect the cached manifest and entry file, and then run the referenced CANarchy CLI or MCP tools explicitly. |
+| `REQ-SKILLAGENT-07` | Event-driven | When a skill manifest sets `compatibility.mcp` to `false`, the agent workflow shall not assume that the skill or its referenced commands are callable as MCP tools. |
+| `REQ-SKILLAGENT-08` | Ubiquitous | The MCP server shall remain a curated command execution surface in phase 1 and shall not expose skills as MCP tools, resources, or prompts. |
+| `REQ-SKILLAGENT-09` | Optional feature | Where an agent can call MCP tools and the fetched skill references MCP-exposed commands, the agent may use those MCP tools after selecting the skill through the CLI provider workflow. |
+| `REQ-SKILLAGENT-10` | Unwanted behaviour | If a skill requires context, tools, or artifact types that are missing from the current analysis task, the agent workflow shall report the incompatibility instead of silently applying the skill. |
+
+## Command Surface
+
+```text
+canarchy skills provider list [--json] [--jsonl] [--table] [--raw]
+canarchy skills search <query> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--table] [--raw]
+canarchy skills fetch <provider>:<skill> [--json] [--jsonl] [--table] [--raw]
+canarchy skills cache list [--json] [--jsonl] [--table] [--raw]
+canarchy skills cache refresh [--provider <name>] [--json] [--jsonl] [--table] [--raw]
+canarchy mcp serve
+```
+
+No new phase-1 command is introduced. Agents use existing `skills` CLI commands for discovery and existing CLI or MCP command execution surfaces for protocol work.
+
+## Responsibilities And Boundaries
+
+In scope:
+
+* phase-1 agent workflow for discovering, fetching, and referencing skills
+* MCP exposure decision for phase 1
+* skill identity, provenance, compatibility, required context, and output contract fields an agent should inspect
+* an end-to-end example of selecting a skill and running canonical CANarchy commands
+
+Out of scope:
+
+* exposing skills as MCP tools, resources, or prompts
+* runtime skill execution inside CANarchy
+* automatic skill selection by CANarchy
+* trust policy, signature validation, or repository authentication beyond the provider/cache workflow
+* converting skill manifests into plugin registrations
+
+## Data Model
+
+Agents should treat the fetched manifest and provider resolution payload as the integration contract.
+
+### Identity
+
+Skill identity is provider-qualified:
+
+* `provider`
+* `name`
+* `source_ref`
+* provider-qualified reference `<provider>:<skill>`
+
+The provider-qualified reference is the stable handle an agent should record in notes, reports, and reproduced workflows.
+
+### Provenance
+
+Agents should preserve provenance fields in analysis notes and generated reports:
+
+* `provider`
+* `source_ref`
+* `revision`
+* `version`
+* `manifest_path`
+* `local_manifest_path`
+* `local_entry_path`
+
+### Compatibility
+
+Agents should inspect manifest compatibility before applying a skill:
+
+* `compatibility.canarchy`
+* `compatibility.mcp`
+* `compatibility.platforms`
+* `required_tools`
+* `inputs.requires_context`
+* `inputs.accepted_artifacts`
+* `outputs.expected_artifacts`
+* `outputs.response_style`
+* `skill.domains`
+* `skill.tags`
+
+`compatibility.mcp` describes whether the skill was authored with MCP-assisted use in mind. It does not make the skill itself an MCP tool.
+
+## Agent Workflow
+
+Phase-1 agents should follow this sequence:
+
+1. Run `canarchy skills search <domain-or-task> --json` to find candidate skills.
+2. Select a provider-qualified reference from the results, such as `github:j1939_compare_triage`.
+3. Run `canarchy skills fetch <provider>:<skill> --json` to cache the manifest and entry file locally.
+4. Read the cached manifest and entry file paths returned by the fetch result.
+5. Check compatibility, required tools, required context, accepted artifacts, and expected outputs.
+6. Execute the required CANarchy CLI commands or MCP tools explicitly.
+7. Record the provider-qualified skill reference and provenance in the final analysis output.
+
+Example:
+
+```bash
+canarchy skills search j1939 --provider github --json
+canarchy skills fetch github:j1939_compare_triage --json
+canarchy j1939 summary --file baseline.candump --json
+canarchy j1939 compare --file baseline.candump --file after-start.candump --json
+```
+
+If MCP is available and the selected skill references an MCP-exposed command, the agent may use the MCP equivalent for that command. For example, an agent may call `j1939_summary` through MCP for `canarchy j1939 summary`, but it still discovers and fetches the skill through the CLI in phase 1.
+
+## MCP Exposure Decision
+
+MCP exposure is out of scope for skills in phase 1.
+
+The MCP server remains a curated command execution surface. Skills are not exposed as:
+
+* MCP tools
+* MCP resources
+* MCP prompts
+* an MCP-specific discovery surface
+
+This avoids presenting workflow descriptors as executable protocol commands before the project defines skill runtime semantics. Future MCP exposure can be added after skill execution, prompt/resource mapping, trust policy, and compatibility validation are designed.
+
+## Output Contracts
+
+Skills provider commands continue to return the standard CANarchy result envelope for JSON output. Agent workflows should consume the same fields documented by `docs/design/skills-provider-workflows.md` and the manifest schema documented by `docs/design/skill-manifest-schema.md`.
+
+MCP command outputs continue to return one JSON text block containing the canonical command result envelope. Skills do not add a new MCP output shape in phase 1.
+
+## Error Contracts
+
+| Code | Trigger | Exit code |
+|------|---------|-----------|
+| `SKILL_PROVIDER_NOT_FOUND` | requested provider is not registered | 3 |
+| `SKILL_NOT_FOUND` | requested skill name is not present in the selected provider catalog | 3 |
+| `SKILL_CACHE_MISS` | provider-backed resolution is requested with no usable provider manifest or cache snapshot | 3 |
+| `SKILL_MANIFEST_INVALID` | repository-backed manifest is missing required schema fields or resolves outside the cache subtree | 3 |
+| `SKILL_FETCH_FAILED` | a skill manifest or entry file could not be downloaded during fetch | 3 |
+
+Agent-level compatibility failures are not a new CANarchy CLI error code in phase 1. Agents should report those failures in their own response when a fetched manifest does not match the available artifacts, tools, or MCP surface.
+
+## Deferred Decisions
+
+* whether skills should later appear as MCP resources, prompts, tools, or a separate discovery capability
+* whether CANarchy should implement a `skills inspect` command for cached manifests
+* whether CANarchy should implement a `skills run` command with explicit runtime semantics
+* whether skill compatibility should be validated automatically by CANarchy or remain an agent responsibility
+* how signed or trusted skill repositories should be represented

--- a/docs/design/skills-provider-workflows.md
+++ b/docs/design/skills-provider-workflows.md
@@ -58,7 +58,7 @@ In scope:
 Out of scope:
 
 * skill execution semantics
-* MCP tool exposure for skills
+* MCP tool, resource, or prompt exposure for skills
 * interactive skill invocation UX
 * repository authentication and trust policy beyond the current provider config
 
@@ -133,3 +133,4 @@ Skills provider and cache workflows emit the command name on success or the firs
 * whether additional provider implementations beyond GitHub should ship in the first stable series
 * whether cache management should later include prune or eager prefetch commands
 * whether future provider metadata should expose trust or signature information
+* whether a later phase should expose skills through MCP tools, resources, prompts, or a dedicated discovery capability

--- a/docs/tests/skills-agent-mcp-integration.md
+++ b/docs/tests/skills-agent-mcp-integration.md
@@ -1,0 +1,123 @@
+# Test Spec: Skills Agent MCP Integration
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| Status | Planned |
+| Design doc | `docs/design/skills-agent-mcp-integration.md` |
+| Test file | documentation review; existing command coverage in `tests/test_skills_provider.py` and `tests/test_mcp_server.py` |
+
+## Requirement Traceability
+
+| REQ ID | Description summary | TEST IDs |
+|--------|--------------------|----------|
+| `REQ-SKILLAGENT-01` | Skills are phase-1 workflow descriptors, not executable MCP tools | `TEST-SKILLAGENT-01`, `TEST-SKILLAGENT-05` |
+| `REQ-SKILLAGENT-02` | Discovery, fetch, and cache stay on the CLI surface | `TEST-SKILLAGENT-02` |
+| `REQ-SKILLAGENT-03` | Skill identity uses `<provider>:<skill>` refs | `TEST-SKILLAGENT-02`, `TEST-SKILLAGENT-04` |
+| `REQ-SKILLAGENT-04` | Provenance is manifest-derived and preserved | `TEST-SKILLAGENT-03`, `TEST-SKILLAGENT-04` |
+| `REQ-SKILLAGENT-05` | Compatibility fields are visible to agents | `TEST-SKILLAGENT-03` |
+| `REQ-SKILLAGENT-06` | Agent selection flow searches, fetches, inspects, then executes explicit commands | `TEST-SKILLAGENT-04` |
+| `REQ-SKILLAGENT-07` | `compatibility.mcp=false` prevents assuming MCP invocation | `TEST-SKILLAGENT-05` |
+| `REQ-SKILLAGENT-08` | MCP does not expose skills as tools, resources, or prompts in phase 1 | `TEST-SKILLAGENT-01` |
+| `REQ-SKILLAGENT-09` | Agents may use MCP for command execution after CLI skill selection | `TEST-SKILLAGENT-06` |
+| `REQ-SKILLAGENT-10` | Agents report missing context or tools instead of silently applying a skill | `TEST-SKILLAGENT-07` |
+
+## Test Cases
+
+### TEST-SKILLAGENT-01 - MCP surface excludes skills
+
+```gherkin
+Given  the MCP server design and agent guide are current
+When   an agent reviews the phase-1 MCP tool surface
+Then   the system shall document that skills are not exposed as MCP tools, resources, or prompts
+And    the documentation shall preserve `skills search` and `skills fetch` as MCP exclusions
+```
+
+**Fixture:** `docs/design/mcp-server.md`, `docs/agents.md`.
+
+---
+
+### TEST-SKILLAGENT-02 - CLI remains the skills discovery surface
+
+```gherkin
+Given  a repository-backed skills provider is available
+When   the operator runs `canarchy skills search j1939 --json`
+Then   the system shall return candidate skills with provider and name fields
+And    the agent workflow shall use those fields to form `<provider>:<skill>` references
+```
+
+**Fixture:** existing skills provider fixtures under `tests/fixtures/skills/`.
+
+---
+
+### TEST-SKILLAGENT-03 - Fetched skills expose provenance and compatibility
+
+```gherkin
+Given  a selected provider-qualified skill reference exists
+When   the operator runs `canarchy skills fetch <provider>:<skill> --json`
+Then   the system shall return local manifest and entry paths
+And    the cached manifest shall expose provenance and compatibility metadata for agent inspection
+```
+
+**Fixture:** `tests/fixtures/skills/j1939_compare_triage.skill.yaml`.
+
+---
+
+### TEST-SKILLAGENT-04 - Agent workflow records selected skill provenance
+
+```gherkin
+Given  an agent has selected and fetched `github:j1939_compare_triage`
+When   the agent completes a J1939 comparison workflow
+Then   the agent shall record the provider-qualified skill reference in its final analysis
+And    the agent shall include provider, revision, version, and local manifest provenance when available
+```
+
+**Fixture:** `docs/design/skills-agent-mcp-integration.md` example workflow.
+
+---
+
+### TEST-SKILLAGENT-05 - MCP-incompatible skills are not invoked through MCP
+
+```gherkin
+Given  a fetched skill manifest sets `compatibility.mcp` to `false`
+When   an agent applies the skill to an analysis task
+Then   the agent shall not assume the skill is callable through MCP
+And    the agent shall use explicit CLI commands unless individual required commands are known MCP tools
+```
+
+**Fixture:** `tests/fixtures/skills/j1939_compare_triage.skill.yaml`.
+
+---
+
+### TEST-SKILLAGENT-06 - MCP may execute referenced commands after skill selection
+
+```gherkin
+Given  an agent has selected a skill through the CLI provider workflow
+When   the skill references a command exposed by the MCP server
+Then   the agent may call the equivalent MCP tool for that command
+And    the MCP response shall preserve the canonical CANarchy result envelope
+```
+
+**Fixture:** `docs/design/mcp-server.md`, `docs/agents.md`.
+
+---
+
+### TEST-SKILLAGENT-07 - Missing context blocks skill application
+
+```gherkin
+Given  a fetched skill manifest requires capture files as context
+When   the current task does not include a compatible capture artifact
+Then   the agent shall report that the skill cannot be applied
+And    the agent shall not silently continue as though the skill requirements were met
+```
+
+**Fixture:** `tests/fixtures/skills/j1939_compare_triage.skill.yaml`.
+
+## Fixtures And Environment
+
+The integration contract uses the existing skills provider fixtures and MCP documentation. Future automated tests can reuse `tests/test_skills_provider.py` for provider resolution assertions and `tests/test_mcp_server.py` for MCP exclusion assertions.
+
+## Explicit Non-Coverage
+
+Phase 1 does not test runtime skill execution, MCP resources, MCP prompts, automatic skill selection, trust policy, signed repositories, or a `skills run` command because those behaviors are explicitly deferred by the design.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
           - J1939 Monitor Command: design/j1939-monitor-command.md
           - Scapy Diagnostic Integration: design/scapy-diagnostic-integration.md
           - Skill Manifest Schema: design/skill-manifest-schema.md
+          - Skills Agent MCP Integration: design/skills-agent-mcp-integration.md
           - Skills Provider Workflows: design/skills-provider-workflows.md
           - Composition: design/composition.md
           - MCP Server: design/mcp-server.md
@@ -122,6 +123,7 @@ nav:
           - J1939 Monitor Command: tests/j1939-monitor-command.md
           - Scapy Diagnostic Integration: tests/scapy-diagnostic-integration.md
           - Skill Manifest Schema: tests/skill-manifest-schema.md
+          - Skills Agent MCP Integration: tests/skills-agent-mcp-integration.md
           - Skills Provider Workflows: tests/skills-provider-workflows.md
           - MCP Server: tests/mcp-server.md
           - Reverse-Engineering Helpers: tests/reverse-engineering-helpers.md


### PR DESCRIPTION
## Summary
- Define the phase-1 agent/MCP integration model for CANarchy skills.
- Document that skills remain CLI-discovered workflow descriptors and are not MCP tools, resources, or prompts in phase 1.
- Add agent-facing selection/fetch/reference guidance, docs nav entries, and changelog coverage.

## Verification
- `git diff --check`
- `uv run pytest tests/test_skills_provider.py tests/test_mcp.py`
- `uv run pytest`
- `uv run mkdocs build --strict`

Closes #167