### PR TITLE
Audit stale documentation references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Documentation
 
+* Audited current operator, design, and test documentation for stale command-status and command-syntax references, aligning reverse-engineering helper status and file-backed examples with the implemented CLI surface.
 * Defined the phase-1 agent and MCP integration model for CANarchy skills, including the decision to keep skills CLI-discovered and out of the MCP tool/resource/prompt surface while documenting how agents should select, fetch, and reference skill provenance.
 * Clarified the agent workflow policy so non-trivial work is expected to happen on dedicated branches and be delivered through pull requests by default rather than direct pushes to `main`.
 * Added dedicated current-state design and test specs for `j1939 monitor` and `config show`, and aligned the surrounding J1939 spec language with the current `j1939 tp sessions` command surface.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,13 @@ Fully implemented and tested:
 * `gateway` — bridge frames between two interfaces (unidirectional and bidirectional)
 * `replay` — deterministic replay planning from candump files
 * `decode`, `encode` — DBC-backed signal decode and encode
-* `j1939 monitor`, `decode`, `pgn`, `spn`, `tp`, `dm1` — J1939 operator workflows across live, file-backed, and decoded views
+* `j1939 monitor`, `decode`, `pgn`, `spn`, `tp`, `dm1`, `faults`, `summary`, `inventory`, `compare` — J1939 operator workflows across live, file-backed, and decoded views
 * `uds scan`, `trace`, `services` — UDS diagnostic workflows and service catalog, including initial transport-backed scan/trace heuristics
+* `re signals` — file-backed signal-candidate ranking across 4-bit, 8-bit, and 16-bit fields
 * `re counters` — file-backed counter-candidate detection for reverse-engineering workflows
 * `re entropy` — file-backed entropy ranking across arbitration IDs and byte positions
+* `re correlate` — file-backed correlation of candidate fields against timestamped reference series
+* `re match-dbc`, `re shortlist-dbc` — provider-backed DBC candidate ranking against captures
 * `session save`, `load`, `show` — session management
 * `export` — structured artifact export
 * `shell` — interactive REPL and `--command` scripting mode
@@ -42,7 +45,6 @@ Fully implemented and tested:
 
 Present in the CLI surface but not yet fully implemented:
 
-* `re signals`, `re correlate` — reverse-engineering helpers (planned)
 * `fuzz replay`, `fuzz mutate`, `fuzz id` — active fuzzing (planned)
 
 Default transport backend is `python-can`; set `CANARCHY_TRANSPORT_BACKEND=scaffold` for deterministic offline behavior.
@@ -136,12 +138,12 @@ Current implementation:
 # Capture and decode
 canarchy capture can0 --candump
 canarchy capture can0 --jsonl
-canarchy decode trace.candump --dbc vehicle.dbc --jsonl
+canarchy decode --file trace.candump --dbc vehicle.dbc --jsonl
 
 # J1939 heavy vehicle analysis
-canarchy j1939 decode trace.candump --table
+canarchy j1939 decode --file trace.candump --table
 canarchy j1939 spn 110 --file trace.candump --table   # Engine Coolant Temp
-canarchy j1939 dm1 trace.candump --table               # Active fault codes
+canarchy j1939 dm1 --file trace.candump --table        # Active fault codes
 
 # Pipe events into downstream tools
 canarchy j1939 spn 110 --file trace.candump --jsonl \
@@ -150,7 +152,7 @@ canarchy j1939 spn 110 --file trace.candump --jsonl \
 # Active workflows
 canarchy generate can0 --count 10 --gap 50 --id 7DF --jsonl
 canarchy gateway can0 239.0.0.1 --count 100
-canarchy replay trace.candump --rate 2.0 --json
+canarchy replay --file trace.candump --rate 2.0 --json
 ```
 
 Use `--candump` for a human-oriented live view. Use `--jsonl` when feeding output to scripts or agents — every line is a typed event from the [canonical schema](docs/event-schema.md).

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -60,6 +60,12 @@ The current MCP surface exposes a curated non-interactive subset of the CLI. Spa
 | `decode` | `canarchy decode` |
 | `encode` | `canarchy encode` |
 | `dbc_inspect` | `canarchy dbc inspect` |
+| `dbc_provider_list` | `canarchy dbc provider list` |
+| `dbc_search` | `canarchy dbc search` |
+| `dbc_fetch` | `canarchy dbc fetch` |
+| `dbc_cache_list` | `canarchy dbc cache list` |
+| `dbc_cache_prune` | `canarchy dbc cache prune` |
+| `dbc_cache_refresh` | `canarchy dbc cache refresh` |
 | `export` | `canarchy export` |
 | `session_save` | `canarchy session save` |
 | `session_load` | `canarchy session load` |
@@ -76,13 +82,17 @@ The current MCP surface exposes a curated non-interactive subset of the CLI. Spa
 | `uds_trace` | `canarchy uds trace` |
 | `uds_services` | `canarchy uds services` |
 | `config_show` | `canarchy config show` |
+| `re_correlate` | `canarchy re correlate` |
+| `re_counters` | `canarchy re counters` |
+| `re_entropy` | `canarchy re entropy` |
+| `re_match_dbc` | `canarchy re match-dbc` |
+| `re_shortlist_dbc` | `canarchy re shortlist-dbc` |
 
 Current exclusions:
 
-* DBC provider and cache commands such as `dbc search` and `dbc fetch`
 * skills provider and cache commands such as `skills search` and `skills fetch`
 * CLI-only workflows such as `j1939 compare` that are not yet exposed as MCP tools
-* reverse-engineering helpers such as `re signals`, `re counters`, `re entropy`, `re match-dbc`, and `re shortlist-dbc`
+* CLI-only workflows such as `j1939 faults` and `re signals` that are not yet exposed as MCP tools
 * interactive or service commands such as `shell`, `tui`, and `mcp serve`
 
 ### Skills Workflow

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -340,7 +340,7 @@ The architecture is intentionally ahead of some implementations. These are the m
 * live transport coverage is currently limited by the `python-can` integration and configured interfaces
 * some protocol commands still rely on explicit sample/reference data providers instead of true transport-backed execution, although `j1939 monitor`, `uds scan`, and `uds trace` now have initial real backend paths when `python-can` is selected
 * the TUI is still a minimal text-mode shell, not yet the richer pane-driven dashboard described in [TUI plan](tui_plan.md)
-* reverse-engineering now has an initial shared analysis subsystem for heuristic ranking (`re signals`, `re counters`, `re entropy`) and provider-backed schema matching (`re match-dbc`, `re shortlist-dbc`); reference-series correlation remains unimplemented
+* reverse-engineering now has a shared analysis subsystem for heuristic ranking (`re signals`, `re counters`, `re entropy`), reference-series correlation (`re correlate`), and provider-backed schema matching (`re match-dbc`, `re shortlist-dbc`)
 * plugin architecture is planned conceptually but not yet implemented as a stable extension boundary
 
 ## Future Plugin Boundary

--- a/docs/command_spec.md
+++ b/docs/command_spec.md
@@ -14,13 +14,13 @@ Implemented and verified in the current codebase:
 * structured `export` for capture files and saved sessions
 * DBC-backed `decode`, `encode`, and `dbc inspect`
 * DBC provider workflows for `dbc provider list`, `dbc search`, `dbc fetch`, `dbc cache list`, `dbc cache prune`, and `dbc cache refresh`
-* J1939 `monitor`, `decode`, `pgn`, `spn`, `tp`, and `dm1`
+* J1939 `monitor`, `decode`, `pgn`, `spn`, `tp`, `dm1`, `faults`, `summary`, `inventory`, and `compare`
 * session `save`, `load`, and `show`
 * shell one-shot command execution
 * initial text-mode `tui` shell over the shared command layer
 * UDS `scan`, `trace`, and `services`
 * `config show` for effective transport configuration inspection
-* `re counters` and `re entropy` for passive file-backed analysis
+* `re signals`, `re counters`, `re entropy`, and `re correlate` for passive file-backed analysis
 * `re match-dbc` and `re shortlist-dbc` for provider-backed DBC candidate ranking against captures
 * structured JSON and JSONL output
 * explicit error schema and exit codes
@@ -34,7 +34,7 @@ Important current behavior:
 * the default `python-can` interface is `socketcan`; set `interface` in the config file or `CANARCHY_PYTHON_CAN_INTERFACE` to change it
 * DBC-backed commands accept local paths and provider refs such as `opendbc:<name>` or `comma:<name>`
 * `decode`, `encode`, and `dbc inspect` include `data.dbc_source` in structured output so callers can see the provider, logical DBC name, pinned version, and resolved local path
-* placeholder-only commands still return `status: planned` and `implementation: command surface scaffold`
+* placeholder-only commands, currently limited to the `fuzz` family, still return `status: planned` and `implementation: command surface scaffold`
 * some protocol-oriented commands currently use explicit sample/reference providers rather than true transport-backed execution paths
 * specialized table formatting exists for J1939 monitor and decode style output; other `--table` output is generic key/value rendering
 * file-backed analysis commands currently support standard timestamped candump log files with `.candump` and `.log` suffixes
@@ -58,9 +58,9 @@ canarchy <action> <object>
 Examples:
 
 * `canarchy capture can0 --json`
-* `canarchy replay tests/fixtures/sample.candump --rate 2.0 --json`
+* `canarchy replay --file tests/fixtures/sample.candump --rate 2.0 --json`
 * `canarchy j1939 monitor --pgn 65262 --json`
-* `canarchy decode tests/fixtures/sample.candump --dbc tests/fixtures/sample.dbc --json`
+* `canarchy decode --file tests/fixtures/sample.candump --dbc tests/fixtures/sample.dbc --json`
 
 ---
 
@@ -248,19 +248,20 @@ Notes:
 Decode frames from a capture source using a DBC file.
 
 ```bash
-canarchy decode <file> --dbc <file> [--stdin] [--json|--jsonl|--table|--raw]
+canarchy decode --file <file> --dbc <file> [--json|--jsonl|--table|--raw]
+canarchy decode --stdin --dbc <file> [--json|--jsonl|--table|--raw]
 ```
 
 Example:
 
 ```bash
-canarchy decode tests/fixtures/sample.candump --dbc tests/fixtures/sample.dbc --json
+canarchy decode --file tests/fixtures/sample.candump --dbc tests/fixtures/sample.dbc --json
 ```
 
 Notes:
 
 * `--dbc` accepts a local file path or a provider ref such as `opendbc:<name>`
-* `--stdin` reads JSONL `frame` events from standard input instead of a positional capture file
+* `--stdin` reads JSONL `frame` events from standard input instead of a `--file` capture source
 * structured output includes a `dbc_source` object describing the provider-backed or local DBC resolution that was used
 
 ### encode
@@ -485,19 +486,21 @@ Notes:
 Decode a capture source into J1939 PGN observations.
 
 ```bash
-canarchy j1939 decode <file> [--stdin] [--json|--jsonl|--table|--raw]
+canarchy j1939 decode --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--table|--raw]
+canarchy j1939 decode --stdin [--dbc <path|provider-ref>] [--json|--jsonl|--table|--raw]
 ```
 
 Notes:
 
-* `--stdin` reads JSONL `frame` events from standard input instead of a positional capture file
+* `--stdin` reads JSONL `frame` events from standard input instead of a `--file` capture source
+* `--dbc` enriches J1939 results with DBC-backed decoded signal events when available
 
 ### j1939 pgn
 
 Inspect events for a specific PGN from a capture file.
 
 ```bash
-canarchy j1939 pgn <pgn> --file <file> [--json|--jsonl|--table|--raw]
+canarchy j1939 pgn <pgn> --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--table|--raw]
 ```
 
 Example:
@@ -506,16 +509,12 @@ Example:
 canarchy j1939 pgn 65262 --file tests/fixtures/sample.candump --json
 ```
 
-```bash
-canarchy j1939 pgn <id> [--json|--jsonl|--table|--raw]
-```
-
 ### j1939 spn
 
 Inspect a curated SPN decoder over recorded J1939 traffic.
 
 ```bash
-canarchy j1939 spn <spn> --file <file> [--json|--jsonl|--table|--raw]
+canarchy j1939 spn <spn> --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--table|--raw]
 ```
 
 Example:
@@ -526,7 +525,8 @@ canarchy j1939 spn 110 --file tests/fixtures/sample.candump --json
 
 Notes:
 
-* the first implementation supports a curated SPN decoder set rather than a full J1939 database
+* curated metadata is built in for common SPNs
+* `--dbc` can expand coverage for SPNs exposed through DBC signal metadata
 * unsupported SPNs return a structured `J1939_SPN_UNSUPPORTED` error
 
 ### j1939 tp sessions
@@ -539,14 +539,22 @@ canarchy j1939 tp sessions --file <file> [--json|--jsonl|--table|--raw]
 
 Notes:
 
-* the first implementation focuses on BAM-style TP sessions and packet reassembly
+* the implementation handles BAM and RTS/CTS transport sessions with packet reassembly
 
 ### j1939 dm1
 
 Inspect DM1 fault traffic from direct J1939 frames and TP-reassembled payloads.
 
 ```bash
-canarchy j1939 dm1 --file <file> [--json|--jsonl|--table|--raw]
+canarchy j1939 dm1 --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--table|--raw]
+```
+
+### j1939 faults
+
+Summarize active DM1 faults by ECU/source address, including lamp state and suspicious DTC markers.
+
+```bash
+canarchy j1939 faults --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--table|--raw]
 ```
 
 ### j1939 inventory
@@ -676,6 +684,21 @@ Notes:
 * the current implementation inspects nibble-aligned 4-bit fields, byte-aligned 8-bit fields, and word-aligned 16-bit fields
 * candidates are ranked by change-rate preference, observed range, and value diversity
 * arbitration IDs with fewer than 5 frames are omitted from the candidate list and reported in `low_sample_ids`
+
+### re correlate
+
+Correlate candidate bit fields against a timestamped reference series.
+
+```bash
+canarchy re correlate <file> --reference <ref.json|ref.jsonl> [--json|--jsonl|--table|--raw]
+```
+
+Notes:
+
+* this command is passive and file-backed
+* reference files may be JSON arrays, named JSON objects with `name` and `samples`, or JSONL sample streams
+* each reference sample must include numeric `timestamp` and `value` fields
+* candidates report `pearson_r`, `spearman_r`, `sample_count`, and `lag_ms`, and are ranked by absolute Pearson correlation
 
 ### re entropy
 
@@ -888,7 +911,7 @@ canarchy dbc search toyota --provider opendbc --json
 ### DBC Provider Decode
 
 ```bash
-canarchy decode tests/fixtures/sample.candump --dbc opendbc:toyota_tnga_k_pt_generated --json
+canarchy decode --file tests/fixtures/sample.candump --dbc opendbc:toyota_tnga_k_pt_generated --json
 ```
 
 ### Reverse-Engineering DBC Match
@@ -943,7 +966,6 @@ canarchy shell --command "capture can0 --raw"
 
 These commands are present in the CLI tree but not yet implemented end to end:
 
-* `re signals` and `re correlate`
 * `fuzz replay|mutate|id`
 
 These deeper capabilities are also not implemented yet even where the command surface exists:

--- a/docs/design/dbc-command-workflows.md
+++ b/docs/design/dbc-command-workflows.md
@@ -31,7 +31,7 @@ DBC-backed workflows are central to protocol-aware CAN analysis. Operators shoul
 ## Command Surface
 
 ```text
-canarchy decode <file> --dbc <file> [--json] [--jsonl] [--table] [--raw]
+canarchy decode --file <file> --dbc <file> [--json] [--jsonl] [--table] [--raw]
 canarchy encode --dbc <file> <message> <signal=value>... [--json] [--jsonl] [--table] [--raw]
 ```
 

--- a/docs/design/dbc-provider-workflows.md
+++ b/docs/design/dbc-provider-workflows.md
@@ -45,7 +45,7 @@ canarchy dbc fetch <ref> [--json] [--jsonl] [--table] [--raw]
 canarchy dbc cache list [--json] [--jsonl] [--table] [--raw]
 canarchy dbc cache prune [--provider <name>] [--json] [--jsonl] [--table] [--raw]
 canarchy dbc cache refresh [--provider <name>] [--json] [--jsonl] [--table] [--raw]
-canarchy decode <file> --dbc <path|provider-ref> [--json] [--jsonl] [--table] [--raw]
+canarchy decode --file <file> --dbc <path|provider-ref> [--json] [--jsonl] [--table] [--raw]
 canarchy encode --dbc <path|provider-ref> <message> <signal=value>... [--json] [--jsonl] [--table] [--raw]
 canarchy dbc inspect <path|provider-ref> [--message <name>] [--signals-only] [--json] [--jsonl] [--table] [--raw]
 ```

--- a/docs/design/dbc-runtime-schema-split.md
+++ b/docs/design/dbc-runtime-schema-split.md
@@ -32,7 +32,7 @@ Operators and agents need richer database-aware workflows than the current thin 
 ## Command Surface
 
 ```text
-canarchy decode <file> --dbc <file> [--json] [--jsonl] [--table] [--raw]
+canarchy decode --file <file> --dbc <file> [--json] [--jsonl] [--table] [--raw]
 canarchy encode --dbc <file> <message> <signal=value>... [--json] [--jsonl] [--table] [--raw]
 canarchy dbc inspect <dbc> [--message <name>] [--signals-only] [--json] [--jsonl] [--table] [--raw]
 ```

--- a/docs/design/j1939-summary-command.md
+++ b/docs/design/j1939-summary-command.md
@@ -21,7 +21,7 @@ Operators often start with the question "what is in this capture and what looks 
 
 | ID | Type | Requirement |
 |----|------|-------------|
-| `REQ-J1939SUM-01` | Ubiquitous | The system shall provide a `canarchy j1939 summary <file>` command for file-backed J1939 capture reconnaissance. |
+| `REQ-J1939SUM-01` | Ubiquitous | The system shall provide a `canarchy j1939 summary --file <file>` command for file-backed J1939 capture reconnaissance. |
 | `REQ-J1939SUM-02` | Event-driven | When `j1939 summary <file>` is invoked, the system shall report at minimum total frames, interfaces, unique arbitration IDs, first and last timestamps, top PGNs, and top source addresses for the analysed capture window. |
 | `REQ-J1939SUM-03` | Event-driven | When `j1939 summary <file>` is invoked, the system shall include a DM1 summary containing whether DM1 traffic is present, how many DM1 messages were observed, and the total active DTC count. |
 | `REQ-J1939SUM-04` | Event-driven | When `j1939 summary <file>` is invoked, the system shall include a TP summary containing total TP session count and complete TP session count. |
@@ -32,7 +32,7 @@ Operators often start with the question "what is in this capture and what looks 
 ## Command Surface
 
 ```text
-canarchy j1939 summary <capture> [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--table] [--raw]
+canarchy j1939 summary --file <capture> [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--table] [--raw]
 ```
 
 ## Responsibilities And Boundaries

--- a/docs/design/mcp-server.md
+++ b/docs/design/mcp-server.md
@@ -58,6 +58,12 @@ The current MCP tool surface is a curated non-interactive subset of the CLI. It 
 | `decode` | `decode` |
 | `encode` | `encode` |
 | `dbc inspect` | `dbc_inspect` |
+| `dbc provider list` | `dbc_provider_list` |
+| `dbc search` | `dbc_search` |
+| `dbc fetch` | `dbc_fetch` |
+| `dbc cache list` | `dbc_cache_list` |
+| `dbc cache prune` | `dbc_cache_prune` |
+| `dbc cache refresh` | `dbc_cache_refresh` |
 | `export` | `export` |
 | `session save` | `session_save` |
 | `session load` | `session_load` |
@@ -74,6 +80,11 @@ The current MCP tool surface is a curated non-interactive subset of the CLI. It 
 | `uds trace` | `uds_trace` |
 | `uds services` | `uds_services` |
 | `config show` | `config_show` |
+| `re correlate` | `re_correlate` |
+| `re counters` | `re_counters` |
+| `re entropy` | `re_entropy` |
+| `re match-dbc` | `re_match_dbc` |
+| `re shortlist-dbc` | `re_shortlist_dbc` |
 
 ## Response Envelope
 

--- a/docs/design/replay-command.md
+++ b/docs/design/replay-command.md
@@ -20,9 +20,9 @@ Replay is a core lab workflow for reproducing traffic patterns, validating tooli
 
 | ID | Type | Requirement |
 |----|------|-------------|
-| `REQ-REPLAY-01` | Ubiquitous | The system shall provide a `canarchy replay <file>` command for deterministic replay planning over capture files. |
-| `REQ-REPLAY-02` | Event-driven | When `replay <file>` is invoked, the system shall produce a replay plan preserving the capture frame count and deriving duration from the capture timeline. |
-| `REQ-REPLAY-03` | Event-driven | When `replay <file> --rate <factor>` is invoked, the system shall scale relative event timing by the specified rate factor. |
+| `REQ-REPLAY-01` | Ubiquitous | The system shall provide a `canarchy replay --file <file>` command for deterministic replay planning over capture files. |
+| `REQ-REPLAY-02` | Event-driven | When `replay --file <file>` is invoked, the system shall produce a replay plan preserving the capture frame count and deriving duration from the capture timeline. |
+| `REQ-REPLAY-03` | Event-driven | When `replay --file <file> --rate <factor>` is invoked, the system shall scale relative event timing by the specified rate factor. |
 | `REQ-REPLAY-04` | Event-driven | When `replay` is invoked, the system shall return a replay plan that remains machine-readable without emitting duplicated active-transmit safety warnings in structured output. |
 | `REQ-REPLAY-05` | Unwanted behaviour | If `--rate` is zero or negative, the system shall return a structured error with code `INVALID_RATE` and exit code 1. |
 | `REQ-REPLAY-06` | Unwanted behaviour | If the capture source file is missing or unreadable, the system shall return a structured error with code `CAPTURE_SOURCE_UNAVAILABLE` and exit code 2. |
@@ -30,7 +30,7 @@ Replay is a core lab workflow for reproducing traffic patterns, validating tooli
 ## Command Surface
 
 ```text
-canarchy replay <file> [--rate <factor>] [--json] [--jsonl] [--table] [--raw]
+canarchy replay --file <file> [--rate <factor>] [--json] [--jsonl] [--table] [--raw]
 ```
 
 ## Responsibilities And Boundaries

--- a/docs/design/reverse-engineering-helpers.md
+++ b/docs/design/reverse-engineering-helpers.md
@@ -4,13 +4,13 @@
 
 | Field | Value |
 |-------|-------|
-| Status | Partial |
+| Status | Implemented |
 | Command surface | `canarchy re signals`, `re counters`, `re entropy`, `re correlate`, `re match-dbc`, `re shortlist-dbc` |
 | Primary area | CLI, analysis |
 
 ## Goal
 
-Provide evidence-driven reverse-engineering helpers over recorded CAN traffic so operators can identify likely signals, counters, entropy-heavy fields, candidate DBC matches, and future correlations without treating heuristics as ground truth.
+Provide evidence-driven reverse-engineering helpers over recorded CAN traffic so operators can identify likely signals, counters, entropy-heavy fields, reference-series correlations, and candidate DBC matches without treating heuristics as ground truth.
 
 ## User-Facing Motivation
 
@@ -29,7 +29,7 @@ Operators analysing unknown traffic need repeatable helpers that summarise likel
 | `REQ-RE-07` | Ubiquitous | Reverse-engineering output shall include confidence, score, or rationale fields that distinguish heuristic inferences from established facts. |
 | `REQ-RE-08` | Ubiquitous | The commands shall support `--json`, `--jsonl`, and `--table` output modes. |
 | `REQ-RE-09` | Unwanted behaviour | If `re correlate` is invoked without `--reference`, the system shall return a structured error with code `RE_REFERENCE_REQUIRED` and exit code 1. |
-| `REQ-RE-10` | Unwanted behaviour | If the reference file is missing, malformed, or does not match the required timestamped numeric sample schema, the system shall return a structured error with code `RE_REFERENCE_INVALID` and exit code 1. |
+| `REQ-RE-10` | Unwanted behaviour | If the reference file is missing, malformed, or does not match the required timestamped numeric sample schema, the system shall return a structured error with code `INVALID_REFERENCE_FILE` and exit code 1. |
 | `REQ-RE-11` | Event-driven | When `re match-dbc <capture>` is invoked, the system shall rank candidate DBCs by comparing provider-catalog message IDs against the capture's observed arbitration IDs. |
 | `REQ-RE-12` | Event-driven | When `re shortlist-dbc <capture> --make <brand>` is invoked, the system shall pre-filter provider-catalog candidates by make before ranking them against the capture. |
 
@@ -44,14 +44,13 @@ canarchy re match-dbc <capture> [--provider <name>] [--limit <n>] [--json] [--js
 canarchy re shortlist-dbc <capture> --make <brand> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--table] [--raw]
 ```
 
-### Initial scope assumptions
+### Scope assumptions
 
-The first implementation should be file-backed and deterministic. Live capture subscriptions, interactive tuning, and OEM-specific knowledge are explicitly deferred.
+The implementation is file-backed and deterministic. Live capture subscriptions, interactive tuning, and OEM-specific knowledge are explicitly deferred.
 
 Current implementation note:
 
-* `re signals`, `re counters`, `re entropy`, `re match-dbc`, and `re shortlist-dbc` are implemented as deterministic file-backed helpers
-* `re correlate` remains deferred
+* `re signals`, `re counters`, `re entropy`, `re correlate`, `re match-dbc`, and `re shortlist-dbc` are implemented as deterministic file-backed helpers
 
 ## Responsibilities And Boundaries
 
@@ -237,5 +236,5 @@ Table output shall present compact ranked candidate summaries with confidence/sc
 
 ## Deferred Decisions
 
-* exact candidate schemas and whether they should also be modelled as typed events
+* whether reverse-engineering candidates should also be modelled as typed events
 * threshold and scoring models for counter and entropy ranking

--- a/docs/design/skill-manifest-schema.md
+++ b/docs/design/skill-manifest-schema.md
@@ -5,13 +5,13 @@
 | Field | Value |
 |-------|-------|
 | Status | Implemented |
-| Command surface | none yet; repository-backed skill manifest contract |
+| Command surface | `canarchy skills provider list`, `skills search`, `skills fetch`, `skills cache list`, `skills cache refresh` consume this manifest contract |
 | Primary area | agent integration, MCP, documentation |
 | Related specs | `docs/design/mcp-server.md`, `docs/design/dbc-provider-workflows.md`, `docs/design/plugin-model.md` |
 
 ## Goal
 
-Define a stable, versioned manifest schema for CANarchy skills so repository-backed skill providers, future cache workflows, and future MCP or agent integration all build against one inspectable contract instead of repository-specific conventions.
+Define a stable, versioned manifest schema for CANarchy skills so repository-backed skill providers, cache workflows, and future MCP or agent integration all build against one inspectable contract instead of repository-specific conventions.
 
 ## User-Facing Motivation
 
@@ -26,15 +26,15 @@ Operators and agents need skills to be discoverable and reproducible. A provider
 | `REQ-SKILLMAN-03` | Ubiquitous | Each manifest shall identify one skill with a stable provider-facing reference composed from provider identity and skill name. |
 | `REQ-SKILLMAN-04` | Ubiquitous | Each manifest shall describe at minimum the skill name, summary, content entry file, domain tags, compatibility metadata, and provenance metadata needed for repository-backed provider workflows. |
 | `REQ-SKILLMAN-05` | Optional feature | Where optional metadata is included, the manifest schema shall allow examples, dependencies, supported capture types, required tools, and deprecation metadata without changing the meaning of the required core fields. |
-| `REQ-SKILLMAN-06` | Unwanted behaviour | If a manifest omits required identity, provenance, compatibility, or content-entry fields, the future validation path shall reject it as invalid rather than guessing missing metadata. |
+| `REQ-SKILLMAN-06` | Unwanted behaviour | If a manifest omits required identity, provenance, compatibility, or content-entry fields, the provider validation path shall reject it as invalid rather than guessing missing metadata. |
 | `REQ-SKILLMAN-07` | Ubiquitous | The schema shall be suitable for repository-backed providers, catalog search, fetch/cache provenance reporting, and future MCP or agent discovery workflows without exposing provider-specific runtime objects. |
-| `REQ-SKILLMAN-08` | State-driven | While only schema documentation exists and no runtime validator has landed yet, the project shall provide canonical example manifests that future provider and validation work can test against. |
+| `REQ-SKILLMAN-08` | State-driven | While provider validation is available, the project shall provide canonical example manifests that provider and schema-validation tests can exercise. |
 
 ## Command Surface
 
 ```text
-No direct CLI command is introduced in this phase.
-This schema is a contract for future `skills` provider/catalog/fetch/cache workflows.
+No direct manifest-only CLI command is introduced in this phase.
+This schema is consumed by the `skills` provider/catalog/fetch/cache workflows.
 ```
 
 ## Responsibilities And Boundaries
@@ -44,11 +44,10 @@ In scope:
 * a versioned manifest format for one skill per manifest
 * required versus optional field definitions
 * a clear split between identity, provenance, compatibility, and content-entry metadata
-* example manifests suitable for future provider and validation tests
+* example manifests suitable for provider and validation tests
 
 Out of scope:
 
-* provider transport, cloning, fetch, or cache implementation
 * runtime skill execution or MCP tool exposure
 * repository authentication or trust policy
 * plugin execution semantics outside the skill metadata contract
@@ -164,13 +163,13 @@ Suggested input/output fields:
 
 ## Output Contracts
 
-No CLI output mode is introduced in this phase. Future provider and cache commands shall surface manifest-derived metadata through the standard CANarchy result envelope.
+No manifest-only CLI output mode is introduced in this phase. Provider and cache commands surface manifest-derived metadata through the standard CANarchy result envelope.
 
 ## Error Contracts
 
-No runtime error codes are implemented in this phase. The future validation path should reserve structured errors for invalid manifests rather than silently tolerating missing required fields.
+Provider workflows reject invalid manifests through structured errors rather than silently tolerating missing required fields.
 
-Suggested future validation codes:
+Validation codes:
 
 | Code | Trigger | Exit code |
 |------|---------|-----------|

--- a/docs/event-schema.md
+++ b/docs/event-schema.md
@@ -30,7 +30,7 @@ Use `--jsonl` on any command to receive one event per line on stdout, suitable f
 
 ```bash
 canarchy capture can0 --jsonl
-canarchy j1939 decode trace.candump --jsonl
+canarchy j1939 decode --file trace.candump --jsonl
 canarchy generate can0 --count 100 --gap 10 --jsonl
 ```
 
@@ -389,11 +389,11 @@ canarchy capture can0 --jsonl \
   | jq 'select(.event_type == "frame") | .payload.frame.arbitration_id'
 
 # Decode a trace and print each signal value
-canarchy decode trace.candump --dbc vehicle.dbc --jsonl \
+canarchy decode --file trace.candump --dbc vehicle.dbc --jsonl \
   | jq 'select(.event_type == "signal") | [.payload.signal_name, .payload.value, .payload.units]'
 
 # Watch for J1939 coolant temperature observations
-canarchy j1939 decode trace.candump --jsonl \
+canarchy j1939 decode --file trace.candump --jsonl \
   | jq 'select(.event_type == "j1939_pgn" and .payload.pgn == 65262)'
 ```
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -139,19 +139,19 @@ CANarchy can operate on standard timestamped candump log files.
 Summarize a capture:
 
 ```bash
-canarchy stats tests/fixtures/sample.candump --json
+canarchy stats --file tests/fixtures/sample.candump --json
 ```
 
 Filter for a specific arbitration ID:
 
 ```bash
-canarchy filter tests/fixtures/sample.candump 'id==0x18FEEE31' --json
+canarchy filter 'id==0x18FEEE31' --file tests/fixtures/sample.candump --json
 ```
 
 Replay a capture with deterministic timing:
 
 ```bash
-canarchy replay tests/fixtures/sample.candump --rate 1.0 --json
+canarchy replay --file tests/fixtures/sample.candump --rate 1.0 --json
 ```
 
 ## Discover and Use DBC Files
@@ -168,7 +168,7 @@ canarchy dbc search toyota --provider opendbc --limit 5 --json
 Decode using a provider ref instead of a local file path:
 
 ```bash
-canarchy decode tests/fixtures/sample.candump --dbc opendbc:toyota_tnga_k_pt_generated --json
+canarchy decode --file tests/fixtures/sample.candump --dbc opendbc:toyota_tnga_k_pt_generated --json
 ```
 
 Structured output for `decode`, `encode`, and `dbc inspect` includes a `data.dbc_source` object so you can see which local or provider-backed DBC resolution was used.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -17,11 +17,12 @@ Implemented and exercised in the current codebase:
 * file-backed `filter`, `stats`, `decode`, `j1939 decode`, and `replay` using candump logs
 * DBC-backed `decode`, `encode`, and `dbc inspect`, including provider-ref resolution and `dbc_source` provenance in structured output
 * DBC provider and cache workflows for catalog search, fetch, and refresh through the optional opendbc integration
-* J1939 `monitor`, `decode`, `pgn`, `spn`, `tp`, and `dm1`
+* J1939 `monitor`, `decode`, `pgn`, `spn`, `tp`, `dm1`, `faults`, `summary`, `inventory`, and `compare`
 * UDS `scan`, `trace`, and `services`
 * `re signals` for file-backed signal candidate inference
 * `re counters` for file-backed likely-counter detection
 * `re entropy` for file-backed per-ID and per-byte entropy ranking
+* `re correlate` for correlating candidate fields against timestamped reference series
 * `re match-dbc` and `re shortlist-dbc` for provider-backed DBC candidate ranking against captures
 * session `save`, `load`, and `show`
 * structured `export` for capture files and saved sessions

--- a/docs/spec-template.md
+++ b/docs/spec-template.md
@@ -75,7 +75,7 @@ And    <additional assertion>
 
 ```gherkin
 Given  the scaffold backend is active and `sample.candump` is present
-When   the operator runs `canarchy replay sample.candump --rate 0 --json`
+When   the operator runs `canarchy replay --file sample.candump --rate 0 --json`
 Then   the system shall exit with code 1
 And    the response shall contain an error with code `"INVALID_RATE"`
 ```

--- a/docs/tests/dbc-command-workflows.md
+++ b/docs/tests/dbc-command-workflows.md
@@ -73,7 +73,7 @@ Then   the result shall include a frame and associated frame events
 
 ```gherkin
 Given  the files `tests/fixtures/sample.candump` and `tests/fixtures/sample.dbc` are available
-When   the operator runs `canarchy decode sample.candump --dbc sample.dbc --json`
+When   the operator runs `canarchy decode --file sample.candump --dbc sample.dbc --json`
 Then   the result shall include a matched message count
 And    the result shall include decoded-message events for known messages
 ```
@@ -99,7 +99,7 @@ And    the result shall include associated frame events
 
 ```gherkin
 Given  the file `tests/fixtures/invalid.dbc` contains malformed DBC content
-When   the operator runs `canarchy decode sample.candump --dbc invalid.dbc --json`
+When   the operator runs `canarchy decode --file sample.candump --dbc invalid.dbc --json`
 Then   the command shall exit with code `3`
 And    `errors[0].code` shall equal `"DBC_LOAD_FAILED"`
 ```

--- a/docs/tests/dbc-provider-workflows.md
+++ b/docs/tests/dbc-provider-workflows.md
@@ -122,7 +122,7 @@ And    the response shall include the refreshed DBC count
 
 ```gherkin
 Given  a mocked provider registry can resolve a provider-backed DBC ref
-When   the operator runs `canarchy decode tests/fixtures/sample.candump --dbc opendbc:toyota_tnga_k_pt_generated --json`
+When   the operator runs `canarchy decode --file tests/fixtures/sample.candump --dbc opendbc:toyota_tnga_k_pt_generated --json`
 Then   the system shall decode using the resolved local DBC path
 And    `data.dbc_source` shall include provider, logical DBC name, version, and path
 ```

--- a/docs/tests/j1939-first-class-decoder.md
+++ b/docs/tests/j1939-first-class-decoder.md
@@ -29,7 +29,7 @@
 
 ```gherkin
 Given  the J1939 decoder backend is replaced with a test double
-When   the operator runs `canarchy j1939 decode tests/fixtures/j1939_heavy_vehicle.candump --json`
+When   the operator runs `canarchy j1939 decode --file tests/fixtures/j1939_heavy_vehicle.candump --json`
 Then   the system shall route the command through the decoder abstraction
 And    the CLI layer shall shape the returned records into the standard CANarchy envelope
 ```
@@ -108,7 +108,7 @@ And    the result shall expose DBC-derived fields according to the documented pr
 
 ```gherkin
 Given  the configured J1939 decoder backend fails during initialization
-When   the operator runs `canarchy j1939 decode tests/fixtures/j1939_heavy_vehicle.candump --json`
+When   the operator runs `canarchy j1939 decode --file tests/fixtures/j1939_heavy_vehicle.candump --json`
 Then   the system shall exit with code `3`
 And    `errors[0].code` shall equal `"J1939_DECODER_UNAVAILABLE"`
 ```

--- a/docs/tests/j1939-summary-command.md
+++ b/docs/tests/j1939-summary-command.md
@@ -26,7 +26,7 @@
 
 ```gherkin
 Given  a representative J1939 capture fixture contains multiple PGNs and at least one TP session
-When   the operator runs `canarchy j1939 summary <capture> --json`
+When   the operator runs `canarchy j1939 summary --file <capture> --json`
 Then   the system shall return total frames, interfaces, unique arbitration IDs, first and last timestamps, top PGNs, top source addresses, DM1 summary fields, and TP summary fields
 And    the JSON field names shall remain stable for automation
 ```
@@ -39,7 +39,7 @@ And    the JSON field names shall remain stable for automation
 
 ```gherkin
 Given  a J1939 TP capture fixture contains a completed payload whose bytes form obvious printable ASCII text
-When   the operator runs `canarchy j1939 summary <capture> --json`
+When   the operator runs `canarchy j1939 summary --file <capture> --json`
 Then   the TP summary shall include that candidate printable identifier string
 And    the candidate shall retain the related PGN and addressing metadata
 ```
@@ -52,7 +52,7 @@ And    the candidate shall retain the related PGN and addressing metadata
 
 ```gherkin
 Given  a J1939 TP capture fixture contains a printable candidate identifier
-When   the operator runs `canarchy j1939 summary <capture> --table`
+When   the operator runs `canarchy j1939 summary --file <capture> --table`
 Then   the output shall show the summary sections for top PGNs and printable identifiers
 And    the printable text shall remain visible in the operator-facing output
 ```

--- a/docs/tests/mcp-server.md
+++ b/docs/tests/mcp-server.md
@@ -45,7 +45,7 @@ And    `canarchy mcp serve --help` shall exit with code `0`
 ```gherkin
 Given  the MCP server is initialised
 When   `handle_list_tools()` is called
-Then   the returned set shall contain at minimum: `capture`, `send`, `filter`, `stats`, `capture_info`, `decode`, `encode`, `dbc_inspect`, `j1939_monitor`, `j1939_decode`, `j1939_pgn`, `j1939_spn`, `j1939_tp`, `j1939_dm1`, `j1939_inventory`, `uds_scan`, `uds_trace`, `uds_services`, `config_show`, `replay`, `gateway`, `generate`, `export`, `session_save`, `session_load`, `session_show`
+Then   the returned set shall contain at minimum: `capture`, `send`, `filter`, `stats`, `capture_info`, `decode`, `encode`, `dbc_inspect`, `dbc_provider_list`, `dbc_search`, `dbc_fetch`, `dbc_cache_list`, `dbc_cache_prune`, `dbc_cache_refresh`, `j1939_monitor`, `j1939_decode`, `j1939_pgn`, `j1939_spn`, `j1939_tp`, `j1939_dm1`, `j1939_summary`, `j1939_inventory`, `uds_scan`, `uds_trace`, `uds_services`, `config_show`, `replay`, `gateway`, `generate`, `export`, `session_save`, `session_load`, `session_show`, `re_correlate`, `re_counters`, `re_entropy`, `re_match_dbc`, `re_shortlist_dbc`
 ```
 
 **Fixture:** none.
@@ -57,7 +57,7 @@ Then   the returned set shall contain at minimum: `capture`, `send`, `filter`, `
 ```gherkin
 Given  the MCP server is initialised
 When   `handle_list_tools()` is called
-Then   at least 26 tools shall be returned — one per registered MCP tool in the current curated surface
+Then   at least 38 tools shall be returned — one per registered MCP tool in the current curated surface
 ```
 
 **Fixture:** none.
@@ -187,10 +187,10 @@ And    `"tui"` shall not appear in the set of tool names
 ```gherkin
 Given  the MCP server is initialised
 When   `handle_list_tools()` is called
-Then   `"dbc_search"` shall not appear in the set of tool names
-And    `"dbc_fetch"` shall not appear in the set of tool names
-And    `"re_counters"` shall not appear in the set of tool names
-And    `"re_match_dbc"` shall not appear in the set of tool names
+Then   `"skills_search"` shall not appear in the set of tool names
+And    `"skills_fetch"` shall not appear in the set of tool names
+And    `"j1939_compare"` shall not appear in the set of tool names
+And    `"re_signals"` shall not appear in the set of tool names
 ```
 
 **Fixture:** none.

--- a/docs/tests/replay-command.md
+++ b/docs/tests/replay-command.md
@@ -59,7 +59,7 @@ Then   event timestamps shall be scaled relative to the slower replay rate
 
 ```gherkin
 Given  the file `tests/fixtures/sample.candump` is available
-When   the operator runs `canarchy replay sample.candump --rate 2.0 --json`
+When   the operator runs `canarchy replay --file sample.candump --rate 2.0 --json`
 Then   the result shall include active mode, frame count, duration, and replay events
 And    the result shall keep `warnings` empty for the replay plan output
 ```
@@ -72,7 +72,7 @@ And    the result shall keep `warnings` empty for the replay plan output
 
 ```gherkin
 Given  a valid capture file is available
-When   the operator runs `canarchy replay sample.candump --rate 0 --json`
+When   the operator runs `canarchy replay --file sample.candump --rate 0 --json`
 Then   the command shall exit with code `1`
 And    `errors[0].code` shall equal `"INVALID_RATE"`
 ```
@@ -85,7 +85,7 @@ And    `errors[0].code` shall equal `"INVALID_RATE"`
 
 ```gherkin
 Given  the file `missing.candump` does not exist
-When   the operator runs `canarchy replay missing.candump --json`
+When   the operator runs `canarchy replay --file missing.candump --json`
 Then   the command shall exit with code `2`
 And    `errors[0].code` shall equal `"CAPTURE_SOURCE_UNAVAILABLE"`
 ```

--- a/docs/tests/skill-manifest-schema.md
+++ b/docs/tests/skill-manifest-schema.md
@@ -6,7 +6,7 @@
 |-------|-------|
 | Status | Implemented |
 | Design doc | `docs/design/skill-manifest-schema.md` |
-| Test file | future schema validation tests; current fixtures live under `tests/fixtures/skills/` |
+| Test file | `tests/test_skills_provider.py`; fixtures live under `tests/fixtures/skills/` |
 
 ## Requirement Traceability
 
@@ -17,9 +17,9 @@
 | `REQ-SKILLMAN-03` | Each manifest identifies one skill with provider-facing identity | `TEST-SKILLMAN-01` |
 | `REQ-SKILLMAN-04` | Required core metadata is present | `TEST-SKILLMAN-01`, `TEST-SKILLMAN-02` |
 | `REQ-SKILLMAN-05` | Optional metadata can be present without redefining required fields | `TEST-SKILLMAN-01`, `TEST-SKILLMAN-03` |
-| `REQ-SKILLMAN-06` | Missing required fields will be rejected by future validation | `TEST-SKILLMAN-02` |
+| `REQ-SKILLMAN-06` | Missing required fields are rejected by provider validation | `TEST-SKILLMAN-02` |
 | `REQ-SKILLMAN-07` | Schema is suitable for provider/catalog/cache and future MCP workflows | `TEST-SKILLMAN-01`, `TEST-SKILLMAN-03` |
-| `REQ-SKILLMAN-08` | Canonical example manifests exist while runtime validation is absent | `TEST-SKILLMAN-01`, `TEST-SKILLMAN-03` |
+| `REQ-SKILLMAN-08` | Canonical example manifests support provider validation tests | `TEST-SKILLMAN-01`, `TEST-SKILLMAN-03` |
 
 ## Test Cases
 
@@ -41,7 +41,7 @@ And    optional workflow metadata may also be present without changing the requi
 
 ```gherkin
 Given  an intentionally incomplete skill manifest fixture exists
-When   a future schema validator checks that manifest
+When   the provider validation path checks that manifest
 Then   the system shall reject the manifest as invalid
 And    the failure shall be attributable to missing required identity, provenance, compatibility, or content-entry fields rather than inferred defaults
 ```
@@ -63,16 +63,15 @@ And    optional metadata such as examples or dependencies may be absent without 
 
 ## Fixtures And Environment
 
-Current fixtures for this issue are documentation and future-validation artifacts only:
+Current fixtures for this issue are provider-validation artifacts:
 
 * `tests/fixtures/skills/j1939_compare_triage.skill.yaml`
 * `tests/fixtures/skills/uds_trace_minimal.skill.yaml`
 * `tests/fixtures/skills/invalid_missing_entry.skill.yaml`
 
-No runtime validator exists yet in this phase.
+Provider refresh and fetch paths validate manifest shape before accepting catalog entries.
 
 ## Explicit Non-Coverage
 
-* provider fetch, refresh, and cache behavior, which belong to `#166`
 * MCP or agent execution behavior, which belongs to `#167`
-* runtime YAML parsing or schema enforcement code, which is deferred until provider implementation work lands
+* standalone manifest linting outside provider refresh/fetch workflows

--- a/docs/tutorials/dbc_provider_workflow.md
+++ b/docs/tutorials/dbc_provider_workflow.md
@@ -76,7 +76,7 @@ Structured output includes `data.dbc_source`, which records the provider, logica
 Use the same provider ref directly with `decode`:
 
 ```bash
-canarchy decode tests/fixtures/sample.candump --dbc opendbc:toyota_tnga_k_pt --json
+canarchy decode --file tests/fixtures/sample.candump --dbc opendbc:toyota_tnga_k_pt --json
 ```
 
 This avoids copying or hard-coding a separate local path.

--- a/docs/tutorials/j1939_heavy_vehicle.md
+++ b/docs/tutorials/j1939_heavy_vehicle.md
@@ -30,7 +30,7 @@ The fixture used in this demo is at `tests/fixtures/j1939_heavy_vehicle.candump`
 Get an overview of what's on the bus:
 
 ```bash
-canarchy j1939 decode tests/fixtures/j1939_heavy_vehicle.candump --table
+canarchy j1939 decode --file tests/fixtures/j1939_heavy_vehicle.candump --table
 ```
 
 ```text
@@ -82,7 +82,7 @@ The coolant temperature is climbing: 85°C → 86°C → 87°C across the 550ms 
 Those TP frames in Step 1 are carrying a DM1 message. Let CANarchy reassemble and decode them:
 
 ```bash
-canarchy j1939 dm1 tests/fixtures/j1939_heavy_vehicle.candump --table
+canarchy j1939 dm1 --file tests/fixtures/j1939_heavy_vehicle.candump --table
 ```
 
 ```text
@@ -109,7 +109,7 @@ All three commands support `--json` for a full structured envelope or `--jsonl` 
 
 ```bash
 # Stream all J1939 observations as JSONL
-canarchy j1939 decode tests/fixtures/j1939_heavy_vehicle.candump --jsonl
+canarchy j1939 decode --file tests/fixtures/j1939_heavy_vehicle.candump --jsonl
 
 # Extract just the coolant temperature values with jq
 canarchy j1939 spn 110 --file tests/fixtures/j1939_heavy_vehicle.candump --jsonl \
@@ -135,7 +135,7 @@ export CANARCHY_TRANSPORT_BACKEND=python-can
 export CANARCHY_PYTHON_CAN_INTERFACE=socketcan   # or kvaser, pcan, etc.
 
 canarchy capture can0 --candump                   # live candump view
-canarchy j1939 dm1 today.candump --table          # decode DM1 from saved capture
+canarchy j1939 dm1 --file today.candump --table   # decode DM1 from saved capture
 ```
 
 For cross-process demos without physical hardware, see the [Generate and Capture Demo](generate_and_capture.md) using the `udp_multicast` backend.


### PR DESCRIPTION
## Summary
- Align README, overview, command spec, tutorials, design specs, and test specs with the current implemented CLI surface.
- Update stale file-backed command examples to use current `--file` syntax and document implemented reverse-engineering helpers.
- Refresh MCP and skills manifest docs to match current provider/cache validation and registered MCP tool coverage.

## Verification
- `uv run mkdocs build --strict`
- `uv run pytest tests/test_mcp.py -q`
- `uv run python -m unittest tests.test_skills_provider tests.test_reverse_engineering tests.test_cli.CliTests.test_re_correlate_returns_ranked_candidates_and_metadata tests.test_cli.CliTests.test_re_signals_returns_ranked_candidates_and_metadata -v`
- `git diff --check`

Refs #211