### PR TITLE
Close out repository-backed skills provider umbrella

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Documentation
 
+* Marked the first-phase repository-backed skills provider workflow as a current capability in top-level project documentation so the skills umbrella issue reflects the implemented manifest, provider, cache, and agent-reference surface.
 * Audited current operator, design, and test documentation for stale command-status and command-syntax references, aligning reverse-engineering helper status and file-backed examples with the implemented CLI surface.
 * Defined the phase-1 agent and MCP integration model for CANarchy skills, including the decision to keep skills CLI-discovered and out of the MCP tool/resource/prompt surface while documenting how agents should select, fetch, and reference skill provenance.
 * Clarified the agent workflow policy so non-trivial work is expected to happen on dedicated branches and be delivered through pull requests by default rather than direct pushes to `main`.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Fully implemented and tested:
 * `re entropy` — file-backed entropy ranking across arbitration IDs and byte positions
 * `re correlate` — file-backed correlation of candidate fields against timestamped reference series
 * `re match-dbc`, `re shortlist-dbc` — provider-backed DBC candidate ranking against captures
+* `skills provider list`, `skills search`, `skills fetch`, `skills cache list`, `skills cache refresh` — repository-backed CANarchy skill discovery, caching, and provenance workflows
 * `session save`, `load`, `show` — session management
 * `export` — structured artifact export
 * `shell` — interactive REPL and `--command` scripting mode

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -24,6 +24,7 @@ Implemented and exercised in the current codebase:
 * `re entropy` for file-backed per-ID and per-byte entropy ranking
 * `re correlate` for correlating candidate fields against timestamped reference series
 * `re match-dbc` and `re shortlist-dbc` for provider-backed DBC candidate ranking against captures
+* repository-backed skills provider workflows for discovering, fetching, caching, and referencing agent-oriented CANarchy skills
 * session `save`, `load`, and `show`
 * structured `export` for capture files and saved sessions
 * shell command reuse through `canarchy shell --command ...`


### PR DESCRIPTION
## Summary
- Mark the first-phase repository-backed skills provider workflow as a current capability in README and project overview.
- Record the umbrella closeout in the unreleased changelog.
- This reflects the already-merged manifest, provider/cache, and agent/MCP integration work from #168, #166, and #167.

## Verification
- `uv run python -m unittest tests.test_skills_provider -v`
- `uv run mkdocs build --strict`
- `git diff --check`

Closes #165