### PR TITLE
Reopen development after 0.6.0

### DIFF
--- a/src/canarchy/__init__.py
+++ b/src/canarchy/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.6.0"
+__version__ = "0.6.1.dev0"


### PR DESCRIPTION
## Summary
- Advance the development version from `0.6.0` to `0.6.1.dev0` after the `v0.6.0` tag and GitHub release.

## Verification
- `uv run canarchy --version` reported `canarchy 0.6.1.dev0`
- `git diff --check`

Refs #217