### PR TITLE
feat: implement plugin model with processor registry (closes #33)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -343,20 +343,41 @@ The architecture is intentionally ahead of some implementations. These are the m
 * reverse-engineering now has a shared analysis subsystem for heuristic ranking (`re signals`, `re counters`, `re entropy`), reference-series correlation (`re correlate`), and provider-backed schema matching (`re match-dbc`, `re shortlist-dbc`)
 * plugin architecture is planned conceptually but not yet implemented as a stable extension boundary
 
-## Future Plugin Boundary
+## Plugin Model
 
-The intended future plugin model should extend the shared engine and command path, not bypass it.
+The plugin registry (`src/canarchy/plugins.py`) provides three stable extension points that let
+third-party packages add analysis processors, output sinks, and input adapters without forking.
 
-Target extension areas:
+Plugins are discovered at startup via Python entry points and must declare a compatible `api_version`.
+The registry follows the same lazy-singleton pattern as the DBC and skills provider registries.
 
-* protocol helpers
-* analysis modules
-* output sinks
-* command registrations
+**Extension points:**
+
+* `ProcessorPlugin` — analysis processors: consume frames, return ranked candidates
+* `SinkPlugin` — output sinks: write command payloads to custom destinations
+* `InputAdapterPlugin` — input adapters: yield frames from custom file formats
+
+**Entry point groups:**
+
+| Group | Extension point |
+|-------|----------------|
+| `canarchy.processors` | `ProcessorPlugin` |
+| `canarchy.sinks` | `SinkPlugin` |
+| `canarchy.input_adapters` | `InputAdapterPlugin` |
+
+Built-in processors for the three heuristic reverse-engineering commands (`re counters`,
+`re entropy`, `re signals`) are registered by the default registry build and serve as the
+proof-of-contract migration. The `reverse_engineering_payload()` command handler routes these
+commands through `get_registry().get_processor(name)` rather than calling the underlying
+analysis functions directly.
+
+See `docs/design/plugin-model.md` for the full design spec and `docs/plugin-guide.md` for the
+third-party author guide.
 
 Non-goal:
 
 * UI-only behavior that cannot also be reached through the canonical CLI surface
+* Command registration via plugins (deferred to a later phase)
 
 ## Design Summary
 

--- a/docs/design/plugin-model.md
+++ b/docs/design/plugin-model.md
@@ -1,0 +1,192 @@
+# Design: Plugin Model
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| Status | Implemented (Phase 1–4) |
+| Test spec | `docs/tests/plugin-model.md` |
+| Implementation | `src/canarchy/plugins.py`, `src/canarchy/re_processors.py` |
+| Author guide | `docs/plugin-guide.md` |
+
+---
+
+## Motivation
+
+CANarchy's shared `execute_command()` path is the behavioral contract for all front ends (CLI, shell, TUI, MCP).
+The plugin model extends that shared engine at well-defined boundaries without requiring a fork.
+
+Third-party authors can add custom decoders, analysis processors, and output sinks by publishing a Python
+package and declaring it in `pyproject.toml`. CANarchy discovers and registers these at startup via Python
+entry points, following the same lazy-singleton registry pattern already used by the DBC and skills providers.
+
+---
+
+## Guiding Constraints
+
+1. Plugins extend the shared engine, not any specific front end.
+2. No plugin may bypass the canonical `CommandResult` envelope or output modes.
+3. Plugin loading must not break startup when a plugin is absent, broken, or incompatible.
+4. The registry pattern follows the existing DBC provider model: lazy singleton, reset-able in tests, config-driven.
+5. Phase 1 covers three extension points. Command registration is deferred to a later phase.
+
+---
+
+## Extension Points
+
+### 1. Processor
+
+A processor consumes a list of `CanFrame` objects and returns ranked candidates plus analysis metadata.
+
+```
+frames: list[CanFrame]  →  ProcessorPlugin.process()  →  ProcessorResult
+```
+
+Use cases: entropy analysis, counter detection, signal inference, custom anomaly detectors.
+
+### 2. Sink
+
+A sink writes a serialized command payload to an external destination or custom format.
+
+```
+payload: dict  →  SinkPlugin.write()  →  dict (write metadata)
+```
+
+Use cases: database export, remote telemetry, custom file formats, SIEM integration.
+
+### 3. Input Adapter
+
+An input adapter yields `CanFrame` objects from a custom source or file format not natively supported by
+the transport layer.
+
+```
+source: str  →  InputAdapterPlugin.read()  →  Iterator[CanFrame]
+```
+
+Use cases: proprietary capture formats, hardware-specific log files, cloud storage backends.
+
+---
+
+## API Version Contract
+
+Every plugin must declare `api_version = "1"`. The registry rejects any plugin whose `api_version` does
+not exactly match `CANARCHY_API_VERSION`. This is an explicit compatibility gate; the registry never
+silently degrades.
+
+The API version will increment when a breaking change is made to any plugin protocol. Minor additive
+changes (new optional kwargs, new metadata fields) do not require a version bump.
+
+---
+
+## Protocol Definitions
+
+```python
+CANARCHY_API_VERSION = "1"
+
+@runtime_checkable
+class ProcessorPlugin(Protocol):
+    name: str
+    api_version: str
+    def process(self, frames: list[CanFrame], **kwargs: Any) -> ProcessorResult: ...
+
+@runtime_checkable
+class SinkPlugin(Protocol):
+    name: str
+    api_version: str
+    supported_formats: list[str]
+    def write(self, payload: dict[str, Any], destination: str, *, output_format: str = "json") -> dict[str, Any]: ...
+
+@runtime_checkable
+class InputAdapterPlugin(Protocol):
+    name: str
+    api_version: str
+    supported_extensions: list[str]
+    def read(self, source: str) -> Iterator[CanFrame]: ...
+
+@dataclass(slots=True, frozen=True)
+class ProcessorResult:
+    candidates: list[dict[str, Any]]
+    metadata: dict[str, Any]
+    warnings: list[str] = field(default_factory=list)
+```
+
+---
+
+## Registry
+
+`PluginRegistry` holds three independent namespaces: processors, sinks, and input adapters.
+Names must be unique within each namespace.
+
+### Registration errors
+
+| Code | Condition |
+|------|-----------|
+| `PLUGIN_INCOMPATIBLE` | `api_version` does not match `CANARCHY_API_VERSION` |
+| `PLUGIN_DUPLICATE` | A plugin with the same name is already registered |
+| `PLUGIN_INVALID` | Object does not satisfy the runtime-checkable protocol |
+
+### Singleton lifecycle
+
+```python
+get_registry()   # builds the default registry on first call
+reset_registry() # resets to None (tests only)
+```
+
+`_build_default_registry()` registers all built-in plugins then calls `_load_entry_point_plugins()`.
+
+---
+
+## Discovery: Entry Points
+
+Third-party plugins are discovered via Python packaging entry points.
+
+| Entry point group | Extension point |
+|-------------------|----------------|
+| `canarchy.processors` | `ProcessorPlugin` |
+| `canarchy.sinks` | `SinkPlugin` |
+| `canarchy.input_adapters` | `InputAdapterPlugin` |
+
+A third-party `pyproject.toml` example:
+
+```toml
+[project.entry-points."canarchy.processors"]
+my-detector = "my_package.plugin:MyDetectorPlugin"
+```
+
+**Error isolation:** `PluginError` from an entry point plugin propagates (the author must fix the
+incompatibility). Any other exception from loading a third-party entry point is caught and emitted as
+a `warnings.warn` so that a single broken plugin does not prevent CANarchy from starting.
+
+---
+
+## Built-in Processors (Phase 3 Migration)
+
+The three heuristic reverse-engineering processors are the first built-in implementations.
+They are registered by `_build_default_registry()` and serve as the proof-of-contract migration.
+
+| Name | Class | Source function |
+|------|-------|-----------------|
+| `counter-candidates` | `CounterCandidateProcessor` | `counter_candidates()` |
+| `entropy-candidates` | `EntropyCandidateProcessor` | `entropy_candidates()` |
+| `signal-analysis` | `SignalAnalysisProcessor` | `signal_analysis()` |
+
+`reverse_engineering_payload()` in `cli.py` looks these up via `get_registry().get_processor(name)`.
+If a processor is absent the command fails with `PLUGIN_NOT_FOUND`; the CLI surface and output envelope
+are unchanged.
+
+---
+
+## Non-Goals (Phase 1)
+
+- Plugin sandboxing or code signing
+- Plugin marketplace or discovery UI
+- Command registration via plugins (deferred to a later phase)
+- Migrating every existing command — one proof migration is sufficient
+
+---
+
+## Future Work
+
+- Command registration extension point so plugins can add new top-level commands
+- Config-driven enable/disable per plugin (mirrors the DBC provider pattern)
+- Plugin author verification / signing for security-sensitive deployments

--- a/docs/plugin-guide.md
+++ b/docs/plugin-guide.md
@@ -1,0 +1,185 @@
+# Plugin Author Guide
+
+CANarchy supports third-party plugins that extend the analysis engine without requiring a fork.
+This guide shows how to build, package, and register a custom processor plugin.
+
+## Extension Points
+
+| Extension point | Use case |
+|----------------|----------|
+| `ProcessorPlugin` | Frame analysis: counters, entropy, anomaly detection, custom classifiers |
+| `SinkPlugin` | Output routing: databases, SIEM, cloud telemetry, custom file formats |
+| `InputAdapterPlugin` | Input parsing: proprietary capture formats, hardware-specific log files |
+
+## API Version
+
+Every plugin must declare `api_version = "1"`. If the version does not match the installed
+CANarchy build, the plugin is rejected at registration time with a clear error message.
+
+## Writing a Processor Plugin
+
+A processor receives a list of `CanFrame` objects and returns a `ProcessorResult`.
+
+```python
+# my_package/plugin.py
+from typing import Any
+from canarchy.models import CanFrame
+from canarchy.plugins import CANARCHY_API_VERSION, ProcessorResult
+
+
+class RepeatingIDDetector:
+    """Flag arbitration IDs that appear suspiciously often relative to others."""
+
+    name = "repeating-id-detector"
+    api_version = CANARCHY_API_VERSION
+
+    def process(self, frames: list[CanFrame], **kwargs: Any) -> ProcessorResult:
+        from collections import Counter
+
+        counts = Counter(f.arbitration_id for f in frames if not f.is_error_frame)
+        total = len(frames) or 1
+        threshold = kwargs.get("threshold", 0.5)
+
+        candidates = [
+            {
+                "arbitration_id": arb_id,
+                "frame_count": count,
+                "fraction": round(count / total, 4),
+            }
+            for arb_id, count in counts.most_common()
+            if count / total >= threshold
+        ]
+
+        warns = []
+        if not candidates:
+            warns.append(f"No arbitration ID exceeded the {threshold:.0%} repetition threshold.")
+
+        return ProcessorResult(
+            candidates=candidates,
+            metadata={
+                "analysis": "repeating_id_detection",
+                "candidate_count": len(candidates),
+                "threshold": threshold,
+            },
+            warnings=warns,
+        )
+```
+
+### Rules
+
+- `name` must be a unique string across all registered processors.
+- `api_version` must equal `canarchy.plugins.CANARCHY_API_VERSION`.
+- `process()` must return a `ProcessorResult`; it must not raise on empty input.
+- `**kwargs` lets callers pass optional parameters; always provide safe defaults.
+- Do not import front-end modules (`cli`, `tui`, `mcp_server`) from within a plugin.
+
+## Packaging and Registration
+
+Declare the plugin via a Python entry point in your `pyproject.toml`:
+
+```toml
+[project]
+name = "canarchy-repeating-id"
+dependencies = ["canarchy>=0.6"]
+
+[project.entry-points."canarchy.processors"]
+repeating-id-detector = "my_package.plugin:RepeatingIDDetector"
+```
+
+Install the package into the same environment as CANarchy:
+
+```
+pip install -e .
+# or
+uv pip install -e .
+```
+
+CANarchy discovers and registers the plugin the next time `get_registry()` is called (on first
+command execution).
+
+## Entry Point Groups
+
+| Group | Extension point |
+|-------|----------------|
+| `canarchy.processors` | `ProcessorPlugin` |
+| `canarchy.sinks` | `SinkPlugin` |
+| `canarchy.input_adapters` | `InputAdapterPlugin` |
+
+## Local Verification
+
+To confirm your plugin is registered before distributing it:
+
+```python
+from canarchy.plugins import get_registry, reset_registry
+
+reset_registry()  # force a fresh build
+registry = get_registry()
+proc = registry.get_processor("repeating-id-detector")
+assert proc is not None, "plugin not found — check entry point group and class name"
+print(registry.list_processors())
+```
+
+## Error Isolation
+
+CANarchy wraps third-party entry point loading in a `try/except`. If your plugin raises an
+unexpected exception during loading, CANarchy emits a `warnings.warn` and continues starting.
+A `PluginError` (version mismatch, duplicate name, invalid interface) propagates immediately
+so you can diagnose it during development.
+
+## Writing a Sink Plugin
+
+A sink writes a serialized command payload to a custom destination.
+
+```python
+import json
+from typing import Any
+from canarchy.plugins import CANARCHY_API_VERSION
+
+
+class JsonFileSink:
+    name = "json-file"
+    api_version = CANARCHY_API_VERSION
+    supported_formats = ["json"]
+
+    def write(
+        self, payload: dict[str, Any], destination: str, *, output_format: str = "json"
+    ) -> dict[str, Any]:
+        with open(destination, "w") as f:
+            json.dump(payload, f, indent=2)
+        return {"destination": destination, "bytes_written": f.tell()}
+```
+
+Entry point group: `canarchy.sinks`.
+
+## Writing an Input Adapter Plugin
+
+An input adapter yields `CanFrame` objects from a custom source.
+
+```python
+from typing import Iterator, Any
+from canarchy.models import CanFrame
+from canarchy.plugins import CANARCHY_API_VERSION
+
+
+class MyFormatAdapter:
+    name = "my-format"
+    api_version = CANARCHY_API_VERSION
+    supported_extensions = [".mylog"]
+
+    def read(self, source: str) -> Iterator[CanFrame]:
+        with open(source) as f:
+            for line in f:
+                arb_id, data_hex = line.strip().split(",")
+                yield CanFrame(
+                    arbitration_id=int(arb_id, 16),
+                    data=bytes.fromhex(data_hex),
+                )
+```
+
+Entry point group: `canarchy.input_adapters`.
+
+## Compatibility Policy
+
+The `api_version` string will increment when any breaking change is made to a plugin protocol
+(removed method, changed required signature). Additive changes — new optional `**kwargs`,
+new metadata fields in `ProcessorResult` — do not require a version bump.

--- a/docs/tests/plugin-model.md
+++ b/docs/tests/plugin-model.md
@@ -1,0 +1,248 @@
+# Test Spec: Plugin Model
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| Status | Implemented |
+| Design doc | `docs/design/plugin-model.md` |
+| Test file | `tests/test_plugins.py` |
+
+---
+
+## Requirement Traceability
+
+| REQ ID | Description summary | TEST IDs |
+|--------|---------------------|----------|
+| `REQ-PLUGIN-01` | Registry builds with all three built-in RE processors registered | `TEST-PLUGIN-01` |
+| `REQ-PLUGIN-02` | `get_processor` returns the registered processor by name | `TEST-PLUGIN-02` |
+| `REQ-PLUGIN-03` | `get_processor` returns None for an unknown name | `TEST-PLUGIN-03` |
+| `REQ-PLUGIN-04` | Duplicate processor name raises `PLUGIN_DUPLICATE` | `TEST-PLUGIN-04` |
+| `REQ-PLUGIN-05` | Incompatible `api_version` raises `PLUGIN_INCOMPATIBLE` | `TEST-PLUGIN-05` |
+| `REQ-PLUGIN-06` | Object not satisfying the protocol raises `PLUGIN_INVALID` | `TEST-PLUGIN-06` |
+| `REQ-PLUGIN-07` | `reset_registry()` causes the next `get_registry()` call to rebuild | `TEST-PLUGIN-07` |
+| `REQ-PLUGIN-08` | `list_processors()` returns name and api_version for each processor | `TEST-PLUGIN-08` |
+| `REQ-PLUGIN-09` | `list_sinks()` and `list_input_adapters()` return empty lists initially | `TEST-PLUGIN-09` |
+| `REQ-PLUGIN-10` | Sink duplicate name raises `PLUGIN_DUPLICATE` | `TEST-PLUGIN-10` |
+| `REQ-PLUGIN-11` | Input adapter duplicate name raises `PLUGIN_DUPLICATE` | `TEST-PLUGIN-11` |
+| `REQ-PLUGIN-12` | Built-in `counter-candidates` processor produces correct output shape | `TEST-PLUGIN-12` |
+| `REQ-PLUGIN-13` | Built-in `entropy-candidates` processor produces correct output shape | `TEST-PLUGIN-13` |
+| `REQ-PLUGIN-14` | Built-in `signal-analysis` processor produces correct output shape | `TEST-PLUGIN-14` |
+| `REQ-PLUGIN-15` | `re signals` CLI command routes through registry and returns valid output | `TEST-PLUGIN-15` |
+| `REQ-PLUGIN-16` | `re counters` CLI command routes through registry and returns valid output | `TEST-PLUGIN-16` |
+| `REQ-PLUGIN-17` | `re entropy` CLI command routes through registry and returns valid output | `TEST-PLUGIN-17` |
+| `REQ-PLUGIN-18` | Third-party processor registered manually is discoverable and callable | `TEST-PLUGIN-18` |
+| `REQ-PLUGIN-19` | `ProcessorResult` warnings list is present even when empty | `TEST-PLUGIN-19` |
+
+---
+
+## Test Cases
+
+### TEST-PLUGIN-01 — Default registry contains all three built-in RE processors
+
+```gherkin
+Given  a freshly reset plugin registry
+When   get_registry() is called
+Then   processors named 'counter-candidates', 'entropy-candidates', and 'signal-analysis' shall be registered
+```
+
+---
+
+### TEST-PLUGIN-02 — get_processor returns the processor by exact name
+
+```gherkin
+Given  the default registry
+When   get_processor('signal-analysis') is called
+Then   the returned object shall have name == 'signal-analysis' and api_version == '1'
+```
+
+---
+
+### TEST-PLUGIN-03 — get_processor returns None for unknown name
+
+```gherkin
+Given  the default registry
+When   get_processor('nonexistent-processor') is called
+Then   the return value shall be None
+```
+
+---
+
+### TEST-PLUGIN-04 — Duplicate processor registration raises PLUGIN_DUPLICATE
+
+```gherkin
+Given  a fresh PluginRegistry
+And    a minimal processor with name 'test-proc' has been registered
+When   a second processor with name 'test-proc' is registered
+Then   a PluginError with code 'PLUGIN_DUPLICATE' shall be raised
+```
+
+---
+
+### TEST-PLUGIN-05 — Incompatible api_version raises PLUGIN_INCOMPATIBLE
+
+```gherkin
+Given  a fresh PluginRegistry
+When   a processor with api_version '99' is registered
+Then   a PluginError with code 'PLUGIN_INCOMPATIBLE' shall be raised
+And    the error message shall name the plugin and the required api_version
+```
+
+---
+
+### TEST-PLUGIN-06 — Object missing required members raises PLUGIN_INVALID
+
+```gherkin
+Given  a fresh PluginRegistry
+When   an object that does not implement ProcessorPlugin (missing 'process') is registered
+Then   a PluginError with code 'PLUGIN_INVALID' shall be raised
+```
+
+---
+
+### TEST-PLUGIN-07 — reset_registry causes rebuild on next access
+
+```gherkin
+Given  get_registry() has been called and the registry is cached
+When   reset_registry() is called
+And    get_registry() is called again
+Then   the returned registry shall be a new instance
+And    it shall contain the built-in processors
+```
+
+---
+
+### TEST-PLUGIN-08 — list_processors returns name and api_version
+
+```gherkin
+Given  the default registry
+When   list_processors() is called
+Then   the result shall be a list of dicts each with 'name' and 'api_version' keys
+And    each entry's api_version shall equal '1'
+```
+
+---
+
+### TEST-PLUGIN-09 — list_sinks and list_input_adapters return empty by default
+
+```gherkin
+Given  a fresh PluginRegistry with no sinks or input adapters registered
+When   list_sinks() and list_input_adapters() are called
+Then   both shall return empty lists
+```
+
+---
+
+### TEST-PLUGIN-10 — Duplicate sink name raises PLUGIN_DUPLICATE
+
+```gherkin
+Given  a fresh PluginRegistry
+And    a sink named 'test-sink' has been registered
+When   a second sink named 'test-sink' is registered
+Then   a PluginError with code 'PLUGIN_DUPLICATE' shall be raised
+```
+
+---
+
+### TEST-PLUGIN-11 — Duplicate input adapter name raises PLUGIN_DUPLICATE
+
+```gherkin
+Given  a fresh PluginRegistry
+And    an input adapter named 'test-adapter' has been registered
+When   a second input adapter named 'test-adapter' is registered
+Then   a PluginError with code 'PLUGIN_DUPLICATE' shall be raised
+```
+
+---
+
+### TEST-PLUGIN-12 — counter-candidates processor produces correct output shape
+
+```gherkin
+Given  a list of CanFrames with a detectable counter field
+When   get_registry().get_processor('counter-candidates').process(frames) is called
+Then   the result shall be a ProcessorResult
+And    result.candidates shall be a non-empty list
+And    each candidate dict shall have 'arbitration_id', 'start_bit', 'bit_length', and 'score' keys
+And    result.metadata['analysis'] shall equal 'counter_detection'
+```
+
+---
+
+### TEST-PLUGIN-13 — entropy-candidates processor produces correct output shape
+
+```gherkin
+Given  a list of CanFrames with varying payload bytes
+When   get_registry().get_processor('entropy-candidates').process(frames) is called
+Then   the result shall be a ProcessorResult
+And    result.metadata['analysis'] shall equal 'entropy_ranking'
+```
+
+---
+
+### TEST-PLUGIN-14 — signal-analysis processor produces correct output shape
+
+```gherkin
+Given  a list of CanFrames with a detectable signal field
+When   get_registry().get_processor('signal-analysis').process(frames) is called
+Then   the result shall be a ProcessorResult
+And    result.metadata shall contain 'analysis_by_id' and 'low_sample_ids' keys
+And    result.metadata['analysis'] shall equal 'signal_inference'
+```
+
+---
+
+### TEST-PLUGIN-15 — re signals CLI command produces valid JSON output
+
+```gherkin
+Given  a candump fixture with known signal fields
+When   canarchy re signals <fixture> --json is run
+Then   exit code shall be 0
+And    output['ok'] shall be True
+And    output['data'] shall contain 'candidates' and 'analysis_by_id'
+```
+
+---
+
+### TEST-PLUGIN-16 — re counters CLI command produces valid JSON output
+
+```gherkin
+Given  a candump fixture with a known counter field
+When   canarchy re counters <fixture> --json is run
+Then   exit code shall be 0
+And    output['ok'] shall be True
+And    output['data']['candidates'] shall be non-empty
+```
+
+---
+
+### TEST-PLUGIN-17 — re entropy CLI command produces valid JSON output
+
+```gherkin
+Given  a candump fixture with non-constant payload bytes
+When   canarchy re entropy <fixture> --json is run
+Then   exit code shall be 0
+And    output['ok'] shall be True
+And    output['data']['candidates'] shall be a list
+```
+
+---
+
+### TEST-PLUGIN-18 — Manually registered third-party processor is discoverable
+
+```gherkin
+Given  a fresh PluginRegistry
+And    a custom processor with name 'custom-proc' and api_version '1' is registered
+When   get_processor('custom-proc') is called
+Then   the returned processor shall be the registered instance
+And    calling process(frames) shall return a ProcessorResult
+```
+
+---
+
+### TEST-PLUGIN-19 — ProcessorResult warnings is always a list
+
+```gherkin
+Given  any processor producing no warnings
+When   process() is called and result.warnings is inspected
+Then   result.warnings shall be an empty list, not None
+```

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -2764,62 +2764,80 @@ def _build_match_catalog(
 def reverse_engineering_payload(
     args: argparse.Namespace,
 ) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
+    from canarchy.plugins import get_registry
+
     transport = LocalTransport()
     if args.command == "re signals":
         frames = transport.frames_from_file(args.file)
-        analysis = signal_analysis(frames)
-        warnings: list[str] = []
-        if analysis["candidate_count"] == 0:
-            warnings.append("No likely signal candidates met the current heuristic threshold.")
+        processor = get_registry().get_processor("signal-analysis")
+        if processor is None:
+            raise CommandError(
+                command=args.command,
+                exit_code=EXIT_USER_ERROR,
+                errors=[ErrorDetail(
+                    code="PLUGIN_NOT_FOUND",
+                    message="Built-in processor 'signal-analysis' is not registered.",
+                    hint="Ensure the plugin registry has not been modified.",
+                )],
+            )
+        result = processor.process(frames)
         return (
             {
                 "mode": "passive",
                 "file": args.file,
-                "analysis": "signal_inference",
-                "candidate_count": analysis["candidate_count"],
-                "candidates": analysis["candidates"],
-                "analysis_by_id": analysis["analysis_by_id"],
-                "low_sample_ids": analysis["low_sample_ids"],
-                "implementation": "file-backed heuristic analysis",
+                **result.metadata,
+                "candidates": result.candidates,
             },
             [],
-            warnings,
+            result.warnings,
         )
     if args.command == "re counters":
         frames = transport.frames_from_file(args.file)
-        candidates = counter_candidates(frames)
-        warnings: list[str] = []
-        if not candidates:
-            warnings.append("No likely counters met the current heuristic threshold.")
+        processor = get_registry().get_processor("counter-candidates")
+        if processor is None:
+            raise CommandError(
+                command=args.command,
+                exit_code=EXIT_USER_ERROR,
+                errors=[ErrorDetail(
+                    code="PLUGIN_NOT_FOUND",
+                    message="Built-in processor 'counter-candidates' is not registered.",
+                    hint="Ensure the plugin registry has not been modified.",
+                )],
+            )
+        result = processor.process(frames)
         return (
             {
                 "mode": "passive",
                 "file": args.file,
-                "analysis": "counter_detection",
-                "candidate_count": len(candidates),
-                "candidates": candidates,
-                "implementation": "file-backed heuristic analysis",
+                **result.metadata,
+                "candidates": result.candidates,
             },
             [],
-            warnings,
+            result.warnings,
         )
     if args.command == "re entropy":
         frames = transport.frames_from_file(args.file)
-        candidates = entropy_candidates(frames)
-        warnings: list[str] = []
-        if not candidates:
-            warnings.append("No arbitration IDs with payload bytes were found for entropy analysis.")
+        processor = get_registry().get_processor("entropy-candidates")
+        if processor is None:
+            raise CommandError(
+                command=args.command,
+                exit_code=EXIT_USER_ERROR,
+                errors=[ErrorDetail(
+                    code="PLUGIN_NOT_FOUND",
+                    message="Built-in processor 'entropy-candidates' is not registered.",
+                    hint="Ensure the plugin registry has not been modified.",
+                )],
+            )
+        result = processor.process(frames)
         return (
             {
                 "mode": "passive",
                 "file": args.file,
-                "analysis": "entropy_ranking",
-                "candidate_count": len(candidates),
-                "candidates": candidates,
-                "implementation": "file-backed heuristic analysis",
+                **result.metadata,
+                "candidates": result.candidates,
             },
             [],
-            warnings,
+            result.warnings,
         )
     if args.command in {"re match-dbc", "re shortlist-dbc"}:
         capture_file = args.capture

--- a/src/canarchy/plugins.py
+++ b/src/canarchy/plugins.py
@@ -75,55 +75,40 @@ class PluginRegistry:
     # --- registration ---
 
     def register_processor(self, plugin: ProcessorPlugin) -> None:
-        """Register a processor plugin. Raises PluginError on version mismatch or duplicate name."""
-        _require_api_version(plugin.api_version, plugin.name)
-        if not isinstance(plugin, ProcessorPlugin):
-            raise PluginError(
-                code="PLUGIN_INVALID",
-                message=f"Plugin '{plugin.name}' does not implement ProcessorPlugin.",
-                hint="Ensure the class has 'name', 'api_version', and 'process(frames, **kwargs)' members.",
-            )
-        if plugin.name in self._processors:
+        """Register a processor plugin. Raises PluginError on invalid interface, version mismatch, or duplicate name."""
+        name = _require_interface(plugin, ProcessorPlugin, "process(frames, **kwargs)")
+        _require_api_version(plugin.api_version, name)
+        if name in self._processors:
             raise PluginError(
                 code="PLUGIN_DUPLICATE",
-                message=f"A processor named '{plugin.name}' is already registered.",
+                message=f"A processor named '{name}' is already registered.",
                 hint="Use a unique name or unregister the existing processor first.",
             )
-        self._processors[plugin.name] = plugin
+        self._processors[name] = plugin
 
     def register_sink(self, plugin: SinkPlugin) -> None:
-        """Register a sink plugin. Raises PluginError on version mismatch or duplicate name."""
-        _require_api_version(plugin.api_version, plugin.name)
-        if not isinstance(plugin, SinkPlugin):
-            raise PluginError(
-                code="PLUGIN_INVALID",
-                message=f"Plugin '{plugin.name}' does not implement SinkPlugin.",
-                hint="Ensure the class has 'name', 'api_version', 'supported_formats', and 'write()' members.",
-            )
-        if plugin.name in self._sinks:
+        """Register a sink plugin. Raises PluginError on invalid interface, version mismatch, or duplicate name."""
+        name = _require_interface(plugin, SinkPlugin, "supported_formats and write()")
+        _require_api_version(plugin.api_version, name)
+        if name in self._sinks:
             raise PluginError(
                 code="PLUGIN_DUPLICATE",
-                message=f"A sink named '{plugin.name}' is already registered.",
+                message=f"A sink named '{name}' is already registered.",
                 hint="Use a unique name or unregister the existing sink first.",
             )
-        self._sinks[plugin.name] = plugin
+        self._sinks[name] = plugin
 
     def register_input_adapter(self, plugin: InputAdapterPlugin) -> None:
-        """Register an input adapter plugin. Raises PluginError on version mismatch or duplicate name."""
-        _require_api_version(plugin.api_version, plugin.name)
-        if not isinstance(plugin, InputAdapterPlugin):
-            raise PluginError(
-                code="PLUGIN_INVALID",
-                message=f"Plugin '{plugin.name}' does not implement InputAdapterPlugin.",
-                hint="Ensure the class has 'name', 'api_version', 'supported_extensions', and 'read()' members.",
-            )
-        if plugin.name in self._input_adapters:
+        """Register an input adapter plugin. Raises PluginError on invalid interface, version mismatch, or duplicate name."""
+        name = _require_interface(plugin, InputAdapterPlugin, "supported_extensions and read()")
+        _require_api_version(plugin.api_version, name)
+        if name in self._input_adapters:
             raise PluginError(
                 code="PLUGIN_DUPLICATE",
-                message=f"An input adapter named '{plugin.name}' is already registered.",
+                message=f"An input adapter named '{name}' is already registered.",
                 hint="Use a unique name or unregister the existing adapter first.",
             )
-        self._input_adapters[plugin.name] = plugin
+        self._input_adapters[name] = plugin
 
     # --- lookup ---
 
@@ -156,6 +141,29 @@ class PluginRegistry:
             }
             for a in self._input_adapters.values()
         ]
+
+
+def _require_interface(plugin: Any, protocol: type, required: str) -> str:
+    """Validate that plugin satisfies the protocol and return its name.
+
+    Raises PluginError(PLUGIN_INVALID) for missing attributes or a failed isinstance check,
+    so callers always receive a structured error instead of a raw AttributeError.
+    """
+    try:
+        name = plugin.name
+    except AttributeError:
+        raise PluginError(
+            code="PLUGIN_INVALID",
+            message=f"Plugin object is missing a 'name' attribute.",
+            hint=f"Ensure the class declares 'name', 'api_version', and {required}.",
+        )
+    if not isinstance(plugin, protocol):
+        raise PluginError(
+            code="PLUGIN_INVALID",
+            message=f"Plugin '{name}' does not implement {protocol.__name__}.",
+            hint=f"Ensure the class declares 'name', 'api_version', and {required}.",
+        )
+    return name
 
 
 def _require_api_version(api_version: str, plugin_name: str) -> None:

--- a/src/canarchy/plugins.py
+++ b/src/canarchy/plugins.py
@@ -1,0 +1,229 @@
+"""Plugin registry: extension points for processors, sinks, and input adapters."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import warnings
+from dataclasses import dataclass, field
+from typing import Any, Iterator, Protocol, runtime_checkable
+
+from canarchy.models import CanFrame
+
+CANARCHY_API_VERSION = "1"
+
+
+class PluginError(Exception):
+    """Raised for plugin registration and compatibility failures."""
+
+    def __init__(self, code: str, message: str, hint: str | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.hint = hint
+
+
+@dataclass(slots=True, frozen=True)
+class ProcessorResult:
+    """Result returned by a ProcessorPlugin.process() call."""
+
+    candidates: list[dict[str, Any]]
+    metadata: dict[str, Any]
+    warnings: list[str] = field(default_factory=list)
+
+
+@runtime_checkable
+class ProcessorPlugin(Protocol):
+    """Analysis processor: consumes frames and produces ranked candidates."""
+
+    name: str
+    api_version: str
+
+    def process(self, frames: list[CanFrame], **kwargs: Any) -> ProcessorResult: ...
+
+
+@runtime_checkable
+class SinkPlugin(Protocol):
+    """Output sink: writes a serialized command payload to an external destination."""
+
+    name: str
+    api_version: str
+    supported_formats: list[str]
+
+    def write(
+        self, payload: dict[str, Any], destination: str, *, output_format: str = "json"
+    ) -> dict[str, Any]: ...
+
+
+@runtime_checkable
+class InputAdapterPlugin(Protocol):
+    """Input adapter: yields CanFrames from a custom source or file format."""
+
+    name: str
+    api_version: str
+    supported_extensions: list[str]
+
+    def read(self, source: str) -> Iterator[CanFrame]: ...
+
+
+class PluginRegistry:
+    """Registry for built-in and third-party CANarchy plugins."""
+
+    def __init__(self) -> None:
+        self._processors: dict[str, ProcessorPlugin] = {}
+        self._sinks: dict[str, SinkPlugin] = {}
+        self._input_adapters: dict[str, InputAdapterPlugin] = {}
+
+    # --- registration ---
+
+    def register_processor(self, plugin: ProcessorPlugin) -> None:
+        """Register a processor plugin. Raises PluginError on version mismatch or duplicate name."""
+        _require_api_version(plugin.api_version, plugin.name)
+        if not isinstance(plugin, ProcessorPlugin):
+            raise PluginError(
+                code="PLUGIN_INVALID",
+                message=f"Plugin '{plugin.name}' does not implement ProcessorPlugin.",
+                hint="Ensure the class has 'name', 'api_version', and 'process(frames, **kwargs)' members.",
+            )
+        if plugin.name in self._processors:
+            raise PluginError(
+                code="PLUGIN_DUPLICATE",
+                message=f"A processor named '{plugin.name}' is already registered.",
+                hint="Use a unique name or unregister the existing processor first.",
+            )
+        self._processors[plugin.name] = plugin
+
+    def register_sink(self, plugin: SinkPlugin) -> None:
+        """Register a sink plugin. Raises PluginError on version mismatch or duplicate name."""
+        _require_api_version(plugin.api_version, plugin.name)
+        if not isinstance(plugin, SinkPlugin):
+            raise PluginError(
+                code="PLUGIN_INVALID",
+                message=f"Plugin '{plugin.name}' does not implement SinkPlugin.",
+                hint="Ensure the class has 'name', 'api_version', 'supported_formats', and 'write()' members.",
+            )
+        if plugin.name in self._sinks:
+            raise PluginError(
+                code="PLUGIN_DUPLICATE",
+                message=f"A sink named '{plugin.name}' is already registered.",
+                hint="Use a unique name or unregister the existing sink first.",
+            )
+        self._sinks[plugin.name] = plugin
+
+    def register_input_adapter(self, plugin: InputAdapterPlugin) -> None:
+        """Register an input adapter plugin. Raises PluginError on version mismatch or duplicate name."""
+        _require_api_version(plugin.api_version, plugin.name)
+        if not isinstance(plugin, InputAdapterPlugin):
+            raise PluginError(
+                code="PLUGIN_INVALID",
+                message=f"Plugin '{plugin.name}' does not implement InputAdapterPlugin.",
+                hint="Ensure the class has 'name', 'api_version', 'supported_extensions', and 'read()' members.",
+            )
+        if plugin.name in self._input_adapters:
+            raise PluginError(
+                code="PLUGIN_DUPLICATE",
+                message=f"An input adapter named '{plugin.name}' is already registered.",
+                hint="Use a unique name or unregister the existing adapter first.",
+            )
+        self._input_adapters[plugin.name] = plugin
+
+    # --- lookup ---
+
+    def get_processor(self, name: str) -> ProcessorPlugin | None:
+        return self._processors.get(name)
+
+    def get_sink(self, name: str) -> SinkPlugin | None:
+        return self._sinks.get(name)
+
+    def get_input_adapter(self, name: str) -> InputAdapterPlugin | None:
+        return self._input_adapters.get(name)
+
+    # --- inspection ---
+
+    def list_processors(self) -> list[dict[str, Any]]:
+        return [{"name": p.name, "api_version": p.api_version} for p in self._processors.values()]
+
+    def list_sinks(self) -> list[dict[str, Any]]:
+        return [
+            {"name": s.name, "api_version": s.api_version, "supported_formats": s.supported_formats}
+            for s in self._sinks.values()
+        ]
+
+    def list_input_adapters(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": a.name,
+                "api_version": a.api_version,
+                "supported_extensions": a.supported_extensions,
+            }
+            for a in self._input_adapters.values()
+        ]
+
+
+def _require_api_version(api_version: str, plugin_name: str) -> None:
+    if api_version != CANARCHY_API_VERSION:
+        raise PluginError(
+            code="PLUGIN_INCOMPATIBLE",
+            message=(
+                f"Plugin '{plugin_name}' declares api_version '{api_version}' "
+                f"but this CANarchy build requires '{CANARCHY_API_VERSION}'."
+            ),
+            hint=f"Update the plugin to declare api_version='{CANARCHY_API_VERSION}'.",
+        )
+
+
+_registry: PluginRegistry | None = None
+
+
+def get_registry() -> PluginRegistry:
+    """Return the module-level plugin registry, building it on first access."""
+    global _registry
+    if _registry is None:
+        _registry = _build_default_registry()
+    return _registry
+
+
+def _build_default_registry() -> PluginRegistry:
+    registry = PluginRegistry()
+
+    from canarchy.re_processors import (
+        CounterCandidateProcessor,
+        EntropyCandidateProcessor,
+        SignalAnalysisProcessor,
+    )
+
+    registry.register_processor(CounterCandidateProcessor())
+    registry.register_processor(EntropyCandidateProcessor())
+    registry.register_processor(SignalAnalysisProcessor())
+
+    _load_entry_point_plugins(registry)
+    return registry
+
+
+def _load_entry_point_plugins(registry: PluginRegistry) -> None:
+    """Discover and register third-party plugins declared via Python entry points."""
+    groups: list[tuple[str, Any]] = [
+        ("canarchy.processors", registry.register_processor),
+        ("canarchy.sinks", registry.register_sink),
+        ("canarchy.input_adapters", registry.register_input_adapter),
+    ]
+    for group, register_fn in groups:
+        try:
+            eps = importlib.metadata.entry_points(group=group)
+        except Exception:
+            continue
+        for ep in eps:
+            try:
+                plugin_cls = ep.load()
+                register_fn(plugin_cls())
+            except PluginError:
+                raise
+            except Exception as exc:
+                warnings.warn(
+                    f"Failed to load plugin '{ep.name}' from group '{group}': {exc}",
+                    stacklevel=2,
+                )
+
+
+def reset_registry() -> None:
+    """Reset the module-level registry singleton (intended for tests)."""
+    global _registry
+    _registry = None

--- a/src/canarchy/re_processors.py
+++ b/src/canarchy/re_processors.py
@@ -1,0 +1,77 @@
+"""Built-in processor plugins for reverse-engineering heuristic analysis."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from canarchy.models import CanFrame
+from canarchy.plugins import CANARCHY_API_VERSION, ProcessorResult
+from canarchy.reverse_engineering import counter_candidates, entropy_candidates, signal_analysis
+
+
+class CounterCandidateProcessor:
+    """Processor plugin: counter field detection via monotonicity heuristics."""
+
+    name = "counter-candidates"
+    api_version = CANARCHY_API_VERSION
+
+    def process(self, frames: list[CanFrame], **kwargs: Any) -> ProcessorResult:
+        candidates = counter_candidates(frames)
+        warns = []
+        if not candidates:
+            warns.append("No likely counters met the current heuristic threshold.")
+        return ProcessorResult(
+            candidates=candidates,
+            metadata={
+                "analysis": "counter_detection",
+                "candidate_count": len(candidates),
+                "implementation": "file-backed heuristic analysis",
+            },
+            warnings=warns,
+        )
+
+
+class EntropyCandidateProcessor:
+    """Processor plugin: byte-level Shannon entropy ranking."""
+
+    name = "entropy-candidates"
+    api_version = CANARCHY_API_VERSION
+
+    def process(self, frames: list[CanFrame], **kwargs: Any) -> ProcessorResult:
+        candidates = entropy_candidates(frames)
+        warns = []
+        if not candidates:
+            warns.append("No arbitration IDs with payload bytes were found for entropy analysis.")
+        return ProcessorResult(
+            candidates=candidates,
+            metadata={
+                "analysis": "entropy_ranking",
+                "candidate_count": len(candidates),
+                "implementation": "file-backed heuristic analysis",
+            },
+            warnings=warns,
+        )
+
+
+class SignalAnalysisProcessor:
+    """Processor plugin: bit-field signal inference via change-rate and span heuristics."""
+
+    name = "signal-analysis"
+    api_version = CANARCHY_API_VERSION
+
+    def process(self, frames: list[CanFrame], **kwargs: Any) -> ProcessorResult:
+        analysis = signal_analysis(frames)
+        warns = []
+        if analysis["candidate_count"] == 0:
+            warns.append("No likely signal candidates met the current heuristic threshold.")
+        return ProcessorResult(
+            candidates=analysis["candidates"],
+            metadata={
+                "analysis": "signal_inference",
+                "candidate_count": analysis["candidate_count"],
+                "analysis_by_id": analysis["analysis_by_id"],
+                "low_sample_ids": analysis["low_sample_ids"],
+                "implementation": "file-backed heuristic analysis",
+            },
+            warnings=warns,
+        )

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -176,6 +176,28 @@ class RegistrationValidationTests(unittest.TestCase):
             self.registry.register_processor(NoProcessMethod())  # type: ignore[arg-type]
         self.assertEqual(ctx.exception.code, "PLUGIN_INVALID")
 
+    def test_plugin_missing_name_attribute_raises_plugin_invalid(self) -> None:
+        class NoNameAttr:
+            api_version = CANARCHY_API_VERSION
+
+            def process(self, frames: list[CanFrame], **kwargs: Any) -> ProcessorResult:
+                return ProcessorResult(candidates=[], metadata={})
+
+        with self.assertRaises(PluginError) as ctx:
+            self.registry.register_processor(NoNameAttr())  # type: ignore[arg-type]
+        self.assertEqual(ctx.exception.code, "PLUGIN_INVALID")
+
+    def test_plugin_missing_name_does_not_raise_attribute_error(self) -> None:
+        class NoNameAttr:
+            api_version = CANARCHY_API_VERSION
+
+        try:
+            self.registry.register_processor(NoNameAttr())  # type: ignore[arg-type]
+        except PluginError:
+            pass
+        except AttributeError:
+            self.fail("register_processor raised AttributeError instead of PluginError")
+
     def test_incompatible_sink_version_raises_plugin_incompatible(self) -> None:
         class BadSinkVersion:
             name = "bad-sink"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,363 @@
+"""Tests for the plugin registry, built-in processors, and CLI integration."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import unittest
+from pathlib import Path
+from typing import Any, Iterator
+
+from canarchy.models import CanFrame
+from canarchy.plugins import (
+    CANARCHY_API_VERSION,
+    InputAdapterPlugin,
+    PluginError,
+    PluginRegistry,
+    ProcessorPlugin,
+    ProcessorResult,
+    SinkPlugin,
+    get_registry,
+    reset_registry,
+)
+from canarchy.transport import LocalTransport
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def run_cli(*argv: str) -> tuple[int, str, str]:
+    from canarchy.cli import main
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        exit_code = main(argv)
+    return exit_code, stdout.getvalue(), stderr.getvalue()
+
+
+def tearDownModule() -> None:
+    reset_registry()
+
+
+# ---------------------------------------------------------------------------
+# Minimal stubs used across multiple tests
+# ---------------------------------------------------------------------------
+
+class _MinimalProcessor:
+    name = "test-proc"
+    api_version = CANARCHY_API_VERSION
+
+    def process(self, frames: list[CanFrame], **kwargs: Any) -> ProcessorResult:
+        return ProcessorResult(candidates=[], metadata={})
+
+
+class _MinimalSink:
+    name = "test-sink"
+    api_version = CANARCHY_API_VERSION
+    supported_formats = ["json"]
+
+    def write(
+        self, payload: dict[str, Any], destination: str, *, output_format: str = "json"
+    ) -> dict[str, Any]:
+        return {}
+
+
+class _MinimalAdapter:
+    name = "test-adapter"
+    api_version = CANARCHY_API_VERSION
+    supported_extensions = [".test"]
+
+    def read(self, source: str) -> Iterator[CanFrame]:
+        return iter([])
+
+
+# ---------------------------------------------------------------------------
+# TEST-PLUGIN-01  Default registry has all three built-in RE processors
+# ---------------------------------------------------------------------------
+
+class DefaultRegistryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_registry()
+
+    def tearDown(self) -> None:
+        reset_registry()
+
+    def test_builtin_processors_registered(self) -> None:
+        registry = get_registry()
+        for name in ("counter-candidates", "entropy-candidates", "signal-analysis"):
+            with self.subTest(name=name):
+                self.assertIsNotNone(registry.get_processor(name))
+
+    def test_builtin_processor_api_versions(self) -> None:
+        registry = get_registry()
+        for name in ("counter-candidates", "entropy-candidates", "signal-analysis"):
+            with self.subTest(name=name):
+                proc = registry.get_processor(name)
+                self.assertEqual(proc.api_version, CANARCHY_API_VERSION)
+
+    def test_get_processor_unknown_returns_none(self) -> None:
+        self.assertIsNone(get_registry().get_processor("nonexistent-processor"))
+
+    def test_list_processors_contains_builtins(self) -> None:
+        entries = get_registry().list_processors()
+        names = {e["name"] for e in entries}
+        self.assertIn("counter-candidates", names)
+        self.assertIn("entropy-candidates", names)
+        self.assertIn("signal-analysis", names)
+
+    def test_list_processors_has_api_version(self) -> None:
+        for entry in get_registry().list_processors():
+            with self.subTest(name=entry["name"]):
+                self.assertIn("api_version", entry)
+                self.assertEqual(entry["api_version"], "1")
+
+    def test_list_sinks_empty_by_default(self) -> None:
+        self.assertEqual(get_registry().list_sinks(), [])
+
+    def test_list_input_adapters_empty_by_default(self) -> None:
+        self.assertEqual(get_registry().list_input_adapters(), [])
+
+    def test_reset_causes_rebuild(self) -> None:
+        first = get_registry()
+        reset_registry()
+        second = get_registry()
+        self.assertIsNot(first, second)
+        self.assertIsNotNone(second.get_processor("signal-analysis"))
+
+
+# ---------------------------------------------------------------------------
+# TEST-PLUGIN-04/05/06  Registration validation
+# ---------------------------------------------------------------------------
+
+class RegistrationValidationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.registry = PluginRegistry()
+
+    def test_duplicate_processor_raises_plugin_duplicate(self) -> None:
+        self.registry.register_processor(_MinimalProcessor())
+        with self.assertRaises(PluginError) as ctx:
+            self.registry.register_processor(_MinimalProcessor())
+        self.assertEqual(ctx.exception.code, "PLUGIN_DUPLICATE")
+
+    def test_duplicate_sink_raises_plugin_duplicate(self) -> None:
+        self.registry.register_sink(_MinimalSink())
+        with self.assertRaises(PluginError) as ctx:
+            self.registry.register_sink(_MinimalSink())
+        self.assertEqual(ctx.exception.code, "PLUGIN_DUPLICATE")
+
+    def test_duplicate_input_adapter_raises_plugin_duplicate(self) -> None:
+        self.registry.register_input_adapter(_MinimalAdapter())
+        with self.assertRaises(PluginError) as ctx:
+            self.registry.register_input_adapter(_MinimalAdapter())
+        self.assertEqual(ctx.exception.code, "PLUGIN_DUPLICATE")
+
+    def test_incompatible_api_version_raises_plugin_incompatible(self) -> None:
+        class BadVersion:
+            name = "bad-version"
+            api_version = "99"
+
+            def process(self, frames: list[CanFrame], **kwargs: Any) -> ProcessorResult:
+                return ProcessorResult(candidates=[], metadata={})
+
+        with self.assertRaises(PluginError) as ctx:
+            self.registry.register_processor(BadVersion())
+        self.assertEqual(ctx.exception.code, "PLUGIN_INCOMPATIBLE")
+        self.assertIn("99", str(ctx.exception))
+        self.assertIn(CANARCHY_API_VERSION, str(ctx.exception))
+
+    def test_invalid_processor_missing_process_raises_plugin_invalid(self) -> None:
+        class NoProcessMethod:
+            name = "no-process"
+            api_version = CANARCHY_API_VERSION
+
+        with self.assertRaises(PluginError) as ctx:
+            self.registry.register_processor(NoProcessMethod())  # type: ignore[arg-type]
+        self.assertEqual(ctx.exception.code, "PLUGIN_INVALID")
+
+    def test_incompatible_sink_version_raises_plugin_incompatible(self) -> None:
+        class BadSinkVersion:
+            name = "bad-sink"
+            api_version = "0"
+            supported_formats = ["json"]
+
+            def write(self, payload: Any, destination: str, *, output_format: str = "json") -> dict:
+                return {}
+
+        with self.assertRaises(PluginError) as ctx:
+            self.registry.register_sink(BadSinkVersion())
+        self.assertEqual(ctx.exception.code, "PLUGIN_INCOMPATIBLE")
+
+    def test_incompatible_adapter_version_raises_plugin_incompatible(self) -> None:
+        class BadAdapterVersion:
+            name = "bad-adapter"
+            api_version = "2"
+            supported_extensions = [".log"]
+
+            def read(self, source: str) -> Iterator[CanFrame]:
+                return iter([])
+
+        with self.assertRaises(PluginError) as ctx:
+            self.registry.register_input_adapter(BadAdapterVersion())
+        self.assertEqual(ctx.exception.code, "PLUGIN_INCOMPATIBLE")
+
+
+# ---------------------------------------------------------------------------
+# TEST-PLUGIN-12/13/14  Built-in processor output shapes
+# ---------------------------------------------------------------------------
+
+class BuiltinProcessorOutputTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_registry()
+        self.registry = get_registry()
+
+    def tearDown(self) -> None:
+        reset_registry()
+
+    def test_counter_candidates_processor_output_shape(self) -> None:
+        frames = LocalTransport().frames_from_file(str(FIXTURES / "re_counter_nibble.candump"))
+        proc = self.registry.get_processor("counter-candidates")
+        result = proc.process(frames)
+
+        self.assertIsInstance(result, ProcessorResult)
+        self.assertIsInstance(result.candidates, list)
+        self.assertGreater(len(result.candidates), 0)
+        self.assertEqual(result.metadata["analysis"], "counter_detection")
+        self.assertIn("candidate_count", result.metadata)
+        candidate = result.candidates[0]
+        for key in ("arbitration_id", "start_bit", "bit_length", "score"):
+            self.assertIn(key, candidate)
+
+    def test_entropy_candidates_processor_output_shape(self) -> None:
+        frames = LocalTransport().frames_from_file(str(FIXTURES / "re_entropy_mixed.candump"))
+        proc = self.registry.get_processor("entropy-candidates")
+        result = proc.process(frames)
+
+        self.assertIsInstance(result, ProcessorResult)
+        self.assertEqual(result.metadata["analysis"], "entropy_ranking")
+        self.assertIn("candidate_count", result.metadata)
+        self.assertIsInstance(result.warnings, list)
+
+    def test_signal_analysis_processor_output_shape(self) -> None:
+        frames = LocalTransport().frames_from_file(str(FIXTURES / "re_signals_mixed.candump"))
+        proc = self.registry.get_processor("signal-analysis")
+        result = proc.process(frames)
+
+        self.assertIsInstance(result, ProcessorResult)
+        self.assertEqual(result.metadata["analysis"], "signal_inference")
+        self.assertIn("analysis_by_id", result.metadata)
+        self.assertIn("low_sample_ids", result.metadata)
+        self.assertIn("candidate_count", result.metadata)
+
+    def test_processor_result_warnings_always_list(self) -> None:
+        frames = LocalTransport().frames_from_file(str(FIXTURES / "re_counter_nibble.candump"))
+        for name in ("counter-candidates", "entropy-candidates", "signal-analysis"):
+            proc = self.registry.get_processor(name)
+            result = proc.process(frames)
+            with self.subTest(processor=name):
+                self.assertIsInstance(result.warnings, list)
+
+    def test_counter_processor_empty_input_returns_result(self) -> None:
+        proc = self.registry.get_processor("counter-candidates")
+        result = proc.process([])
+        self.assertIsInstance(result, ProcessorResult)
+        self.assertEqual(result.candidates, [])
+        self.assertGreater(len(result.warnings), 0)
+
+    def test_signal_processor_empty_input_returns_result(self) -> None:
+        proc = self.registry.get_processor("signal-analysis")
+        result = proc.process([])
+        self.assertIsInstance(result, ProcessorResult)
+        self.assertEqual(result.candidates, [])
+
+    def test_entropy_processor_empty_input_returns_result(self) -> None:
+        proc = self.registry.get_processor("entropy-candidates")
+        result = proc.process([])
+        self.assertIsInstance(result, ProcessorResult)
+        self.assertEqual(result.candidates, [])
+
+
+# ---------------------------------------------------------------------------
+# TEST-PLUGIN-18  Custom third-party processor round-trip
+# ---------------------------------------------------------------------------
+
+class ThirdPartyProcessorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.registry = PluginRegistry()
+
+    def test_custom_processor_registered_and_callable(self) -> None:
+        class CustomProc:
+            name = "custom-proc"
+            api_version = CANARCHY_API_VERSION
+
+            def process(self, frames: list[CanFrame], **kwargs: Any) -> ProcessorResult:
+                return ProcessorResult(
+                    candidates=[{"count": len(frames)}],
+                    metadata={"analysis": "custom"},
+                )
+
+        self.registry.register_processor(CustomProc())
+        proc = self.registry.get_processor("custom-proc")
+        self.assertIsNotNone(proc)
+        self.assertEqual(proc.name, "custom-proc")
+
+        result = proc.process([])
+        self.assertIsInstance(result, ProcessorResult)
+        self.assertEqual(result.candidates[0]["count"], 0)
+
+    def test_custom_sink_registered_and_listable(self) -> None:
+        self.registry.register_sink(_MinimalSink())
+        entries = self.registry.list_sinks()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["name"], "test-sink")
+        self.assertIn("supported_formats", entries[0])
+
+    def test_custom_adapter_registered_and_listable(self) -> None:
+        self.registry.register_input_adapter(_MinimalAdapter())
+        entries = self.registry.list_input_adapters()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["name"], "test-adapter")
+        self.assertIn("supported_extensions", entries[0])
+
+
+# ---------------------------------------------------------------------------
+# TEST-PLUGIN-15/16/17  CLI integration: RE commands route through registry
+# ---------------------------------------------------------------------------
+
+class CliIntegrationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_registry()
+
+    def tearDown(self) -> None:
+        reset_registry()
+
+    def test_re_signals_returns_ok_json(self) -> None:
+        code, out, _ = run_cli("re", "signals", str(FIXTURES / "re_signals_mixed.candump"), "--json")
+        self.assertEqual(code, 0)
+        data = json.loads(out)
+        self.assertTrue(data["ok"])
+        self.assertIn("candidates", data["data"])
+        self.assertIn("analysis_by_id", data["data"])
+
+    def test_re_counters_returns_ok_json(self) -> None:
+        code, out, _ = run_cli("re", "counters", str(FIXTURES / "re_counter_nibble.candump"), "--json")
+        self.assertEqual(code, 0)
+        data = json.loads(out)
+        self.assertTrue(data["ok"])
+        self.assertGreater(len(data["data"]["candidates"]), 0)
+
+    def test_re_entropy_returns_ok_json(self) -> None:
+        code, out, _ = run_cli("re", "entropy", str(FIXTURES / "re_entropy_mixed.candump"), "--json")
+        self.assertEqual(code, 0)
+        data = json.loads(out)
+        self.assertTrue(data["ok"])
+        self.assertIn("candidates", data["data"])
+
+    def test_re_signals_mode_and_file_in_output(self) -> None:
+        fixture = str(FIXTURES / "re_signals_mixed.candump")
+        code, out, _ = run_cli("re", "signals", fixture, "--json")
+        self.assertEqual(code, 0)
+        data = json.loads(out)
+        self.assertEqual(data["data"]["mode"], "passive")
+        self.assertEqual(data["data"]["file"], fixture)


### PR DESCRIPTION
## Summary

- Adds `src/canarchy/plugins.py`: a `PluginRegistry` with three extension points (`ProcessorPlugin`, `SinkPlugin`, `InputAdapterPlugin`), API version gating, duplicate/invalid rejection, and third-party discovery via Python entry points (`canarchy.processors`, `canarchy.sinks`, `canarchy.input_adapters`)
- Adds `src/canarchy/re_processors.py`: `CounterCandidateProcessor`, `EntropyCandidateProcessor`, and `SignalAnalysisProcessor` — built-in proof-of-contract implementations wrapping the existing heuristic analysis functions
- Migrates `re signals`, `re counters`, and `re entropy` in `cli.py` to route through `get_registry()` instead of calling analysis functions directly; CLI surface and output envelope are unchanged
- Adds `tests/test_plugins.py`: 29 tests covering registry construction, version/duplicate/invalid validation, built-in processor output shapes, and CLI integration
- Adds `docs/design/plugin-model.md`, `docs/tests/plugin-model.md`, `docs/plugin-guide.md`, and updates `docs/architecture.md`

## Design decisions

- Follows the existing DBC and skills provider pattern: lazy singleton via `get_registry()`, reset-able in tests via `reset_registry()`, error-isolated third-party loading
- `CANARCHY_API_VERSION = "1"` is an explicit compatibility gate; incompatible plugins are rejected immediately with a structured `PluginError`
- Third-party entry point failures emit `warnings.warn` (non-fatal) unless the error is a `PluginError` (version/duplicate), which propagates so authors can diagnose it
- Command registration via plugins is deferred to a later phase per the planning comment on #33

## Test plan

- [x] All 29 new plugin tests pass
- [x] Full suite: 504 passed, 1 skipped — no regressions

https://claude.ai/code/session_019MEY16S2ChcXdo5bd6pKNZ

---
_Generated by [Claude Code](https://claude.ai/code/session_019MEY16S2ChcXdo5bd6pKNZ)_