### PR TITLE
feat: add dataset streaming workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -439,6 +439,15 @@ canarchy
     fetch
     cache list
     cache refresh
+  datasets
+    provider list
+    search
+    inspect
+    fetch
+    cache list
+    cache refresh
+    convert
+    stream
   export
   session
     save

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+* Added `canarchy datasets stream` for chunked streaming of downloaded dataset files to candump or JSONL, including JSONL provenance metadata for provider refs, frame offsets, and chunk positions so large datasets can be piped into analysis without buffering the full conversion in memory.
+
 ## [0.6.0] - 2026-04-28
 
 ### Added

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -91,6 +91,7 @@ The current MCP surface exposes a curated non-interactive subset of the CLI. Spa
 Current exclusions:
 
 * skills provider and cache commands such as `skills search` and `skills fetch`
+* dataset provider and streaming commands such as `datasets search`, `datasets fetch`, and `datasets stream`
 * CLI-only workflows such as `j1939 compare` that are not yet exposed as MCP tools
 * CLI-only workflows such as `j1939 faults` and `re signals` that are not yet exposed as MCP tools
 * interactive or service commands such as `shell`, `tui`, and `mcp serve`
@@ -154,6 +155,6 @@ tool: send {"interface": "vcan0", "frame_id": "0x7DF", "data": "0201F1"}
 
 ### Notes
 
-* Streaming is not supported in v1 — live-capture tools (`capture`, `gateway`) return a buffered batch from the active backend.
+* MCP streaming is not supported in v1 — live-capture tools (`capture`, `gateway`) return a buffered batch from the active backend. Use CLI `datasets stream` for dataset-file JSONL or candump pipelines.
 * `shell`, `tui`, and `mcp serve` are not exposed as MCP tools.
 * Error codes are identical to the CLI, so existing JSON-parsing logic transfers without changes.

--- a/docs/command_spec.md
+++ b/docs/command_spec.md
@@ -14,6 +14,7 @@ Implemented and verified in the current codebase:
 * structured `export` for capture files and saved sessions
 * DBC-backed `decode`, `encode`, and `dbc inspect`
 * DBC provider workflows for `dbc provider list`, `dbc search`, `dbc fetch`, `dbc cache list`, `dbc cache prune`, and `dbc cache refresh`
+* dataset provider workflows for `datasets provider list`, `datasets search`, `datasets inspect`, `datasets fetch`, `datasets cache list`, `datasets cache refresh`, `datasets convert`, and `datasets stream`
 * J1939 `monitor`, `decode`, `pgn`, `spn`, `tp`, `dm1`, `faults`, `summary`, `inventory`, and `compare`
 * session `save`, `load`, and `show`
 * shell one-shot command execution
@@ -427,6 +428,85 @@ Notes:
 * `skills fetch` returns both the cached manifest path and the cached skill entry path
 * skills provider/cache commands are currently CLI-only and are not exposed as MCP tools, resources, or prompts in phase 1
 * agents should use skills as workflow descriptors: search, fetch, inspect compatibility/provenance, then run referenced CANarchy commands explicitly
+
+### datasets provider list
+
+List registered public CAN dataset providers.
+
+```bash
+canarchy datasets provider list [--json|--jsonl|--table|--raw]
+```
+
+### datasets search
+
+Search public CAN dataset provider catalogs by name, protocol, or keyword.
+
+```bash
+canarchy datasets search [query] [--provider <name>] [--limit <n>] [--json|--jsonl|--table|--raw]
+```
+
+### datasets inspect
+
+Show full metadata for a dataset ref.
+
+```bash
+canarchy datasets inspect <provider>:<dataset> [--json|--jsonl|--table|--raw]
+```
+
+### datasets fetch
+
+Record dataset provenance in the local cache. This does not download large dataset payloads.
+
+```bash
+canarchy datasets fetch <provider>:<dataset> [--json|--jsonl|--table|--raw]
+```
+
+### datasets cache list
+
+List cached dataset provider manifests and provenance records.
+
+```bash
+canarchy datasets cache list [--json|--jsonl|--table|--raw]
+```
+
+### datasets cache refresh
+
+Refresh the built-in dataset catalog manifest.
+
+```bash
+canarchy datasets cache refresh [--provider <name>] [--json|--jsonl|--table|--raw]
+```
+
+### datasets convert
+
+Convert a downloaded dataset file to a CANarchy-compatible capture format.
+
+```bash
+canarchy datasets convert <file> --source-format hcrl-csv --format candump|jsonl [--output <path>] [--json|--jsonl|--table|--raw]
+```
+
+### datasets stream
+
+Stream a downloaded dataset file to candump or JSONL without loading the full conversion into memory.
+
+```bash
+canarchy datasets stream <file> --source-format hcrl-csv --format candump|jsonl [--chunk-size <n>] [--provider-ref <ref>] [--output <path>] [--json]
+```
+
+Examples:
+
+```bash
+canarchy datasets stream sample.csv --source-format hcrl-csv --format jsonl --provider-ref catalog:hcrl-car-hacking
+canarchy datasets stream sample.csv --source-format hcrl-csv --format candump --output sample.candump
+canarchy datasets stream sample.csv --source-format hcrl-csv --format jsonl --json
+```
+
+Notes:
+
+* without `--json`, stream records are written directly to stdout or `--output`
+* JSONL stream records include `payload.dataset.provider_ref`, `frame_offset`, `chunk_index`, and `chunk_position`
+* with `--json`, stdout contains the standard result envelope and reports `frame_count` and `chunks`
+* live-bus replay from dataset streams is not part of this command; use explicit replay workflows after writing a capture file
 
 ### session save
 

--- a/docs/design/dataset-provider-workflow.md
+++ b/docs/design/dataset-provider-workflow.md
@@ -4,8 +4,8 @@
 
 | Field | Value |
 |-------|-------|
-| Status | Implemented (Phase 1) |
-| Issue | #216 |
+| Status | Implemented (Phase 2) |
+| Issue | #216, #220 |
 | Implementation | `src/canarchy/dataset_provider.py`, `dataset_cache.py`, `dataset_catalog.py`, `dataset_convert.py` |
 
 ---
@@ -31,6 +31,7 @@ canarchy datasets fetch <ref>
 canarchy datasets cache list
 canarchy datasets cache refresh [--provider <name>]
 canarchy datasets convert <file> --source-format hcrl-csv --format candump|jsonl [--output <path>]
+canarchy datasets stream <file> --source-format hcrl-csv --format candump|jsonl [--chunk-size N] [--provider-ref <ref>] [--output <path>]
 ```
 
 All commands follow the standard `--json`, `--jsonl`, `--table`, `--raw` output modes.
@@ -154,6 +155,37 @@ column (if present) is preserved in `payload.label`.
 
 ---
 
+## Streaming
+
+`datasets stream` is the streaming-oriented companion to `datasets convert`. It parses supported
+dataset files incrementally and writes each output record directly to stdout or `--output` without
+building a full in-memory frame list.
+
+### Requirements
+
+| ID | Type | Requirement |
+|----|------|-------------|
+| REQ-DATASET-STREAM-01 | Ubiquitous | The system shall stream supported dataset files without loading all parsed frames into memory. |
+| REQ-DATASET-STREAM-02 | Ubiquitous | The system shall support `candump` and `jsonl` stream output formats for supported dataset source formats. |
+| REQ-DATASET-STREAM-03 | Optional feature | Where `--provider-ref` is specified, the system shall include the provider reference in JSONL dataset provenance metadata. |
+| REQ-DATASET-STREAM-04 | Ubiquitous | The system shall include `frame_offset`, `chunk_index`, and `chunk_position` metadata on JSONL streamed frame events. |
+| REQ-DATASET-STREAM-05 | Unwanted behaviour | If `--chunk-size` is less than 1, the system shall return a structured `INVALID_CHUNK_SIZE` error. |
+| REQ-DATASET-STREAM-06 | Unwanted behaviour | If the source file is malformed, the system shall return a structured `MALFORMED_SOURCE` error instead of emitting partial success as a normal completion. |
+
+### JSONL Stream Event
+
+```json
+{"event_type": "frame", "source": "hcrl-csv", "timestamp": 0.0, "payload": {"arbitration_id": 790, "data": "0000000000000000", "interface": null, "dataset": {"provider_ref": "catalog:hcrl-car-hacking", "frame_offset": 0, "chunk_index": 0, "chunk_position": 0}}}
+```
+
+### Notes
+
+- `datasets stream` writes stream records directly unless `--json` is requested.
+- With `--json`, the command returns the standard result envelope with `frame_count`, `chunks`, and stream configuration metadata.
+- Active live-bus replay remains out of scope for this increment; dataset streams can be saved or piped into existing file/stdin-aware analysis commands.
+
+---
+
 ## Non-Goals (Phase 1)
 
 - Vendoring large external datasets into the repository
@@ -169,4 +201,5 @@ column (if present) is preserved in `payload.label`.
 - Automated download for small, openly-licensed datasets (e.g., SynCAN)
 - Additional source formats (SynCAN CSV, ROAD CSV, comma.ai msgpack)
 - `datasets convert` reading from a provider ref (after fetch downloads the data)
-- Streaming conversion for large files (feeds into issue #220)
+- Provider-specific streaming adapters for remote datasets such as commaCarSegments
+- Explicit safe live-bus replay from dataset streams

--- a/docs/tests/dataset-provider-workflow.md
+++ b/docs/tests/dataset-provider-workflow.md
@@ -1,0 +1,92 @@
+# Test Spec: Dataset Provider Workflow
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| Status | Implemented |
+| Related design spec | `docs/design/dataset-provider-workflow.md` |
+| Issues | #216, #220 |
+| Test module | `tests/test_dataset_provider.py` |
+
+---
+
+## Test Cases
+
+### TEST-DATASET-STREAM-01: Stream HCRL CSV To JSONL With Chunk Metadata
+
+```gherkin
+Given a small HCRL CSV fixture with six CAN frames
+When the operator streams it as JSONL with chunk size 2 and a provider ref
+Then six frame events are emitted
+And frame offsets are monotonic
+And chunk indexes advance at the configured boundary
+And the provider ref is preserved in dataset provenance metadata
+```
+
+**Fixture:** `tests/fixtures/dataset_hcrl_sample.csv`
+
+### TEST-DATASET-STREAM-02: Stream HCRL CSV To Candump
+
+```gherkin
+Given a small HCRL CSV fixture with six CAN frames
+When the operator streams it as candump to a destination file
+Then six candump lines are written
+And each line uses timestamped candump syntax
+```
+
+**Fixture:** `tests/fixtures/dataset_hcrl_sample.csv`
+
+### TEST-DATASET-STREAM-03: Reject Invalid Chunk Size
+
+```gherkin
+Given a valid HCRL CSV fixture
+When the operator requests a stream with chunk size 0
+Then the command fails with `INVALID_CHUNK_SIZE`
+```
+
+**Fixture:** `tests/fixtures/dataset_hcrl_sample.csv`
+
+### TEST-DATASET-STREAM-04: CLI Streams JSONL To Stdout
+
+```gherkin
+Given a small HCRL CSV fixture with six CAN frames
+When the operator runs `canarchy datasets stream` with JSONL output and no destination
+Then stdout contains six JSONL frame events
+And stdout does not contain a wrapping result envelope
+```
+
+**Fixture:** `tests/fixtures/dataset_hcrl_sample.csv`
+
+### TEST-DATASET-STREAM-05: CLI JSON Summary Mode
+
+```gherkin
+Given a small HCRL CSV fixture with six CAN frames
+When the operator runs `canarchy datasets stream --json`
+Then stdout contains a standard JSON result envelope
+And the result reports frame count and chunk count
+And frame events are not emitted to stdout
+```
+
+**Fixture:** `tests/fixtures/dataset_hcrl_sample.csv`
+
+---
+
+## Traceability
+
+| Requirement | Tests |
+|-------------|-------|
+| REQ-DATASET-STREAM-01 | TEST-DATASET-STREAM-01, TEST-DATASET-STREAM-02, TEST-DATASET-STREAM-04 |
+| REQ-DATASET-STREAM-02 | TEST-DATASET-STREAM-01, TEST-DATASET-STREAM-02 |
+| REQ-DATASET-STREAM-03 | TEST-DATASET-STREAM-01, TEST-DATASET-STREAM-04 |
+| REQ-DATASET-STREAM-04 | TEST-DATASET-STREAM-01, TEST-DATASET-STREAM-04 |
+| REQ-DATASET-STREAM-05 | TEST-DATASET-STREAM-03 |
+| REQ-DATASET-STREAM-06 | Covered by existing malformed HCRL CSV conversion tests in `tests/test_dataset_provider.py` |
+
+---
+
+## Not Tested
+
+- Remote provider-specific streaming adapters are not tested because this increment only streams local downloaded dataset files.
+- Live-bus replay is not tested because active replay is intentionally deferred.
+- Network access is not tested; all tests use checked-in fixtures.

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -59,7 +59,7 @@ TRANSPORT_COMMANDS = {"capture", "send", "filter", "stats", "generate", "capture
 DBC_COMMANDS = {"decode", "encode", "dbc inspect"}
 DBC_PROVIDER_COMMANDS = {"dbc provider list", "dbc search", "dbc fetch", "dbc cache list", "dbc cache prune", "dbc cache refresh"}
 SKILLS_COMMANDS = {"skills provider list", "skills search", "skills fetch", "skills cache list", "skills cache refresh"}
-DATASETS_COMMANDS = {"datasets provider list", "datasets search", "datasets inspect", "datasets fetch", "datasets cache list", "datasets cache refresh", "datasets convert"}
+DATASETS_COMMANDS = {"datasets provider list", "datasets search", "datasets inspect", "datasets fetch", "datasets cache list", "datasets cache refresh", "datasets convert", "datasets stream"}
 J1939_COMMANDS = {"j1939 monitor", "j1939 decode", "j1939 pgn", "j1939 spn", "j1939 tp sessions", "j1939 tp compare", "j1939 dm1", "j1939 faults", "j1939 summary", "j1939 inventory", "j1939 compare"}
 SESSION_COMMANDS = {"session save", "session load", "session show"}
 UDS_COMMANDS = {"uds scan", "uds trace", "uds services"}
@@ -432,6 +432,29 @@ def build_parser() -> CanarchyArgumentParser:
     datasets_convert.add_argument("--output", help="output file path (defaults to source path with new suffix)")
     add_output_arguments(datasets_convert)
     datasets_convert.set_defaults(command="datasets convert")
+
+    datasets_stream = datasets_subparsers.add_parser(
+        "stream", help="stream a downloaded dataset file to candump or JSONL"
+    )
+    datasets_stream.add_argument("file", help="path to the downloaded dataset file")
+    datasets_stream.add_argument(
+        "--source-format",
+        required=True,
+        choices=["hcrl-csv"],
+        help="source file format (hcrl-csv: HCRL Timestamp,ID,DLC,Data CSV)",
+    )
+    datasets_stream.add_argument(
+        "--format",
+        dest="output_format",
+        required=True,
+        choices=["candump", "jsonl"],
+        help="stream output format",
+    )
+    datasets_stream.add_argument("--output", help="output file path; omit or use '-' for stdout")
+    datasets_stream.add_argument("--chunk-size", type=int, default=1000, help="frames per metadata chunk (default: 1000)")
+    datasets_stream.add_argument("--provider-ref", help="dataset provider ref to preserve in JSONL provenance")
+    add_output_arguments(datasets_stream)
+    datasets_stream.set_defaults(command="datasets stream")
 
     export = subparsers.add_parser("export", help="export session data")
     export.add_argument("source")
@@ -2748,6 +2771,33 @@ def datasets_payload(args: argparse.Namespace) -> tuple[dict[str, Any], list[dic
             ) from exc
         return (result, [], [])
 
+    if args.command == "datasets stream":
+        from canarchy.dataset_convert import ConversionError, stream_file
+
+        destination = getattr(args, "output", None)
+        if destination in (None, "-"):
+            destination = None if not getattr(args, "json", False) else None
+        try:
+            if getattr(args, "json", False) and destination is None:
+                import os
+
+                destination = os.devnull
+            result = stream_file(
+                args.file,
+                source_format=args.source_format,
+                output_format=args.output_format,
+                destination=destination,
+                chunk_size=getattr(args, "chunk_size", 1000),
+                provider_ref=getattr(args, "provider_ref", None),
+            )
+        except ConversionError as exc:
+            raise CommandError(
+                command=args.command,
+                exit_code=EXIT_USER_ERROR,
+                errors=[ErrorDetail(code=exc.code, message=str(exc), hint=exc.hint)],
+            ) from exc
+        return (result, [], [])
+
     raise AssertionError(f"unsupported datasets command: {args.command}")
 
 
@@ -3963,6 +4013,29 @@ def emit_live_gateway(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def emit_dataset_stream(args: argparse.Namespace) -> int:
+    from canarchy.dataset_convert import ConversionError, stream_file
+
+    try:
+        stream_file(
+            args.file,
+            source_format=args.source_format,
+            output_format=args.output_format,
+            destination=getattr(args, "output", None),
+            chunk_size=getattr(args, "chunk_size", 1000),
+            provider_ref=getattr(args, "provider_ref", None),
+        )
+    except ConversionError as exc:
+        result = CommandResult(
+            command=args.command,
+            ok=False,
+            errors=[ErrorDetail(code=exc.code, message=str(exc), hint=exc.hint)],
+        )
+        emit_result(result, "json")
+        return EXIT_USER_ERROR
+    return EXIT_OK
+
+
 def _emit_warnings_jsonl(payload: dict[str, Any], result: CommandResult) -> None:
     for warning in payload["warnings"]:
         print(
@@ -4330,6 +4403,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return emit_live_capture(args, output_format)
     if args.command == "gateway" and output_format in {"table", "raw"}:
         return emit_live_gateway(args)
+    if args.command == "datasets stream" and not args.json:
+        return emit_dataset_stream(args)
 
     exit_code, result = execute_command(argv)
     if result is not None:

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -4026,9 +4026,8 @@ def emit_dataset_stream(args: argparse.Namespace) -> int:
             provider_ref=getattr(args, "provider_ref", None),
         )
     except ConversionError as exc:
-        result = CommandResult(
-            command=args.command,
-            ok=False,
+        result = error_result(
+            args.command,
             errors=[ErrorDetail(code=exc.code, message=str(exc), hint=exc.hint)],
         )
         emit_result(result, "json")

--- a/src/canarchy/dataset_convert.py
+++ b/src/canarchy/dataset_convert.py
@@ -1,11 +1,12 @@
-"""Conversion helpers: public CAN dataset CSV files → candump or JSONL FrameEvents."""
+"""Conversion helpers for public CAN dataset files."""
 
 from __future__ import annotations
 
 import csv
 import json
+import sys
 from pathlib import Path
-from typing import Iterator
+from typing import IO, Iterator
 
 from canarchy.dataset_provider import DatasetError
 
@@ -25,17 +26,7 @@ def convert_file(
     output_format: str,
     destination: str | None = None,
 ) -> dict:
-    """Convert a dataset file to candump or JSONL format.
-
-    Args:
-        source_path: Path to the input file.
-        source_format: Source file format identifier. Currently supported: 'hcrl-csv'.
-        output_format: Target format: 'candump' or 'jsonl'.
-        destination: Output file path. Defaults to source path with new suffix.
-
-    Returns:
-        Dict with destination path, frame_count, source_format, output_format.
-    """
+    """Convert a dataset file to candump or JSONL format."""
     if source_format not in _SUPPORTED_SOURCE_FORMATS:
         raise ConversionError(
             code="UNSUPPORTED_SOURCE_FORMAT",
@@ -83,6 +74,85 @@ def convert_file(
     }
 
 
+def stream_file(
+    source_path: str,
+    *,
+    source_format: str,
+    output_format: str,
+    destination: str | None = None,
+    chunk_size: int = 1000,
+    provider_ref: str | None = None,
+) -> dict:
+    """Stream a dataset file to candump or JSONL without materializing all frames."""
+    if source_format not in _SUPPORTED_SOURCE_FORMATS:
+        raise ConversionError(
+            code="UNSUPPORTED_SOURCE_FORMAT",
+            message=f"Source format '{source_format}' is not supported.",
+            hint=f"Supported source formats: {', '.join(_SUPPORTED_SOURCE_FORMATS)}.",
+        )
+    if output_format not in _SUPPORTED_OUTPUT_FORMATS:
+        raise ConversionError(
+            code="UNSUPPORTED_OUTPUT_FORMAT",
+            message=f"Output format '{output_format}' is not supported.",
+            hint=f"Supported output formats: {', '.join(_SUPPORTED_OUTPUT_FORMATS)}.",
+        )
+    if chunk_size < 1:
+        raise ConversionError(
+            code="INVALID_CHUNK_SIZE",
+            message="Chunk size must be at least 1.",
+            hint="Use `--chunk-size` with a positive integer.",
+        )
+
+    src = Path(source_path)
+    if not src.exists():
+        raise ConversionError(
+            code="SOURCE_NOT_FOUND",
+            message=f"Source file not found: {source_path}",
+            hint="Provide a valid path to a downloaded dataset file.",
+        )
+
+    if source_format == "hcrl-csv":
+        frames = _parse_hcrl_csv(src)
+    else:
+        raise AssertionError(f"unhandled source format: {source_format}")
+
+    if destination is None or destination == "-":
+        counts = _stream_frames(
+            frames,
+            sys.stdout,
+            output_format=output_format,
+            source=source_format,
+            chunk_size=chunk_size,
+            provider_ref=provider_ref,
+        )
+        destination_label = "-"
+    else:
+        dest = Path(destination)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with open(dest, "w") as handle:
+            counts = _stream_frames(
+                frames,
+                handle,
+                output_format=output_format,
+                source=source_format,
+                chunk_size=chunk_size,
+                provider_ref=provider_ref,
+            )
+        destination_label = str(dest)
+
+    return {
+        "source": str(src),
+        "destination": destination_label,
+        "source_format": source_format,
+        "output_format": output_format,
+        "chunk_size": chunk_size,
+        "chunks": counts["chunks"],
+        "frame_count": counts["frame_count"],
+        "provider_ref": provider_ref,
+        "streamed": True,
+    }
+
+
 def _parse_hcrl_csv(path: Path) -> Iterator[dict]:
     """Parse HCRL Car-Hacking CSV format.
 
@@ -120,34 +190,86 @@ def _parse_hcrl_csv(path: Path) -> Iterator[dict]:
             yield {"timestamp": timestamp, "arbitration_id": arb_id, "data": data_bytes, "label": label}
 
 
+def _stream_frames(
+    frames: Iterator[dict],
+    handle: IO[str],
+    *,
+    output_format: str,
+    source: str,
+    chunk_size: int,
+    provider_ref: str | None,
+) -> dict:
+    frame_count = 0
+    chunk_index = 0
+    chunk_position = 0
+    for frame in frames:
+        if chunk_position >= chunk_size:
+            chunk_index += 1
+            chunk_position = 0
+        if output_format == "candump":
+            handle.write(_format_candump_frame(frame))
+        elif output_format == "jsonl":
+            event = _frame_to_event(
+                frame,
+                source=source,
+                provider_ref=provider_ref,
+                frame_offset=frame_count,
+                chunk_index=chunk_index,
+                chunk_position=chunk_position,
+            )
+            handle.write(json.dumps(event, sort_keys=True) + "\n")
+        frame_count += 1
+        chunk_position += 1
+    handle.flush()
+    return {"frame_count": frame_count, "chunks": chunk_index + (1 if chunk_position else 0)}
+
+
+def _format_candump_frame(frame: dict) -> str:
+    ts = f"{frame['timestamp']:.6f}"
+    arb_id = f"{frame['arbitration_id']:X}"
+    data_hex = frame["data"].hex().upper()
+    return f"({ts}) can0 {arb_id}#{data_hex}\n"
+
+
+def _frame_to_event(
+    frame: dict,
+    *,
+    source: str,
+    provider_ref: str | None = None,
+    frame_offset: int | None = None,
+    chunk_index: int | None = None,
+    chunk_position: int | None = None,
+) -> dict:
+    event = {
+        "event_type": "frame",
+        "source": source,
+        "timestamp": frame["timestamp"],
+        "payload": {
+            "arbitration_id": frame["arbitration_id"],
+            "data": frame["data"].hex(),
+            "interface": None,
+        },
+    }
+    if frame.get("label"):
+        event["payload"]["label"] = frame["label"]
+    if provider_ref is not None or frame_offset is not None or chunk_index is not None:
+        event["payload"]["dataset"] = {
+            "provider_ref": provider_ref,
+            "frame_offset": frame_offset,
+            "chunk_index": chunk_index,
+            "chunk_position": chunk_position,
+        }
+    return event
+
+
 def _write_candump(frames: list[dict], dest: Path) -> None:
     """Write frames in candump log format: (timestamp) interface id#data"""
-    lines = []
-    for frame in frames:
-        ts = f"{frame['timestamp']:.6f}"
-        arb_id = f"{frame['arbitration_id']:X}"
-        data_hex = frame["data"].hex().upper()
-        lines.append(f"({ts}) can0 {arb_id}#{data_hex}\n")
-    dest.write_text("".join(lines))
+    dest.write_text("".join(_format_candump_frame(frame) for frame in frames))
 
 
 def _write_jsonl(frames: list[dict], dest: Path, *, source: str) -> None:
     """Write frames as JSONL FrameEvents."""
-    lines = []
-    for frame in frames:
-        event = {
-            "event_type": "frame",
-            "source": source,
-            "timestamp": frame["timestamp"],
-            "payload": {
-                "arbitration_id": frame["arbitration_id"],
-                "data": frame["data"].hex(),
-                "interface": None,
-            },
-        }
-        if frame.get("label"):
-            event["payload"]["label"] = frame["label"]
-        lines.append(json.dumps(event))
+    lines = [json.dumps(_frame_to_event(frame, source=source)) for frame in frames]
     dest.write_text("\n".join(lines) + ("\n" if lines else ""))
 
 

--- a/tests/test_dataset_provider.py
+++ b/tests/test_dataset_provider.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from canarchy.dataset_catalog import PublicDatasetProvider
-from canarchy.dataset_convert import ConversionError, convert_file
+from canarchy.dataset_convert import ConversionError, convert_file, stream_file
 from canarchy.dataset_provider import (
     DatasetDescriptor,
     DatasetError,
@@ -297,6 +297,42 @@ class DatasetConvertTests(unittest.TestCase):
             # ID should be uppercase hex without leading zeros beyond necessary
             self.assertRegex(first_line, r"\([0-9.]+\) can0 [0-9A-F]+#[0-9A-F]*")
 
+    def test_stream_hcrl_csv_to_jsonl_preserves_chunk_metadata(self) -> None:
+        src = str(FIXTURES / "dataset_hcrl_sample.csv")
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = str(Path(tmp) / "stream.jsonl")
+            result = stream_file(
+                src,
+                source_format="hcrl-csv",
+                output_format="jsonl",
+                destination=dest,
+                chunk_size=2,
+                provider_ref="catalog:hcrl-car-hacking",
+            )
+            self.assertEqual(result["frame_count"], 6)
+            self.assertEqual(result["chunks"], 3)
+            events = [json.loads(line) for line in Path(dest).read_text().splitlines()]
+            self.assertEqual(events[0]["payload"]["dataset"]["frame_offset"], 0)
+            self.assertEqual(events[2]["payload"]["dataset"]["chunk_index"], 1)
+            self.assertEqual(events[2]["payload"]["dataset"]["chunk_position"], 0)
+            self.assertEqual(events[0]["payload"]["dataset"]["provider_ref"], "catalog:hcrl-car-hacking")
+
+    def test_stream_hcrl_csv_to_candump_writes_incrementally(self) -> None:
+        src = str(FIXTURES / "dataset_hcrl_sample.csv")
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = str(Path(tmp) / "stream.log")
+            result = stream_file(src, source_format="hcrl-csv", output_format="candump", destination=dest)
+            lines = Path(dest).read_text().splitlines()
+            self.assertEqual(result["frame_count"], 6)
+            self.assertEqual(len(lines), 6)
+            self.assertTrue(lines[0].startswith("(0.000000) can0 "))
+
+    def test_stream_invalid_chunk_size_raises_conversion_error(self) -> None:
+        src = str(FIXTURES / "dataset_hcrl_sample.csv")
+        with self.assertRaises(ConversionError) as ctx:
+            stream_file(src, source_format="hcrl-csv", output_format="jsonl", chunk_size=0)
+        self.assertEqual(ctx.exception.code, "INVALID_CHUNK_SIZE")
+
 
 # ---------------------------------------------------------------------------
 # CLI integration
@@ -407,3 +443,32 @@ class CliIntegrationTests(unittest.TestCase):
         data = json.loads(out)
         self.assertTrue(data["ok"])
         self.assertEqual(data["data"]["output_format"], "jsonl")
+
+    def test_datasets_stream_hcrl_to_stdout_jsonl(self) -> None:
+        src = str(FIXTURES / "dataset_hcrl_sample.csv")
+        code, out, _ = run_cli(
+            "datasets", "stream", src,
+            "--source-format", "hcrl-csv",
+            "--format", "jsonl",
+            "--chunk-size", "2",
+            "--provider-ref", "catalog:hcrl-car-hacking",
+        )
+        self.assertEqual(code, 0)
+        events = [json.loads(line) for line in out.splitlines()]
+        self.assertEqual(len(events), 6)
+        self.assertEqual(events[2]["payload"]["dataset"]["chunk_index"], 1)
+
+    def test_datasets_stream_json_summary_does_not_emit_frames(self) -> None:
+        src = str(FIXTURES / "dataset_hcrl_sample.csv")
+        code, out, _ = run_cli(
+            "datasets", "stream", src,
+            "--source-format", "hcrl-csv",
+            "--format", "jsonl",
+            "--chunk-size", "2",
+            "--json",
+        )
+        self.assertEqual(code, 0)
+        data = json.loads(out)
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["data"]["frame_count"], 6)
+        self.assertEqual(data["data"]["chunks"], 3)

--- a/tests/test_dataset_provider.py
+++ b/tests/test_dataset_provider.py
@@ -472,3 +472,16 @@ class CliIntegrationTests(unittest.TestCase):
         self.assertTrue(data["ok"])
         self.assertEqual(data["data"]["frame_count"], 6)
         self.assertEqual(data["data"]["chunks"], 3)
+
+    def test_datasets_stream_invalid_chunk_size_returns_structured_error(self) -> None:
+        src = str(FIXTURES / "dataset_hcrl_sample.csv")
+        code, out, _ = run_cli(
+            "datasets", "stream", src,
+            "--source-format", "hcrl-csv",
+            "--format", "jsonl",
+            "--chunk-size", "0",
+        )
+        self.assertEqual(code, 1)
+        data = json.loads(out)
+        self.assertFalse(data["ok"])
+        self.assertEqual(data["errors"][0]["code"], "INVALID_CHUNK_SIZE")


### PR DESCRIPTION
## Summary
- Add `canarchy datasets stream` for chunked HCRL CSV streaming to JSONL or candump without materializing all frames.
- Include JSONL dataset provenance metadata for provider refs, frame offsets, chunk indexes, and chunk positions.
- Update command/design/test/agent docs and changelog for the new dataset streaming workflow.

## Verification
- `uv run python -m unittest tests.test_dataset_provider -v`
- `uv run pytest`
- `uv run --group docs mkdocs build --strict`

Closes #220