### PR TITLE
fix: improve datasets search table output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 * Added `canarchy datasets stream` for chunked streaming of downloaded dataset files to candump or JSONL, including JSONL provenance metadata for provider refs, frame offsets, and chunk positions so large datasets can be piped into analysis without buffering the full conversion in memory.
 
+### Fixed
+
+* Made `canarchy datasets search <query>` default to a readable dataset listing instead of dumping raw Python result dictionaries, while preserving explicit JSON output for automation.
+
 ## [0.6.0] - 2026-04-28
 
 ### Added

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -3942,6 +3942,28 @@ def format_skills_table(result: CommandResult) -> list[str]:
     return lines
 
 
+def format_datasets_table(result: CommandResult) -> list[str]:
+    lines = [f"command: {result.command}"]
+    if result.command == "datasets search":
+        lines.append(f"query: {result.data.get('query', '')}")
+        lines.append(f"results: {result.data.get('count', 0)}")
+        for item in result.data.get("results", []):
+            formats = ",".join(item.get("formats", []))
+            targets = ",".join(item.get("conversion_targets", []))
+            lines.append(
+                f"  {item['provider']}:{item['name']}  "
+                f"protocol={item.get('protocol_family', '')}  "
+                f"formats={formats or '-'}  "
+                f"targets={targets or '-'}  "
+                f"license={item.get('license', '')}  "
+                f"size={item.get('size_description', '')}"
+            )
+            lines.append(f"    source: {item.get('source_url', '')}")
+            if item.get("access_notes"):
+                lines.append(f"    access: {item['access_notes']}")
+    return lines
+
+
 def emit_live_capture(args: argparse.Namespace, output_format: str) -> int:
     """Stream live capture frames until Ctrl+C, honouring *output_format*.
 
@@ -4189,6 +4211,13 @@ def emit_result(result: CommandResult, output_format: str) -> None:
 
     if output_format == "table" and result.ok and result.command in SKILLS_COMMANDS:
         for line in format_skills_table(result):
+            print(line)
+        for warning in payload["warnings"]:
+            print(f"warning: {warning}")
+        return
+
+    if output_format == "table" and result.ok and result.command == "datasets search":
+        for line in format_datasets_table(result):
             print(line)
         for warning in payload["warnings"]:
             print(f"warning: {warning}")

--- a/tests/test_dataset_provider.py
+++ b/tests/test_dataset_provider.py
@@ -371,6 +371,15 @@ class CliIntegrationTests(unittest.TestCase):
         protocols = [r["protocol_family"] for r in data["data"]["results"]]
         self.assertIn("j1939", protocols)
 
+    def test_datasets_search_default_output_is_human_readable(self) -> None:
+        code, out, _ = run_cli("datasets", "search", "hcrl")
+        self.assertEqual(code, 0)
+        self.assertIn("query: hcrl", out)
+        self.assertIn("results: 9", out)
+        self.assertIn("catalog:hcrl-car-hacking", out)
+        self.assertIn("protocol=can", out)
+        self.assertNotIn("results: [{", out)
+
     def test_datasets_inspect_known(self) -> None:
         code, out, _ = run_cli("datasets", "inspect", "road", "--json")
         self.assertEqual(code, 0)


### PR DESCRIPTION
## Summary
- Add dataset-specific default table formatting for `canarchy datasets search <query>`.
- Keep explicit `--json` output unchanged for automation.
- Add regression coverage that default search output is human-readable rather than a raw Python dict dump.

## Verification
- `uv run python -m unittest tests.test_dataset_provider -v`
- `uv run canarchy datasets search hcrl`
- `uv run canarchy datasets search hcrl --json`
- `uv run pytest`

Closes #227