### PR TITLE
fix: improve datasets provider list output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
-* Made `canarchy datasets search <query>` default to a compact readable table instead of dumping raw Python result dictionaries, added `--verbose` for detailed result blocks, and preserved explicit JSON output for automation.
+* Made `canarchy datasets provider list` and `canarchy datasets search <query>` default to compact readable output instead of dumping raw Python result dictionaries, added `--verbose` for detailed search result blocks, and preserved explicit JSON output for automation.
 
 ## [0.6.0] - 2026-04-28
 

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -3945,6 +3945,13 @@ def format_skills_table(result: CommandResult) -> list[str]:
 
 
 def format_datasets_table(result: CommandResult) -> list[str]:
+    if result.command == "datasets provider list":
+        lines = ["Dataset providers"]
+        for provider in result.data.get("providers", []):
+            status = "registered" if provider.get("registered") else "unregistered"
+            lines.append(f"  {provider['name']} ({status})")
+        return lines
+
     if result.command != "datasets search":
         return [f"command: {result.command}"]
 
@@ -4253,7 +4260,7 @@ def emit_result(result: CommandResult, output_format: str) -> None:
             print(f"warning: {warning}")
         return
 
-    if output_format == "table" and result.ok and result.command == "datasets search":
+    if output_format == "table" and result.ok and result.command in {"datasets provider list", "datasets search"}:
         for line in format_datasets_table(result):
             print(line)
         for warning in payload["warnings"]:

--- a/tests/test_dataset_provider.py
+++ b/tests/test_dataset_provider.py
@@ -353,6 +353,13 @@ class CliIntegrationTests(unittest.TestCase):
         names = [p["name"] for p in data["data"]["providers"]]
         self.assertIn("catalog", names)
 
+    def test_datasets_provider_list_default_output_is_human_readable(self) -> None:
+        code, out, _ = run_cli("datasets", "provider", "list")
+        self.assertEqual(code, 0)
+        self.assertIn("Dataset providers", out)
+        self.assertIn("catalog (registered)", out)
+        self.assertNotIn("providers: [{", out)
+
     def test_datasets_search_all(self) -> None:
         code, out, _ = run_cli("datasets", "search", "--json")
         self.assertEqual(code, 0)


### PR DESCRIPTION
## Summary
- Add human-readable default output for `canarchy datasets provider list`.
- Keep `--json` output unchanged for automation.
- Add regression coverage for the default provider list output.

## Verification
- `uv run canarchy datasets provider list`
- `uv run canarchy datasets provider list --json`
- `uv run python -m unittest tests.test_dataset_provider -v`

Closes #230