### PR TITLE
feat: add CANdid dataset catalog entry closes #225

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Added
 
 * Added `canarchy datasets stream` for chunked streaming of downloaded dataset files to candump or JSONL, including JSONL provenance metadata for provider refs, frame offsets, and chunk positions so large datasets can be piped into analysis without buffering the full conversion in memory.
+* Added `candid` (CANdid) dataset to the built-in catalog: VehicleSec 2025 paper dataset with 10-passenger-vehicle candump-format CAN logs, annotations, GPS, metadata, and video. Ref: `catalog:candid`. Closes #225.
 
 ### Fixed
 

--- a/docs/command_spec.md
+++ b/docs/command_spec.md
@@ -1029,6 +1029,26 @@ Notes:
 * the result reports `protocol_decoder` as `built-in` by default
 * negative responses may include `negative_response_code` and `negative_response_name`
 
+### Dataset Analysis (CANdid)
+
+The CANdid dataset (VehicleSec 2025) provides candump-format CAN logs ready for direct analysis:
+
+```bash
+# Summarize a CANdid capture
+canarchy stats --file 2_driving_CAN.log --json
+canarchy capture-info --file 2_driving_CAN.log --json
+
+# Filter for specific IDs
+canarchy filter 'id==0x123' --file 2_steering_CAN.log --json
+
+# Reverse-engineering helpers
+canarchy re entropy --file 2_driving_CAN.log
+canarchy re counters --file 2_driving_CAN.log
+
+# Inspect the catalog entry
+canarchy datasets inspect catalog:candid --json
+```
+
 ### Session Save
 
 ```bash

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -154,6 +154,32 @@ Replay a capture with deterministic timing:
 canarchy replay --file tests/fixtures/sample.candump --rate 1.0 --json
 ```
 
+## Analyze CANdid Dataset Files
+
+The [CANdid dataset](https://doi.org/10.25909/29068553) (VehicleSec 2025) provides candump-format CAN logs from 10 passenger vehicles. After downloading, use `*_CAN.log` files directly:
+
+Summarize a CANdid capture:
+```bash
+canarchy stats --file 2_driving_CAN.log --json
+canarchy capture-info --file 2_driving_CAN.log --json
+```
+
+Filter for specific arbitration IDs:
+```bash
+canarchy filter 'id==0x123' --file 2_steering_CAN.log --json
+```
+
+Run reverse-engineering helpers:
+```bash
+canarchy re entropy --file 2_driving_CAN.log
+canarchy re counters --file 2_driving_CAN.log
+```
+
+The catalog entry includes metadata about annotations, GPS traces, and video artifacts:
+```bash
+canarchy datasets inspect catalog:candid --json
+```
+
 ## Discover and Use DBC Files
 
 CANarchy can work with local DBC files or provider-backed refs.

--- a/src/canarchy/dataset_catalog.py
+++ b/src/canarchy/dataset_catalog.py
@@ -229,6 +229,33 @@ _CATALOG: list[dict[str, Any]] = [
             "csv_note": "SynCAN CSV has a 'Time' column and per-signal value columns, not raw byte payloads.",
         },
     },
+    {
+        "name": "candid",
+        "version": "vehiclesec25",
+        "source_url": "https://doi.org/10.25909/29068553",
+        "license": "CC BY 4.0",
+        "protocol_family": "can",
+        "formats": ("candump",),
+        "size_description": "~13.7 GB",
+        "description": (
+            "CANdid: A CAN bus dataset for vehicle security research from VehicleSec 2025. "
+            "Raw CAN logs captured from 10 modern passenger vehicles during controlled maneuvers "
+            "(braking, steering, indicator, lights, gears, engine, driving). "
+            "CAN logs are in can-utils candump format and can be used directly with CANarchy. "
+            "Also includes annotation logs, GPS traces, metadata JSON, and cabin/dashboard video."
+        ),
+        "access_notes": "Download via Figshare: https://doi.org/10.25909/29068553. Figshare account may be required.",
+        "conversion_targets": ("jsonl",),
+        "metadata": {
+            "publisher": "VehicleSec 2025 / University of South Australia",
+            "paper": "https://www.usenix.org/conference/vehiclesec25/presentation/howson",
+            "vehicle_type": "passenger",
+            "vehicle_count": 10,
+            "maneuvers": ["brakes", "steering", "indicator", "lights", "gears", "engine", "driving"],
+            "artifacts": ["CAN.log", "annot.log", "GPS.log", "meta.json", "cabin.mp4", "dashboard.mp4"],
+            "note": "CAN logs (*_CAN.log) are ready for capture-info, stats, filter, re entropy, re counters.",
+        },
+    },
 ]
 
 

--- a/tests/test_dataset_provider.py
+++ b/tests/test_dataset_provider.py
@@ -126,6 +126,22 @@ class PublicDatasetProviderTests(unittest.TestCase):
         self.assertEqual(desc.license, "MIT")
         self.assertIn("candump", desc.conversion_targets)
 
+    def test_candid_is_in_catalog(self) -> None:
+        desc = self.provider.inspect("candid")
+        self.assertEqual(desc.license, "CC BY 4.0")
+        self.assertEqual(desc.protocol_family, "can")
+        self.assertEqual(desc.version, "vehiclesec25")
+        self.assertIn("candump", desc.formats)
+        self.assertIn("jsonl", desc.conversion_targets)
+        self.assertIn("10.25909", desc.source_url)
+
+    def test_candid_metadata_has_paper_and_vehicle_count(self) -> None:
+        desc = self.provider.inspect("candid")
+        self.assertIn("paper", desc.metadata)
+        self.assertEqual(desc.metadata["vehicle_count"], 10)
+        self.assertIn("CAN logs", desc.metadata["note"])
+        self.assertIn("capture-info", desc.metadata["note"])
+
     def test_fetch_records_provenance_file(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             with patch("canarchy.dataset_cache.cache_root", return_value=Path(tmp) / "cache"):


### PR DESCRIPTION
## Summary
- Adds `candid` (CANdid) dataset from VehicleSec 2025 to the built-in catalog (`catalog:candid`)
- CANdid provides candump-format CAN logs from 10 passenger vehicles with annotations, GPS, metadata, and video
- Source: https://doi.org/10.25909/29068553 (CC BY 4.0)
- Added tests for catalog entry metadata (paper URL, vehicle count, format support)
- Added usage examples to `docs/getting_started.md` and `docs/command_spec.md`
- Updates CHANGELOG.md under `[Unreleased]`

## Acceptance Criteria
- [x] `canarchy datasets search candid --json` returns the CANdid descriptor
- [x] `canarchy datasets inspect catalog:candid --json` includes DOI/source URL, CC BY 4.0 license, candump format
- [x] Tests cover the new catalog entry without network access
- [x] Documentation includes examples using `*_CAN.log` files with CANarchy analysis commands
- [x] No large CANdid artifacts are vendored into the repository

## Related Issues
Closes #225