### PR TITLE
Add dataset replay streaming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -448,6 +448,7 @@ canarchy
     cache refresh
     convert
     stream
+    replay
   export
   session
     save

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 * Added `canarchy datasets stream` for chunked streaming of downloaded dataset files to candump or JSONL, including JSONL provenance metadata for provider refs, frame offsets, and chunk positions so large datasets can be piped into analysis without buffering the full conversion in memory.
 * Added `candid` (CANdid) dataset to the built-in catalog: VehicleSec 2025 paper dataset with 10-passenger-vehicle candump-format CAN logs, annotations, GPS, metadata, and video. Ref: `catalog:candid`. Closes #225.
+* Added `canarchy datasets replay` for Netflix-style streaming playback from a direct candump URL or replayable dataset ref such as `catalog:candid`, with candump/JSONL stdout output, rate control, and JSON summary mode. Closes #233.
 
 ### Fixed
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -91,7 +91,7 @@ The current MCP surface exposes a curated non-interactive subset of the CLI. Spa
 Current exclusions:
 
 * skills provider and cache commands such as `skills search` and `skills fetch`
-* dataset provider and streaming commands such as `datasets search`, `datasets fetch`, and `datasets stream`
+* dataset provider and streaming commands such as `datasets search`, `datasets fetch`, `datasets stream`, and `datasets replay`
 * CLI-only workflows such as `j1939 compare` that are not yet exposed as MCP tools
 * CLI-only workflows such as `j1939 faults` and `re signals` that are not yet exposed as MCP tools
 * interactive or service commands such as `shell`, `tui`, and `mcp serve`
@@ -155,6 +155,6 @@ tool: send {"interface": "vcan0", "frame_id": "0x7DF", "data": "0201F1"}
 
 ### Notes
 
-* MCP streaming is not supported in v1 — live-capture tools (`capture`, `gateway`) return a buffered batch from the active backend. Use CLI `datasets stream` for dataset-file JSONL or candump pipelines.
+* MCP streaming is not supported in v1 — live-capture tools (`capture`, `gateway`) return a buffered batch from the active backend. Use CLI `datasets stream` for local dataset-file JSONL or candump pipelines, and `datasets replay` for remote dataset-ref or URL playback to stdout.
 * `shell`, `tui`, and `mcp serve` are not exposed as MCP tools.
 * Error codes are identical to the CLI, so existing JSON-parsing logic transfers without changes.

--- a/docs/command_spec.md
+++ b/docs/command_spec.md
@@ -14,7 +14,7 @@ Implemented and verified in the current codebase:
 * structured `export` for capture files and saved sessions
 * DBC-backed `decode`, `encode`, and `dbc inspect`
 * DBC provider workflows for `dbc provider list`, `dbc search`, `dbc fetch`, `dbc cache list`, `dbc cache prune`, and `dbc cache refresh`
-* dataset provider workflows for `datasets provider list`, `datasets search`, `datasets inspect`, `datasets fetch`, `datasets cache list`, `datasets cache refresh`, `datasets convert`, and `datasets stream`
+* dataset provider workflows for `datasets provider list`, `datasets search`, `datasets inspect`, `datasets fetch`, `datasets cache list`, `datasets cache refresh`, `datasets convert`, `datasets stream`, and `datasets replay`
 * J1939 `monitor`, `decode`, `pgn`, `spn`, `tp`, `dm1`, `faults`, `summary`, `inventory`, and `compare`
 * session `save`, `load`, and `show`
 * shell one-shot command execution
@@ -508,6 +508,30 @@ Notes:
 * JSONL stream records include `payload.dataset.provider_ref`, `frame_offset`, `chunk_index`, and `chunk_position`
 * with `--json`, stdout contains the standard result envelope and reports `frame_count` and `chunks`
 * live-bus replay from dataset streams is not part of this command; use explicit replay workflows after writing a capture file
+
+### datasets replay
+
+Stream a remote candump dataset file directly to stdout with replay timing. The source may be a direct candump download URL or a replayable dataset ref such as `catalog:candid`.
+
+```bash
+canarchy datasets replay <dataset-ref-or-url> [--format candump|jsonl] [--rate <multiplier>] [--max-frames <n>] [--json]
+```
+
+Examples:
+
+```bash
+canarchy datasets replay catalog:candid --rate 1.0
+canarchy datasets replay catalog:candid --format jsonl --rate 10 --max-frames 1000
+canarchy datasets replay https://ndownloader.figshare.com/files/54551156 --rate 1000 --max-frames 10
+canarchy datasets replay catalog:candid --rate 1000 --max-frames 10 --json
+```
+
+Notes:
+
+* without `--json`, replayed frames are written directly to stdout as candump or JSONL records for piping
+* with `--json`, stdout contains a clean standard result envelope with replay metadata and no frame records
+* replay downloads incrementally from the remote HTTP response and does not require a complete local dataset file
+* `catalog:candid` currently resolves to the CANdid `2_brakes_CAN.log` Figshare file as its default replay source
 
 ### session save
 

--- a/docs/design/dataset-provider-workflow.md
+++ b/docs/design/dataset-provider-workflow.md
@@ -32,6 +32,7 @@ canarchy datasets cache list
 canarchy datasets cache refresh [--provider <name>]
 canarchy datasets convert <file> --source-format hcrl-csv --format candump|jsonl [--output <path>]
 canarchy datasets stream <file> --source-format hcrl-csv --format candump|jsonl [--chunk-size N] [--provider-ref <ref>] [--output <path>]
+canarchy datasets replay <dataset-ref-or-url> [--format candump|jsonl] [--rate N] [--max-frames N]
 ```
 
 All commands follow the standard `--json`, `--jsonl`, `--table`, `--raw` output modes.
@@ -183,6 +184,16 @@ building a full in-memory frame list.
 - `datasets stream` writes stream records directly unless `--json` is requested.
 - With `--json`, the command returns the standard result envelope with `frame_count`, `chunks`, and stream configuration metadata.
 - Active live-bus replay remains out of scope for this increment; dataset streams can be saved or piped into existing file/stdin-aware analysis commands.
+
+### Remote Replay Requirements
+
+| ID | Type | Requirement |
+|----|------|-------------|
+| REQ-DATASET-REPLAY-01 | Ubiquitous | The system shall accept a direct remote candump URL as a dataset replay source. |
+| REQ-DATASET-REPLAY-02 | Optional feature | Where replay metadata is available for a dataset descriptor, the system shall accept a dataset ref such as `catalog:candid` as a replay source. |
+| REQ-DATASET-REPLAY-03 | Ubiquitous | The system shall stream remote replay frames incrementally without requiring a complete local dataset file. |
+| REQ-DATASET-REPLAY-04 | Ubiquitous | The system shall support candump and JSONL stdout replay formats. |
+| REQ-DATASET-REPLAY-05 | Optional feature | Where `--json` is specified, the system shall emit a standard result envelope without interleaving frame records. |
 
 ---
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -156,7 +156,16 @@ canarchy replay --file tests/fixtures/sample.candump --rate 1.0 --json
 
 ## Analyze CANdid Dataset Files
 
-The [CANdid dataset](https://doi.org/10.25909/29068553) (VehicleSec 2025) provides candump-format CAN logs from 10 passenger vehicles. After downloading, use `*_CAN.log` files directly:
+The [CANdid dataset](https://doi.org/10.25909/29068553) (VehicleSec 2025) provides candump-format CAN logs from 10 passenger vehicles.
+
+Replay the default CANdid catalog stream directly from the remote provider without downloading the full file first:
+
+```bash
+canarchy datasets replay catalog:candid --rate 1.0
+canarchy datasets replay catalog:candid --format jsonl --rate 10 --max-frames 1000
+```
+
+After downloading specific `*_CAN.log` files, use them directly with file-backed analysis commands:
 
 Summarize a CANdid capture:
 ```bash

--- a/docs/tests/dataset-provider-workflow.md
+++ b/docs/tests/dataset-provider-workflow.md
@@ -6,7 +6,7 @@
 |-------|-------|
 | Status | Implemented |
 | Related design spec | `docs/design/dataset-provider-workflow.md` |
-| Issues | #216, #220 |
+| Issues | #216, #220, #233 |
 | Test module | `tests/test_dataset_provider.py` |
 
 ---
@@ -70,6 +70,29 @@ And frame events are not emitted to stdout
 
 **Fixture:** `tests/fixtures/dataset_hcrl_sample.csv`
 
+### TEST-DATASET-REPLAY-01: Remote Candump Replay Without Local File
+
+```gherkin
+Given a mocked remote candump HTTP response
+When the operator replays the remote URL
+Then candump frames are emitted to stdout
+And no complete local dataset file is required
+```
+
+**Fixture:** mocked `requests.get` response in `tests/test_dataset_provider.py`
+
+### TEST-DATASET-REPLAY-02: Catalog Ref Replay JSON Summary
+
+```gherkin
+Given the CANdid catalog entry defines default replay metadata
+When the operator runs `canarchy datasets replay catalog:candid --json`
+Then stdout contains a standard JSON result envelope
+And the result identifies `catalog:candid` and the default replay file
+And frame records are not interleaved into the JSON output
+```
+
+**Fixture:** mocked `requests.get` response in `tests/test_dataset_provider.py`
+
 ---
 
 ## Traceability
@@ -82,11 +105,16 @@ And frame events are not emitted to stdout
 | REQ-DATASET-STREAM-04 | TEST-DATASET-STREAM-01, TEST-DATASET-STREAM-04 |
 | REQ-DATASET-STREAM-05 | TEST-DATASET-STREAM-03 |
 | REQ-DATASET-STREAM-06 | Covered by existing malformed HCRL CSV conversion tests in `tests/test_dataset_provider.py` |
+| REQ-DATASET-REPLAY-01 | TEST-DATASET-REPLAY-01 |
+| REQ-DATASET-REPLAY-02 | TEST-DATASET-REPLAY-02 |
+| REQ-DATASET-REPLAY-03 | TEST-DATASET-REPLAY-01 |
+| REQ-DATASET-REPLAY-04 | TEST-DATASET-REPLAY-01, TEST-DATASET-REPLAY-02 |
+| REQ-DATASET-REPLAY-05 | TEST-DATASET-REPLAY-02 |
 
 ---
 
 ## Not Tested
 
-- Remote provider-specific streaming adapters are not tested because this increment only streams local downloaded dataset files.
+- Remote provider-specific replay is tested with mocked HTTP responses only; tests do not perform network downloads.
 - Live-bus replay is not tested because active replay is intentionally deferred.
 - Network access is not tested; all tests use checked-in fixtures.

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -59,7 +59,7 @@ TRANSPORT_COMMANDS = {"capture", "send", "filter", "stats", "generate", "capture
 DBC_COMMANDS = {"decode", "encode", "dbc inspect"}
 DBC_PROVIDER_COMMANDS = {"dbc provider list", "dbc search", "dbc fetch", "dbc cache list", "dbc cache prune", "dbc cache refresh"}
 SKILLS_COMMANDS = {"skills provider list", "skills search", "skills fetch", "skills cache list", "skills cache refresh"}
-DATASETS_COMMANDS = {"datasets provider list", "datasets search", "datasets inspect", "datasets fetch", "datasets cache list", "datasets cache refresh", "datasets convert", "datasets stream"}
+DATASETS_COMMANDS = {"datasets provider list", "datasets search", "datasets inspect", "datasets fetch", "datasets cache list", "datasets cache refresh", "datasets convert", "datasets stream", "datasets replay"}
 J1939_COMMANDS = {"j1939 monitor", "j1939 decode", "j1939 pgn", "j1939 spn", "j1939 tp sessions", "j1939 tp compare", "j1939 dm1", "j1939 faults", "j1939 summary", "j1939 inventory", "j1939 compare"}
 SESSION_COMMANDS = {"session save", "session load", "session show"}
 UDS_COMMANDS = {"uds scan", "uds trace", "uds services"}
@@ -456,6 +456,20 @@ def build_parser() -> CanarchyArgumentParser:
     datasets_stream.add_argument("--provider-ref", help="dataset provider ref to preserve in JSONL provenance")
     add_output_arguments(datasets_stream)
     datasets_stream.set_defaults(command="datasets stream")
+
+    datasets_replay = datasets_subparsers.add_parser("replay", help="Netflix-style streaming replay from a dataset ref or URL")
+    datasets_replay.add_argument("source", help="dataset ref (e.g. catalog:candid) or remote candump URL")
+    datasets_replay.add_argument(
+        "--format",
+        dest="output_format",
+        default="candump",
+        choices=["candump", "jsonl"],
+        help="stream output format (default: candump)",
+    )
+    datasets_replay.add_argument("--rate", type=float, default=1.0, help="playback rate multiplier (default: 1.0 real-time)")
+    datasets_replay.add_argument("--max-frames", type=int, default=None, help="stop after N frames")
+    add_output_arguments(datasets_replay)
+    datasets_replay.set_defaults(command="datasets replay")
 
     export = subparsers.add_parser("export", help="export session data")
     export.add_argument("source")
@@ -2800,7 +2814,67 @@ def datasets_payload(args: argparse.Namespace) -> tuple[dict[str, Any], list[dic
             ) from exc
         return (result, [], [])
 
+    if args.command == "datasets replay":
+        from canarchy.dataset_convert import ConversionError, stream_replay
+
+        try:
+            replay_source = resolve_dataset_replay_source(args.source, registry)
+            result = stream_replay(
+                replay_source["download_url"],
+                source_format=replay_source["source_format"],
+                output_format=args.output_format,
+                rate=args.rate,
+                max_frames=getattr(args, "max_frames", None),
+                emit_frames=False,
+            )
+        except ConversionError as exc:
+            raise CommandError(
+                command=args.command,
+                exit_code=EXIT_USER_ERROR,
+                errors=[ErrorDetail(code=exc.code, message=str(exc), hint=exc.hint)],
+            ) from exc
+        except DatasetError as exc:
+            raise CommandError(
+                command=args.command,
+                exit_code=EXIT_USER_ERROR,
+                errors=[ErrorDetail(code=exc.code, message=str(exc), hint=exc.hint)],
+            ) from exc
+        return ({**result, **replay_source}, [], [])
+
     raise AssertionError(f"unsupported datasets command: {args.command}")
+
+
+def resolve_dataset_replay_source(source: str, registry: Any) -> dict[str, Any]:
+    """Resolve a replay source from either a direct URL or dataset descriptor metadata."""
+    if source.startswith(("http://", "https://")):
+        return {
+            "source": source,
+            "source_type": "url",
+            "download_url": source,
+            "source_format": "candump",
+        }
+
+    from canarchy.dataset_provider import DatasetError
+
+    descriptor = registry.inspect(source)
+    replay = descriptor.metadata.get("replay") if isinstance(descriptor.metadata, dict) else None
+    if not isinstance(replay, dict) or not replay.get("download_url"):
+        raise DatasetError(
+            code="DATASET_REPLAY_UNAVAILABLE",
+            message=f"Dataset '{source}' does not define a replayable remote file.",
+            hint="Use `canarchy datasets inspect <ref>` to review available metadata, or pass a direct candump download URL.",
+        )
+
+    return {
+        "source": source,
+        "source_type": "dataset_ref",
+        "provider": descriptor.provider,
+        "name": descriptor.name,
+        "ref": f"{descriptor.provider}:{descriptor.name}",
+        "default_file": replay.get("default_file"),
+        "download_url": replay["download_url"],
+        "source_format": replay.get("source_format", "candump"),
+    }
 
 
 def uds_payload(args: argparse.Namespace) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
@@ -4101,6 +4175,37 @@ def emit_dataset_stream(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def emit_dataset_replay(args: argparse.Namespace) -> int:
+    """Handle datasets replay command - stream frames from a dataset ref or URL."""
+    from canarchy.dataset_provider import DatasetError, get_registry
+    from canarchy.dataset_convert import ConversionError, stream_replay
+
+    try:
+        replay_source = resolve_dataset_replay_source(args.source, get_registry())
+        result = stream_replay(
+            replay_source["download_url"],
+            source_format=replay_source["source_format"],
+            output_format=args.output_format,
+            rate=args.rate,
+            max_frames=getattr(args, "max_frames", None),
+        )
+    except ConversionError as exc:
+        result = error_result(
+            args.command,
+            errors=[ErrorDetail(code=exc.code, message=str(exc), hint=exc.hint)],
+        )
+        emit_result(result, "json")
+        return EXIT_USER_ERROR
+    except DatasetError as exc:
+        result = error_result(
+            args.command,
+            errors=[ErrorDetail(code=exc.code, message=str(exc), hint=exc.hint)],
+        )
+        emit_result(result, "json")
+        return EXIT_USER_ERROR
+    return EXIT_OK
+
+
 def _emit_warnings_jsonl(payload: dict[str, Any], result: CommandResult) -> None:
     for warning in payload["warnings"]:
         print(
@@ -4477,6 +4582,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return emit_live_gateway(args)
     if args.command == "datasets stream" and not args.json:
         return emit_dataset_stream(args)
+    if args.command == "datasets replay" and not args.json:
+        return emit_dataset_replay(args)
 
     exit_code, result = execute_command(argv)
     if result is not None:

--- a/src/canarchy/dataset_catalog.py
+++ b/src/canarchy/dataset_catalog.py
@@ -254,6 +254,11 @@ _CATALOG: list[dict[str, Any]] = [
             "maneuvers": ["brakes", "steering", "indicator", "lights", "gears", "engine", "driving"],
             "artifacts": ["CAN.log", "annot.log", "GPS.log", "meta.json", "cabin.mp4", "dashboard.mp4"],
             "note": "CAN logs (*_CAN.log) are ready for capture-info, stats, filter, re entropy, re counters.",
+            "replay": {
+                "default_file": "2_brakes_CAN.log",
+                "download_url": "https://ndownloader.figshare.com/files/54551156",
+                "source_format": "candump",
+            },
         },
     },
 ]

--- a/src/canarchy/dataset_convert.py
+++ b/src/canarchy/dataset_convert.py
@@ -4,14 +4,18 @@ from __future__ import annotations
 
 import csv
 import json
+import re
 import sys
+import time
 from pathlib import Path
 from typing import IO, Iterator
+
+import requests
 
 from canarchy.dataset_provider import DatasetError
 
 
-_SUPPORTED_SOURCE_FORMATS = ("hcrl-csv",)
+_SUPPORTED_SOURCE_FORMATS = ("hcrl-csv", "candump")
 _SUPPORTED_OUTPUT_FORMATS = ("candump", "jsonl")
 
 
@@ -48,16 +52,14 @@ def convert_file(
             hint="Provide a valid path to a downloaded dataset file.",
         )
 
-    if destination is None:
-        suffix = ".log" if output_format == "candump" else ".jsonl"
-        destination = str(src.with_suffix(suffix))
-
     if source_format == "hcrl-csv":
         frames = list(_parse_hcrl_csv(src))
+    elif source_format == "candump":
+        frames = list(_parse_candump(src))
     else:
         raise AssertionError(f"unhandled source format: {source_format}")
 
-    dest = Path(destination)
+    dest = Path(destination) if destination else src.with_suffix(".log" if output_format == "candump" else ".jsonl")
     dest.parent.mkdir(parents=True, exist_ok=True)
 
     if output_format == "candump":
@@ -103,16 +105,10 @@ def stream_file(
             hint="Use `--chunk-size` with a positive integer.",
         )
 
-    src = Path(source_path)
-    if not src.exists():
-        raise ConversionError(
-            code="SOURCE_NOT_FOUND",
-            message=f"Source file not found: {source_path}",
-            hint="Provide a valid path to a downloaded dataset file.",
-        )
-
     if source_format == "hcrl-csv":
-        frames = _parse_hcrl_csv(src)
+        frames = _parse_hcrl_csv(Path(source_path))
+    elif source_format == "candump":
+        frames = _parse_candump(Path(source_path))
     else:
         raise AssertionError(f"unhandled source format: {source_format}")
 
@@ -141,7 +137,7 @@ def stream_file(
         destination_label = str(dest)
 
     return {
-        "source": str(src),
+        "source": source_path,
         "destination": destination_label,
         "source_format": source_format,
         "output_format": output_format,
@@ -150,6 +146,131 @@ def stream_file(
         "frame_count": counts["frame_count"],
         "provider_ref": provider_ref,
         "streamed": True,
+    }
+
+
+def stream_replay(
+    source_url: str,
+    *,
+    source_format: str = "candump",
+    output_format: str = "candump",
+    rate: float = 1.0,
+    max_frames: int | None = None,
+    emit_frames: bool = True,
+    handle: IO[str] | None = None,
+) -> dict:
+    """Netflix-style streaming replay: download and play frames with timing.
+    
+    Downloads from remote URL incrementally and replays with original timing * rate.
+    No local file is required — frames stream directly from HTTP to output.
+    """
+    if source_format != "candump":
+        raise ConversionError(
+            code="UNSUPPORTED_SOURCE_FORMAT",
+            message=f"Streaming replay only supports candump format, got '{source_format}'.",
+            hint="Use source_format='candump' for streaming replay.",
+        )
+
+    if output_format not in _SUPPORTED_OUTPUT_FORMATS:
+        raise ConversionError(
+            code="UNSUPPORTED_OUTPUT_FORMAT",
+            message=f"Output format '{output_format}' is not supported.",
+            hint=f"Supported output formats: {', '.join(_SUPPORTED_OUTPUT_FORMATS)}.",
+        )
+    
+    if rate <= 0:
+        raise ConversionError(
+            code="INVALID_RATE",
+            message=f"Replay rate must be positive, got {rate}.",
+            hint="Use a positive rate like 1.0 (real-time) or 0.5 (half-speed).",
+        )
+
+    frame_count = 0
+    last_timestamp = None
+    start_time = time.monotonic()
+    output = handle or sys.stdout
+
+    with requests.get(source_url, stream=True) as resp:
+        resp.raise_for_status()
+        for line in resp.iter_lines():
+            if not line or not line.strip():
+                continue
+            
+            # iter_lines() returns bytes, decode to string
+            if isinstance(line, bytes):
+                line = line.decode("utf-8", errors="replace")
+            
+            # Parse candump line to get timestamp
+            frame = _parse_candump_line(line)
+            if frame is None:
+                continue
+            
+            if max_frames is not None and frame_count >= max_frames:
+                break
+            frame_count += 1
+            
+            # Timing: sleep to maintain original timing * rate
+            if last_timestamp is not None and frame["timestamp"] > last_timestamp:
+                delay = (frame["timestamp"] - last_timestamp) / rate
+                if delay > 0:
+                    time.sleep(min(delay, 1.0))  # Cap sleeps at 1s for safety
+            
+            last_timestamp = frame["timestamp"]
+            
+            if emit_frames:
+                if output_format == "candump":
+                    output_line = f"({frame['timestamp']:.6f}) {frame.get('interface') or 'can0'} {frame['arbitration_id']:X}#{frame['data'].hex().upper()}"
+                elif output_format == "jsonl":
+                    output_line = json.dumps(_frame_to_event(frame, source=source_format))
+                else:
+                    raise AssertionError(f"unhandled output format: {output_format}")
+                print(output_line, file=output, flush=True)
+            
+    elapsed = time.monotonic() - start_time
+    return {
+        "source_url": source_url,
+        "source_format": source_format,
+        "output_format": output_format,
+        "rate": rate,
+        "frame_count": frame_count,
+        "elapsed_seconds": elapsed,
+        "streamed": True,
+    }
+
+
+def _parse_candump(path: Path) -> Iterator[dict]:
+    """Parse candump format file incrementally."""
+    with open(path) as f:
+        for line in f:
+            frame = _parse_candump_line(line)
+            if frame:
+                yield frame
+
+
+def _parse_candump_line(line: str) -> dict | None:
+    """Parse a single candump line like: (0.000000) can0 420#3F0000334200F257"""
+    line = line.strip()
+    if not line:
+        return None
+    
+    match = re.match(r"\((\d+\.?\d*)\)\s+(\S+)\s+([0-9A-Fa-fXx]+)#([0-9A-Fa-f]*)", line)
+    if not match:
+        return None
+    
+    timestamp = float(match.group(1))
+    interface = match.group(2)
+    arb_id_str = match.group(3)
+    data_hex = match.group(4)
+    
+    arb_id = int(arb_id_str, 16)
+    data_bytes = bytes.fromhex(data_hex) if data_hex else b""
+    
+    return {
+        "timestamp": timestamp,
+        "interface": interface,
+        "arbitration_id": arb_id,
+        "data": data_bytes,
+        "dlc": len(data_bytes),
     }
 
 
@@ -190,6 +311,22 @@ def _parse_hcrl_csv(path: Path) -> Iterator[dict]:
             yield {"timestamp": timestamp, "arbitration_id": arb_id, "data": data_bytes, "label": label}
 
 
+def _frame_to_event(frame: dict, *, source: str) -> dict:
+    """Convert a frame dict to a FrameEvent."""
+    event = {
+        "event_type": "frame",
+        "source": source,
+        "timestamp": frame["timestamp"],
+        "payload": {
+            "arbitration_id": frame["arbitration_id"],
+            "data": frame["data"].hex().upper(),
+            "interface": frame.get("interface"),
+            "label": frame.get("label"),
+        },
+    }
+    return event
+
+
 def _stream_frames(
     frames: Iterator[dict],
     handle: IO[str],
@@ -199,77 +336,53 @@ def _stream_frames(
     chunk_size: int,
     provider_ref: str | None,
 ) -> dict:
+    """Stream frames to handle, emitting metadata chunks."""
     frame_count = 0
     chunk_index = 0
-    chunk_position = 0
+    frame_offset = 0
+
     for frame in frames:
-        if chunk_position >= chunk_size:
-            chunk_index += 1
-            chunk_position = 0
         if output_format == "candump":
-            handle.write(_format_candump_frame(frame))
+            line = f"({frame['timestamp']:.6f}) can0 {frame['arbitration_id']:x}#{frame['data'].hex().upper()}\n"
         elif output_format == "jsonl":
-            event = _frame_to_event(
-                frame,
-                source=source,
-                provider_ref=provider_ref,
-                frame_offset=frame_count,
-                chunk_index=chunk_index,
-                chunk_position=chunk_position,
-            )
-            handle.write(json.dumps(event, sort_keys=True) + "\n")
+            event = _frame_to_event(frame, source=source)
+            event["payload"]["dataset"] = {
+                "chunk_index": chunk_index,
+                "chunk_position": frame_count % chunk_size,
+                "frame_offset": frame_offset,
+                "provider_ref": provider_ref,
+            }
+            line = json.dumps(event) + "\n"
+        else:
+            raise AssertionError(f"unhandled output format: {output_format}")
+
+        handle.write(line)
         frame_count += 1
-        chunk_position += 1
-    handle.flush()
-    return {"frame_count": frame_count, "chunks": chunk_index + (1 if chunk_position else 0)}
+        frame_offset += 1
 
+        if frame_count % chunk_size == 0:
+            chunk_index += 1
 
-def _format_candump_frame(frame: dict) -> str:
-    ts = f"{frame['timestamp']:.6f}"
-    arb_id = f"{frame['arbitration_id']:X}"
-    data_hex = frame["data"].hex().upper()
-    return f"({ts}) can0 {arb_id}#{data_hex}\n"
-
-
-def _frame_to_event(
-    frame: dict,
-    *,
-    source: str,
-    provider_ref: str | None = None,
-    frame_offset: int | None = None,
-    chunk_index: int | None = None,
-    chunk_position: int | None = None,
-) -> dict:
-    event = {
-        "event_type": "frame",
-        "source": source,
-        "timestamp": frame["timestamp"],
-        "payload": {
-            "arbitration_id": frame["arbitration_id"],
-            "data": frame["data"].hex(),
-            "interface": None,
-        },
-    }
-    if frame.get("label"):
-        event["payload"]["label"] = frame["label"]
-    if provider_ref is not None or frame_offset is not None or chunk_index is not None:
-        event["payload"]["dataset"] = {
-            "provider_ref": provider_ref,
-            "frame_offset": frame_offset,
-            "chunk_index": chunk_index,
-            "chunk_position": chunk_position,
-        }
-    return event
+    # chunk_index is 0-based; if frame_count % chunk_size == 0, we have exactly frame_count/chunk_size chunks
+    if frame_count % chunk_size == 0:
+        chunks = frame_count // chunk_size
+    else:
+        chunks = (frame_count // chunk_size) + 1
+    return {"frame_count": frame_count, "chunks": chunks}
 
 
 def _write_candump(frames: list[dict], dest: Path) -> None:
-    """Write frames in candump log format: (timestamp) interface id#data"""
-    dest.write_text("".join(_format_candump_frame(frame) for frame in frames))
+    """Write frames as candump format."""
+    lines = [
+        f"({f['timestamp']:.6f}) can0 {f['arbitration_id']:x}#{f['data'].hex().upper()}"
+        for f in frames
+    ]
+    dest.write_text("\n".join(lines) + "\n")
 
 
 def _write_jsonl(frames: list[dict], dest: Path, *, source: str) -> None:
     """Write frames as JSONL FrameEvents."""
-    lines = [json.dumps(_frame_to_event(frame, source=source)) for frame in frames]
+    lines = [json.dumps(_frame_to_event(f, source=source)) for f in frames]
     dest.write_text("\n".join(lines) + ("\n" if lines else ""))
 
 

--- a/src/canarchy/dataset_convert.py
+++ b/src/canarchy/dataset_convert.py
@@ -105,10 +105,18 @@ def stream_file(
             hint="Use `--chunk-size` with a positive integer.",
         )
 
+    src = Path(source_path)
+    if not src.exists():
+        raise ConversionError(
+            code="SOURCE_NOT_FOUND",
+            message=f"Source file not found: {source_path}",
+            hint="Provide a valid path to a downloaded dataset file.",
+        )
+
     if source_format == "hcrl-csv":
-        frames = _parse_hcrl_csv(Path(source_path))
+        frames = _parse_hcrl_csv(src)
     elif source_format == "candump":
-        frames = _parse_candump(Path(source_path))
+        frames = _parse_candump(src)
     else:
         raise AssertionError(f"unhandled source format: {source_format}")
 
@@ -190,41 +198,48 @@ def stream_replay(
     start_time = time.monotonic()
     output = handle or sys.stdout
 
-    with requests.get(source_url, stream=True) as resp:
-        resp.raise_for_status()
-        for line in resp.iter_lines():
-            if not line or not line.strip():
-                continue
-            
-            # iter_lines() returns bytes, decode to string
-            if isinstance(line, bytes):
-                line = line.decode("utf-8", errors="replace")
-            
-            # Parse candump line to get timestamp
-            frame = _parse_candump_line(line)
-            if frame is None:
-                continue
-            
-            if max_frames is not None and frame_count >= max_frames:
-                break
-            frame_count += 1
-            
-            # Timing: sleep to maintain original timing * rate
-            if last_timestamp is not None and frame["timestamp"] > last_timestamp:
-                delay = (frame["timestamp"] - last_timestamp) / rate
-                if delay > 0:
-                    time.sleep(min(delay, 1.0))  # Cap sleeps at 1s for safety
-            
-            last_timestamp = frame["timestamp"]
-            
-            if emit_frames:
-                if output_format == "candump":
-                    output_line = f"({frame['timestamp']:.6f}) {frame.get('interface') or 'can0'} {frame['arbitration_id']:X}#{frame['data'].hex().upper()}"
-                elif output_format == "jsonl":
-                    output_line = json.dumps(_frame_to_event(frame, source=source_format))
-                else:
-                    raise AssertionError(f"unhandled output format: {output_format}")
-                print(output_line, file=output, flush=True)
+    try:
+        with requests.get(source_url, stream=True) as resp:
+            resp.raise_for_status()
+            for line in resp.iter_lines():
+                if not line or not line.strip():
+                    continue
+
+                # iter_lines() returns bytes, decode to string
+                if isinstance(line, bytes):
+                    line = line.decode("utf-8", errors="replace")
+
+                # Parse candump line to get timestamp
+                frame = _parse_candump_line(line)
+                if frame is None:
+                    continue
+
+                if max_frames is not None and frame_count >= max_frames:
+                    break
+                frame_count += 1
+
+                # Timing: sleep to maintain original timing * rate
+                if last_timestamp is not None and frame["timestamp"] > last_timestamp:
+                    delay = (frame["timestamp"] - last_timestamp) / rate
+                    if delay > 0:
+                        time.sleep(min(delay, 1.0))  # Cap sleeps at 1s for safety
+
+                last_timestamp = frame["timestamp"]
+
+                if emit_frames:
+                    if output_format == "candump":
+                        output_line = f"({frame['timestamp']:.6f}) {frame.get('interface') or 'can0'} {frame['arbitration_id']:X}#{frame['data'].hex().upper()}"
+                    elif output_format == "jsonl":
+                        output_line = json.dumps(_frame_to_event(frame, source=source_format))
+                    else:
+                        raise AssertionError(f"unhandled output format: {output_format}")
+                    print(output_line, file=output, flush=True)
+    except requests.RequestException as exc:
+        raise ConversionError(
+            code="DATASET_REPLAY_FETCH_FAILED",
+            message=f"Failed to stream replay source: {source_url}",
+            hint="Check the dataset replay URL, network connectivity, and provider availability.",
+        ) from exc
             
     elapsed = time.monotonic() - start_time
     return {

--- a/tests/test_dataset_provider.py
+++ b/tests/test_dataset_provider.py
@@ -10,6 +10,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+import requests
+
 from canarchy.dataset_catalog import PublicDatasetProvider
 from canarchy.dataset_convert import ConversionError, convert_file, stream_file, stream_replay
 from canarchy.dataset_provider import (
@@ -367,6 +369,11 @@ class DatasetConvertTests(unittest.TestCase):
             stream_file(src, source_format="hcrl-csv", output_format="jsonl", chunk_size=0)
         self.assertEqual(ctx.exception.code, "INVALID_CHUNK_SIZE")
 
+    def test_stream_missing_source_file_raises_conversion_error(self) -> None:
+        with self.assertRaises(ConversionError) as ctx:
+            stream_file("/nonexistent/path.csv", source_format="hcrl-csv", output_format="jsonl")
+        self.assertEqual(ctx.exception.code, "SOURCE_NOT_FOUND")
+
     def test_stream_replay_reads_remote_candump_without_local_file(self) -> None:
         response = FakeStreamingResponse([
             "(0.000000) can0 316#0000000000000000",
@@ -387,6 +394,12 @@ class DatasetConvertTests(unittest.TestCase):
                 result = stream_replay("https://example.test/candid.log", emit_frames=False)
         self.assertEqual(result["frame_count"], 1)
         self.assertEqual(stdout.getvalue(), "")
+
+    def test_stream_replay_http_failure_raises_conversion_error(self) -> None:
+        with patch("canarchy.dataset_convert.requests.get", side_effect=requests.ConnectionError("offline")):
+            with self.assertRaises(ConversionError) as ctx:
+                stream_replay("https://example.test/candid.log")
+        self.assertEqual(ctx.exception.code, "DATASET_REPLAY_FETCH_FAILED")
 
 
 # ---------------------------------------------------------------------------
@@ -569,6 +582,17 @@ class CliIntegrationTests(unittest.TestCase):
         self.assertFalse(data["ok"])
         self.assertEqual(data["errors"][0]["code"], "INVALID_CHUNK_SIZE")
 
+    def test_datasets_stream_missing_source_returns_structured_error(self) -> None:
+        code, out, _ = run_cli(
+            "datasets", "stream", "/nonexistent/path.csv",
+            "--source-format", "hcrl-csv",
+            "--format", "jsonl",
+        )
+        self.assertEqual(code, 1)
+        data = json.loads(out)
+        self.assertFalse(data["ok"])
+        self.assertEqual(data["errors"][0]["code"], "SOURCE_NOT_FOUND")
+
     def test_datasets_replay_catalog_ref_json_summary(self) -> None:
         response = FakeStreamingResponse(["(0.000000) can0 316#0000000000000000"])
         with patch("canarchy.dataset_convert.requests.get", return_value=response):
@@ -593,6 +617,17 @@ class CliIntegrationTests(unittest.TestCase):
                 "datasets", "replay", "https://example.test/candid.log",
                 "--rate", "1000",
                 "--max-frames", "1",
-            )
+        )
         self.assertEqual(code, 0)
         self.assertEqual(out.strip(), "(0.000000) can0 316#0000000000000000")
+
+    def test_datasets_replay_http_failure_returns_structured_error(self) -> None:
+        with patch("canarchy.dataset_convert.requests.get", side_effect=requests.ConnectionError("offline")):
+            code, out, _ = run_cli(
+                "datasets", "replay", "https://example.test/candid.log",
+                "--json",
+            )
+        self.assertEqual(code, 1)
+        data = json.loads(out)
+        self.assertFalse(data["ok"])
+        self.assertEqual(data["errors"][0]["code"], "DATASET_REPLAY_FETCH_FAILED")

--- a/tests/test_dataset_provider.py
+++ b/tests/test_dataset_provider.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from canarchy.dataset_catalog import PublicDatasetProvider
-from canarchy.dataset_convert import ConversionError, convert_file, stream_file
+from canarchy.dataset_convert import ConversionError, convert_file, stream_file, stream_replay
 from canarchy.dataset_provider import (
     DatasetDescriptor,
     DatasetError,
@@ -23,6 +23,24 @@ from canarchy.dataset_provider import (
 
 
 FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class FakeStreamingResponse:
+    def __init__(self, lines: list[str]) -> None:
+        self.lines = lines
+
+    def __enter__(self) -> "FakeStreamingResponse":
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def iter_lines(self):
+        for line in self.lines:
+            yield line.encode()
 
 
 def run_cli(*argv: str) -> tuple[int, str, str]:
@@ -349,6 +367,27 @@ class DatasetConvertTests(unittest.TestCase):
             stream_file(src, source_format="hcrl-csv", output_format="jsonl", chunk_size=0)
         self.assertEqual(ctx.exception.code, "INVALID_CHUNK_SIZE")
 
+    def test_stream_replay_reads_remote_candump_without_local_file(self) -> None:
+        response = FakeStreamingResponse([
+            "(0.000000) can0 316#0000000000000000",
+            "(0.001000) can0 18F#0000000000600000",
+        ])
+        with patch("canarchy.dataset_convert.requests.get", return_value=response) as get:
+            with patch("sys.stdout", new_callable=io.StringIO) as stdout:
+                result = stream_replay("https://example.test/candid.log", rate=1000.0)
+        get.assert_called_once_with("https://example.test/candid.log", stream=True)
+        self.assertEqual(result["frame_count"], 2)
+        self.assertEqual(result["output_format"], "candump")
+        self.assertIn("316#0000000000000000", stdout.getvalue())
+
+    def test_stream_replay_json_summary_suppresses_frame_output(self) -> None:
+        response = FakeStreamingResponse(["(0.000000) can0 316#0000000000000000"])
+        with patch("canarchy.dataset_convert.requests.get", return_value=response):
+            with patch("sys.stdout", new_callable=io.StringIO) as stdout:
+                result = stream_replay("https://example.test/candid.log", emit_frames=False)
+        self.assertEqual(result["frame_count"], 1)
+        self.assertEqual(stdout.getvalue(), "")
+
 
 # ---------------------------------------------------------------------------
 # CLI integration
@@ -529,3 +568,31 @@ class CliIntegrationTests(unittest.TestCase):
         data = json.loads(out)
         self.assertFalse(data["ok"])
         self.assertEqual(data["errors"][0]["code"], "INVALID_CHUNK_SIZE")
+
+    def test_datasets_replay_catalog_ref_json_summary(self) -> None:
+        response = FakeStreamingResponse(["(0.000000) can0 316#0000000000000000"])
+        with patch("canarchy.dataset_convert.requests.get", return_value=response):
+            code, out, _ = run_cli(
+                "datasets", "replay", "catalog:candid",
+                "--rate", "1000",
+                "--max-frames", "1",
+                "--json",
+            )
+        self.assertEqual(code, 0)
+        data = json.loads(out)
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["data"]["ref"], "catalog:candid")
+        self.assertEqual(data["data"]["default_file"], "2_brakes_CAN.log")
+        self.assertEqual(data["data"]["frame_count"], 1)
+        self.assertNotIn("316#", out.splitlines()[0])
+
+    def test_datasets_replay_direct_url_streams_frames(self) -> None:
+        response = FakeStreamingResponse(["(0.000000) can0 316#0000000000000000"])
+        with patch("canarchy.dataset_convert.requests.get", return_value=response):
+            code, out, _ = run_cli(
+                "datasets", "replay", "https://example.test/candid.log",
+                "--rate", "1000",
+                "--max-frames", "1",
+            )
+        self.assertEqual(code, 0)
+        self.assertEqual(out.strip(), "(0.000000) can0 316#0000000000000000")


### PR DESCRIPTION
## Summary
- Add `canarchy datasets replay` for streaming remote candump replay from a direct URL or replayable dataset ref.
- Add default CANdid replay metadata for `catalog:candid`.
- Update command docs, agent docs, design/test specs, changelog, and tests for issue #233.

## Tests
- `uv run pytest`
- `uv run pytest tests/test_dataset_provider.py -k 'stream or replay' -vv`
- `uv run canarchy datasets replay catalog:candid --rate 1000 --max-frames 2 --json`
- `uv run canarchy datasets replay catalog:candid --rate 1000 --max-frames 2`
- `uv run canarchy datasets replay catalog:candid --format jsonl --rate 1000 --max-frames 2`

Closes #233