### PR TITLE
fix: correct MCP stats and filter argv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Fixed
 
 * Made `canarchy datasets provider list` and `canarchy datasets search <query>` default to compact readable output instead of dumping raw Python result dictionaries, added `--verbose` for detailed search result blocks, and preserved explicit JSON output for automation.
+* Fixed MCP `stats` and `filter` tool argument mapping so they invoke the current CLI grammar (`stats --file <file>` and `filter <expr> --file <file>`) and return successful canonical envelopes. Closes #237.
 
 ## [0.6.0] - 2026-04-28
 

--- a/docs/tests/mcp-server.md
+++ b/docs/tests/mcp-server.md
@@ -15,7 +15,7 @@
 | REQ-MCP-01 | `mcp serve` subcommand starts MCP server | TEST-MCP-01 |
 | REQ-MCP-02 | Each selected CLI command surfaces as an MCP tool | TEST-MCP-02, TEST-MCP-03 |
 | REQ-MCP-03 | Input schemas derived from argparse definitions | TEST-MCP-04 |
-| REQ-MCP-04 | Tool responses use canonical event envelope | TEST-MCP-05, TEST-MCP-06, TEST-MCP-19 |
+| REQ-MCP-04 | Tool responses use canonical event envelope | TEST-MCP-05, TEST-MCP-06, TEST-MCP-19, TEST-MCP-20, TEST-MCP-21 |
 | REQ-MCP-05 | Invalid inputs return same error codes as CLI | TEST-MCP-07, TEST-MCP-08 |
 | REQ-MCP-06 | Tool discovery returns all registered MCP tools with metadata | TEST-MCP-02, TEST-MCP-03 |
 | REQ-MCP-07 | stdio transport only | TEST-MCP-01 |
@@ -112,6 +112,34 @@ When   `handle_call_tool("capture_info", {"file": "tests/fixtures/sample.candump
 Then   the response `text` shall parse as JSON with `ok` equal to `true`
 And    `command` shall equal `"capture-info"`
 And    `data.frame_count` and `data.unique_ids` shall both be greater than `0`
+```
+
+**Fixture:** `tests/fixtures/sample.candump`.
+
+---
+
+### `TEST-MCP-20` — `stats` maps file input to current CLI grammar
+
+```gherkin
+Given  the MCP server is initialised
+When   `handle_call_tool("stats", {"file": "tests/fixtures/sample.candump"})` is called
+Then   the response `text` shall parse as JSON with `ok` equal to `true`
+And    `command` shall equal `"stats"`
+And    the result shall report the expected frame and arbitration-ID counts
+```
+
+**Fixture:** `tests/fixtures/sample.candump`.
+
+---
+
+### `TEST-MCP-21` — `filter` maps expression and file input to current CLI grammar
+
+```gherkin
+Given  the MCP server is initialised
+When   `handle_call_tool("filter", {"file": "tests/fixtures/sample.candump", "expression": "id==0x18FEEE31"})` is called
+Then   the response `text` shall parse as JSON with `ok` equal to `true`
+And    `command` shall equal `"filter"`
+And    the result shall contain one matching frame
 ```
 
 **Fixture:** `tests/fixtures/sample.candump`.

--- a/src/canarchy/mcp_server.py
+++ b/src/canarchy/mcp_server.py
@@ -547,7 +547,7 @@ def _build_argv(tool_name: str, arguments: dict[str, Any]) -> list[str]:
                 argv += ["--rate", str(a["rate"])]
             return argv + ["--json"]
         case "filter":
-            argv = ["filter", a["file"], a["expression"]]
+            argv = ["filter", a["expression"], "--file", a["file"]]
             if a.get("offset") is not None and a["offset"] > 0:
                 argv += ["--offset", str(a["offset"])]
             if a.get("max_frames") is not None:
@@ -556,7 +556,7 @@ def _build_argv(tool_name: str, arguments: dict[str, Any]) -> list[str]:
                 argv += ["--seconds", str(a["seconds"])]
             return argv + ["--json"]
         case "stats":
-            argv = ["stats", a["file"]]
+            argv = ["stats", "--file", a["file"]]
             if a.get("offset") is not None and a["offset"] > 0:
                 argv += ["--offset", str(a["offset"])]
             if a.get("max_frames") is not None:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -83,6 +83,34 @@ def test_call_tool_capture_info():
     assert payload["data"]["unique_ids"] == 3
 
 
+def test_call_tool_stats_uses_file_flag():
+    results = asyncio.run(
+        handle_call_tool("stats", {"file": str(FIXTURES / "sample.candump")})
+    )
+    assert len(results) == 1
+    payload = json.loads(results[0].text)
+    assert payload["ok"] is True
+    assert payload["command"] == "stats"
+    assert payload["data"]["total_frames"] == 3
+    assert payload["data"]["unique_arbitration_ids"] == 3
+
+
+def test_call_tool_filter_orders_expression_before_file_flag():
+    results = asyncio.run(
+        handle_call_tool(
+            "filter",
+            {"file": str(FIXTURES / "sample.candump"), "expression": "id==0x18FEEE31"},
+        )
+    )
+    assert len(results) == 1
+    payload = json.loads(results[0].text)
+    assert payload["ok"] is True
+    assert payload["command"] == "filter"
+    assert len(payload["data"]["events"]) == 1
+    frame = payload["data"]["events"][0]["payload"]["frame"]
+    assert frame["arbitration_id"] == 0x18FEEE31
+
+
 # --- TEST-MCP-07: invalid frame_id returns structured error ----------------
 
 def test_call_tool_send_invalid_frame_id():
@@ -137,6 +165,19 @@ def test_build_argv_capture():
 def test_build_argv_capture_info():
     argv = _build_argv("capture_info", {"file": "trace.candump"})
     assert argv == ["capture-info", "--file", "trace.candump", "--json"]
+
+
+def test_build_argv_stats_uses_file_flag():
+    argv = _build_argv("stats", {"file": "trace.candump", "max_frames": 50})
+    assert argv == ["stats", "--file", "trace.candump", "--max-frames", "50", "--json"]
+
+
+def test_build_argv_filter_uses_expression_then_file_flag():
+    argv = _build_argv(
+        "filter",
+        {"file": "trace.candump", "expression": "id==0x123", "seconds": 2.5},
+    )
+    assert argv == ["filter", "id==0x123", "--file", "trace.candump", "--seconds", "2.5", "--json"]
 
 
 def test_build_argv_j1939_monitor_with_pgn():


### PR DESCRIPTION
## Summary
- Fixes MCP `stats` argv construction to call `canarchy stats --file <file>`.
- Fixes MCP `filter` argv construction to call `canarchy filter <expression> --file <file>`.
- Adds argv and end-to-end MCP tests for both tools.
- Updates MCP test spec traceability and changelog.

## Verification
- `uv run pytest tests/test_mcp.py -v`
- `uv run pytest --tb=short`
- MCP smoke test via `handle_call_tool` for `stats` and `filter`

Refs #237