### PR TITLE
fix: handle dataset replay broken pipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 * Made `canarchy datasets provider list` and `canarchy datasets search <query>` default to compact readable output instead of dumping raw Python result dictionaries, added `--verbose` for detailed search result blocks, and preserved explicit JSON output for automation.
 * Fixed MCP `stats` and `filter` tool argument mapping so they invoke the current CLI grammar (`stats --file <file>` and `filter <expr> --file <file>`) and return successful canonical envelopes. Closes #237.
+* Made `canarchy datasets replay` stop cleanly on closed stdout pipes instead of printing a Python `BrokenPipeError` traceback. Closes #240.
 
 ## [0.6.0] - 2026-04-28
 

--- a/docs/design/dataset-provider-workflow.md
+++ b/docs/design/dataset-provider-workflow.md
@@ -204,6 +204,7 @@ building a full in-memory frame list.
 | REQ-DATASET-REPLAY-03 | Ubiquitous | The system shall stream remote replay frames incrementally without requiring a complete local dataset file. |
 | REQ-DATASET-REPLAY-04 | Ubiquitous | The system shall support candump and JSONL stdout replay formats. |
 | REQ-DATASET-REPLAY-05 | Optional feature | Where `--json` is specified, the system shall emit a standard result envelope without interleaving frame records. |
+| REQ-DATASET-REPLAY-06 | Unwanted behaviour | If replay stdout is closed by a downstream pipeline consumer, the system shall stop replay cleanly without printing a Python traceback. |
 
 ---
 

--- a/docs/tests/dataset-provider-workflow.md
+++ b/docs/tests/dataset-provider-workflow.md
@@ -115,6 +115,18 @@ And frame records are not interleaved into the JSON output
 
 **Fixture:** mocked `requests.get` response in `tests/test_dataset_provider.py`
 
+### TEST-DATASET-REPLAY-03: Closed Replay Stdout Stops Cleanly
+
+```gherkin
+Given a mocked remote candump HTTP response
+And a replay output handle that raises `BrokenPipeError`
+When the operator replays the remote URL
+Then replay stops without raising a traceback
+And the result reports `stop_reason` as `broken_pipe`
+```
+
+**Fixture:** mocked `requests.get` response and broken-pipe writer in `tests/test_dataset_provider.py`
+
 ---
 
 ## Traceability
@@ -135,6 +147,7 @@ And frame records are not interleaved into the JSON output
 | REQ-DATASET-REPLAY-03 | TEST-DATASET-REPLAY-01 |
 | REQ-DATASET-REPLAY-04 | TEST-DATASET-REPLAY-01, TEST-DATASET-REPLAY-02 |
 | REQ-DATASET-REPLAY-05 | TEST-DATASET-REPLAY-02 |
+| REQ-DATASET-REPLAY-06 | TEST-DATASET-REPLAY-03 |
 
 ---
 

--- a/src/canarchy/dataset_convert.py
+++ b/src/canarchy/dataset_convert.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import json
+import os
 import re
 import sys
 import time
@@ -197,6 +198,7 @@ def stream_replay(
     last_timestamp = None
     start_time = time.monotonic()
     output = handle or sys.stdout
+    stop_reason = "eof"
 
     try:
         with requests.get(source_url, stream=True) as resp:
@@ -215,6 +217,7 @@ def stream_replay(
                     continue
 
                 if max_frames is not None and frame_count >= max_frames:
+                    stop_reason = "max_frames"
                     break
                 frame_count += 1
 
@@ -233,7 +236,12 @@ def stream_replay(
                         output_line = json.dumps(_frame_to_event(frame, source=source_format))
                     else:
                         raise AssertionError(f"unhandled output format: {output_format}")
-                    print(output_line, file=output, flush=True)
+                    try:
+                        print(output_line, file=output, flush=True)
+                    except BrokenPipeError:
+                        stop_reason = "broken_pipe"
+                        _silence_broken_stdout(output)
+                        break
     except requests.RequestException as exc:
         raise ConversionError(
             code="DATASET_REPLAY_FETCH_FAILED",
@@ -249,8 +257,21 @@ def stream_replay(
         "rate": rate,
         "frame_count": frame_count,
         "elapsed_seconds": elapsed,
+        "stop_reason": stop_reason,
         "streamed": True,
     }
+
+
+def _silence_broken_stdout(output: IO[str]) -> None:
+    """Prevent Python shutdown from printing a second BrokenPipeError."""
+    if output is not sys.stdout:
+        return
+    try:
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+        os.close(devnull)
+    except (AttributeError, OSError, ValueError):
+        pass
 
 
 def _parse_candump(path: Path) -> Iterator[dict]:

--- a/tests/test_dataset_provider.py
+++ b/tests/test_dataset_provider.py
@@ -45,6 +45,11 @@ class FakeStreamingResponse:
             yield line.encode()
 
 
+class BrokenPipeWriter(io.StringIO):
+    def write(self, s: str) -> int:
+        raise BrokenPipeError("closed pipe")
+
+
 def run_cli(*argv: str) -> tuple[int, str, str]:
     from canarchy.cli import main
 
@@ -413,6 +418,20 @@ class DatasetConvertTests(unittest.TestCase):
             with self.assertRaises(ConversionError) as ctx:
                 stream_replay("https://example.test/candid.log")
         self.assertEqual(ctx.exception.code, "DATASET_REPLAY_FETCH_FAILED")
+
+    def test_stream_replay_broken_pipe_stops_cleanly(self) -> None:
+        response = FakeStreamingResponse([
+            "(0.000000) can0 316#0000000000000000",
+            "(0.001000) can0 18F#0000000000600000",
+        ])
+        with patch("canarchy.dataset_convert.requests.get", return_value=response):
+            result = stream_replay(
+                "https://example.test/candid.log",
+                rate=1000.0,
+                handle=BrokenPipeWriter(),
+            )
+        self.assertEqual(result["frame_count"], 1)
+        self.assertEqual(result["stop_reason"], "broken_pipe")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Treats closed stdout during `datasets replay` as a normal early pipeline stop instead of surfacing a Python traceback.
- Records `stop_reason: broken_pipe` in the replay result for testability and structured summaries.
- Adds dataset replay broken-pipe test coverage and updates the dataset workflow specs/changelog.

## Verification
- `python3 -m py_compile src/canarchy/dataset_convert.py`
- `uv run pytest tests/test_dataset_provider.py -v`
- `uv run pytest --tb=short`
- Smoke: `uv run canarchy datasets replay catalog:candid --rate 1000 | head -n 1` produced one frame and empty stderr

Refs #240