### PR TITLE
Add dataset replay dry-run planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * Added `canarchy datasets stream` for chunked streaming of downloaded dataset files to candump or JSONL, including JSONL provenance metadata for provider refs, frame offsets, and chunk positions so large datasets can be piped into analysis without buffering the full conversion in memory.
 * Added `candid` (CANdid) dataset to the built-in catalog: VehicleSec 2025 paper dataset with 10-passenger-vehicle candump-format CAN logs, annotations, GPS, metadata, and video. Ref: `catalog:candid`. Closes #225.
 * Added `canarchy datasets replay` for Netflix-style streaming playback from a direct candump URL or replayable dataset ref such as `catalog:candid`, with candump/JSONL stdout output, rate control, and JSON summary mode. Closes #233.
+* Added `canarchy datasets replay --dry-run` so operators and agents can resolve replay metadata for dataset refs or direct URLs without opening the remote stream. Closes #247.
 * Added `pivot-auto-datasets` to the built-in catalog as a curated source index for CAN, CAN-FD, J1939, and broader automotive datasets listed by the PIVOT Project. Closes #235.
 
 ### Fixed

--- a/docs/command_spec.md
+++ b/docs/command_spec.md
@@ -526,7 +526,7 @@ Notes:
 Stream a remote candump dataset file directly to stdout with replay timing. The source may be a direct candump download URL or a replayable dataset ref such as `catalog:candid`.
 
 ```bash
-canarchy datasets replay <dataset-ref-or-url> [--format candump|jsonl] [--rate <multiplier>] [--max-frames <n>] [--json]
+canarchy datasets replay <dataset-ref-or-url> [--format candump|jsonl] [--rate <multiplier>] [--max-frames <n>] [--dry-run] [--json]
 ```
 
 Examples:
@@ -536,6 +536,7 @@ canarchy datasets replay catalog:candid --rate 1.0
 canarchy datasets replay catalog:candid --format jsonl --rate 10 --max-frames 1000
 canarchy datasets replay https://ndownloader.figshare.com/files/54551156 --rate 1000 --max-frames 10
 canarchy datasets replay catalog:candid --rate 1000 --max-frames 10 --json
+canarchy datasets replay catalog:candid --dry-run --json
 ```
 
 Notes:
@@ -543,6 +544,7 @@ Notes:
 * without `--json`, replayed frames are written directly to stdout as candump or JSONL records for piping
 * with `--json`, stdout contains a clean standard result envelope with replay metadata and no frame records
 * replay downloads incrementally from the remote HTTP response and does not require a complete local dataset file
+* `--dry-run` resolves replay source metadata without opening the remote stream
 * `catalog:candid` currently resolves to the CANdid `2_brakes_CAN.log` Figshare file as its default replay source
 
 ### session save

--- a/docs/design/dataset-provider-workflow.md
+++ b/docs/design/dataset-provider-workflow.md
@@ -32,7 +32,7 @@ canarchy datasets cache list
 canarchy datasets cache refresh [--provider <name>]
 canarchy datasets convert <file> --source-format hcrl-csv --format candump|jsonl [--output <path>]
 canarchy datasets stream <file> --source-format hcrl-csv --format candump|jsonl [--chunk-size N] [--provider-ref <ref>] [--output <path>]
-canarchy datasets replay <dataset-ref-or-url> [--format candump|jsonl] [--rate N] [--max-frames N]
+canarchy datasets replay <dataset-ref-or-url> [--format candump|jsonl] [--rate N] [--max-frames N] [--dry-run]
 ```
 
 All commands follow the standard `--json`, `--jsonl`, `--table`, `--raw` output modes.
@@ -205,6 +205,7 @@ building a full in-memory frame list.
 | REQ-DATASET-REPLAY-04 | Ubiquitous | The system shall support candump and JSONL stdout replay formats. |
 | REQ-DATASET-REPLAY-05 | Optional feature | Where `--json` is specified, the system shall emit a standard result envelope without interleaving frame records. |
 | REQ-DATASET-REPLAY-06 | Unwanted behaviour | If replay stdout is closed by a downstream pipeline consumer, the system shall stop replay cleanly without printing a Python traceback. |
+| REQ-DATASET-REPLAY-07 | Optional feature | Where `--dry-run` is specified, the system shall resolve replay source metadata without opening the remote stream. |
 
 ---
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -161,6 +161,7 @@ The [CANdid dataset](https://doi.org/10.25909/29068553) (VehicleSec 2025) provid
 Replay the default CANdid catalog stream directly from the remote provider without downloading the full file first:
 
 ```bash
+canarchy datasets replay catalog:candid --dry-run --json
 canarchy datasets replay catalog:candid --rate 1.0
 canarchy datasets replay catalog:candid --format jsonl --rate 10 --max-frames 1000
 ```

--- a/docs/tests/dataset-provider-workflow.md
+++ b/docs/tests/dataset-provider-workflow.md
@@ -127,6 +127,18 @@ And the result reports `stop_reason` as `broken_pipe`
 
 **Fixture:** mocked `requests.get` response and broken-pipe writer in `tests/test_dataset_provider.py`
 
+### TEST-DATASET-REPLAY-04: Dry Run Resolves Replay Source Without Streaming
+
+```gherkin
+Given the CANdid catalog entry defines default replay metadata
+When the operator runs `canarchy datasets replay catalog:candid --dry-run --json`
+Then stdout contains a standard JSON result envelope
+And the result identifies the resolved replay source, output format, rate, and frame limit
+And no remote stream is opened
+```
+
+**Fixture:** mocked `requests.get` assertion in `tests/test_dataset_provider.py`
+
 ---
 
 ## Traceability
@@ -148,6 +160,7 @@ And the result reports `stop_reason` as `broken_pipe`
 | REQ-DATASET-REPLAY-04 | TEST-DATASET-REPLAY-01, TEST-DATASET-REPLAY-02 |
 | REQ-DATASET-REPLAY-05 | TEST-DATASET-REPLAY-02 |
 | REQ-DATASET-REPLAY-06 | TEST-DATASET-REPLAY-03 |
+| REQ-DATASET-REPLAY-07 | TEST-DATASET-REPLAY-04 |
 
 ---
 

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -468,6 +468,7 @@ def build_parser() -> CanarchyArgumentParser:
     )
     datasets_replay.add_argument("--rate", type=float, default=1.0, help="playback rate multiplier (default: 1.0 real-time)")
     datasets_replay.add_argument("--max-frames", type=int, default=None, help="stop after N frames")
+    datasets_replay.add_argument("--dry-run", action="store_true", help="resolve replay source metadata without opening the stream")
     add_output_arguments(datasets_replay)
     datasets_replay.set_defaults(command="datasets replay")
 
@@ -2819,6 +2820,8 @@ def datasets_payload(args: argparse.Namespace) -> tuple[dict[str, Any], list[dic
 
         try:
             replay_source = resolve_dataset_replay_source(args.source, registry)
+            if getattr(args, "dry_run", False):
+                return (dataset_replay_plan(args, replay_source), [], [])
             result = stream_replay(
                 replay_source["download_url"],
                 source_format=replay_source["source_format"],
@@ -2868,12 +2871,27 @@ def resolve_dataset_replay_source(source: str, registry: Any) -> dict[str, Any]:
     return {
         "source": source,
         "source_type": "dataset_ref",
+        "is_replayable": True,
         "provider": descriptor.provider,
         "name": descriptor.name,
         "ref": f"{descriptor.provider}:{descriptor.name}",
         "default_file": replay.get("default_file"),
         "download_url": replay["download_url"],
         "source_format": replay.get("source_format", "candump"),
+    }
+
+
+def dataset_replay_plan(args: argparse.Namespace, replay_source: dict[str, Any]) -> dict[str, Any]:
+    """Return replay source resolution metadata without opening the remote stream."""
+    return {
+        **replay_source,
+        "dry_run": True,
+        "is_replayable": True,
+        "output_format": args.output_format,
+        "rate": args.rate,
+        "max_frames": getattr(args, "max_frames", None),
+        "streamed": False,
+        "would_stream": True,
     }
 
 
@@ -4582,7 +4600,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return emit_live_gateway(args)
     if args.command == "datasets stream" and not args.json:
         return emit_dataset_stream(args)
-    if args.command == "datasets replay" and not args.json:
+    if args.command == "datasets replay" and not args.json and not getattr(args, "dry_run", False):
         return emit_dataset_replay(args)
 
     exit_code, result = execute_command(argv)

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -2820,6 +2820,7 @@ def datasets_payload(args: argparse.Namespace) -> tuple[dict[str, Any], list[dic
 
         try:
             replay_source = resolve_dataset_replay_source(args.source, registry)
+            validate_dataset_replay_options(args, replay_source)
             if getattr(args, "dry_run", False):
                 return (dataset_replay_plan(args, replay_source), [], [])
             result = stream_replay(
@@ -2893,6 +2894,25 @@ def dataset_replay_plan(args: argparse.Namespace, replay_source: dict[str, Any])
         "streamed": False,
         "would_stream": True,
     }
+
+
+def validate_dataset_replay_options(args: argparse.Namespace, replay_source: dict[str, Any]) -> None:
+    """Validate replay options that dry-run plans claim would be streamable."""
+    from canarchy.dataset_convert import ConversionError
+
+    source_format = replay_source.get("source_format", "candump")
+    if source_format != "candump":
+        raise ConversionError(
+            code="UNSUPPORTED_SOURCE_FORMAT",
+            message=f"Streaming replay only supports candump format, got '{source_format}'.",
+            hint="Use source_format='candump' for streaming replay.",
+        )
+    if args.rate <= 0:
+        raise ConversionError(
+            code="INVALID_RATE",
+            message=f"Replay rate must be positive, got {args.rate}.",
+            hint="Use a positive rate like 1.0 (real-time) or 0.5 (half-speed).",
+        )
 
 
 def uds_payload(args: argparse.Namespace) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:

--- a/tests/test_dataset_provider.py
+++ b/tests/test_dataset_provider.py
@@ -663,3 +663,53 @@ class CliIntegrationTests(unittest.TestCase):
         data = json.loads(out)
         self.assertFalse(data["ok"])
         self.assertEqual(data["errors"][0]["code"], "DATASET_REPLAY_FETCH_FAILED")
+
+    def test_datasets_replay_catalog_ref_dry_run_does_not_open_stream(self) -> None:
+        with patch("canarchy.dataset_convert.requests.get") as get:
+            code, out, _ = run_cli(
+                "datasets", "replay", "catalog:candid",
+                "--format", "jsonl",
+                "--rate", "10",
+                "--max-frames", "5",
+                "--dry-run",
+                "--json",
+            )
+        self.assertEqual(code, 0)
+        get.assert_not_called()
+        data = json.loads(out)
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["data"]["ref"], "catalog:candid")
+        self.assertEqual(data["data"]["default_file"], "2_brakes_CAN.log")
+        self.assertEqual(data["data"]["output_format"], "jsonl")
+        self.assertEqual(data["data"]["rate"], 10.0)
+        self.assertEqual(data["data"]["max_frames"], 5)
+        self.assertTrue(data["data"]["dry_run"])
+        self.assertTrue(data["data"]["would_stream"])
+        self.assertFalse(data["data"]["streamed"])
+
+    def test_datasets_replay_direct_url_dry_run_does_not_open_stream(self) -> None:
+        with patch("canarchy.dataset_convert.requests.get") as get:
+            code, out, _ = run_cli(
+                "datasets", "replay", "https://example.test/candid.log",
+                "--dry-run",
+                "--json",
+            )
+        self.assertEqual(code, 0)
+        get.assert_not_called()
+        data = json.loads(out)
+        self.assertEqual(data["data"]["source_type"], "url")
+        self.assertEqual(data["data"]["download_url"], "https://example.test/candid.log")
+        self.assertTrue(data["data"]["is_replayable"])
+
+    def test_datasets_replay_index_dry_run_returns_structured_error(self) -> None:
+        with patch("canarchy.dataset_convert.requests.get") as get:
+            code, out, _ = run_cli(
+                "datasets", "replay", "catalog:pivot-auto-datasets",
+                "--dry-run",
+                "--json",
+            )
+        self.assertEqual(code, 1)
+        get.assert_not_called()
+        data = json.loads(out)
+        self.assertFalse(data["ok"])
+        self.assertEqual(data["errors"][0]["code"], "DATASET_REPLAY_UNAVAILABLE")

--- a/tests/test_dataset_provider.py
+++ b/tests/test_dataset_provider.py
@@ -701,6 +701,20 @@ class CliIntegrationTests(unittest.TestCase):
         self.assertEqual(data["data"]["download_url"], "https://example.test/candid.log")
         self.assertTrue(data["data"]["is_replayable"])
 
+    def test_datasets_replay_dry_run_validates_rate_before_plan(self) -> None:
+        with patch("canarchy.dataset_convert.requests.get") as get:
+            code, out, _ = run_cli(
+                "datasets", "replay", "https://example.test/candid.log",
+                "--rate", "0",
+                "--dry-run",
+                "--json",
+            )
+        self.assertEqual(code, 1)
+        get.assert_not_called()
+        data = json.loads(out)
+        self.assertFalse(data["ok"])
+        self.assertEqual(data["errors"][0]["code"], "INVALID_RATE")
+
     def test_datasets_replay_index_dry_run_returns_structured_error(self) -> None:
         with patch("canarchy.dataset_convert.requests.get") as get:
             code, out, _ = run_cli(


### PR DESCRIPTION
## Summary
- Add `canarchy datasets replay --dry-run` to resolve replay metadata without opening the remote stream.
- Return machine-readable replay plan fields for catalog refs and direct URLs, while preserving structured errors for non-replayable catalog entries.
- Update command docs, design/test specs, getting started docs, changelog, and dataset provider CLI tests.

## Verification
- `uv run pytest tests/test_dataset_provider.py -v`
- `uv run canarchy datasets replay catalog:candid --dry-run --json`
- `uv run canarchy datasets replay https://example.test/candid.log --dry-run --json`
- `uv run canarchy datasets replay catalog:pivot-auto-datasets --dry-run --json`
- `uv run pytest --tb=short`

## Acceptance Criteria
- Issue referenced: refs #247
- Tests pass: yes, 579 passed, 1 skipped
- Changelog updated: yes
- Design spec current: yes
- Test spec current: yes
- Agent guide current: no agent workflow change beyond documented command surface
- No stale documentation left: command spec and getting started updated

Refs #247