### PR TITLE
Add dataset machine-readable fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -483,6 +483,8 @@ canarchy
 
 This tree is a starting point, not a lock.
 
+For dataset automation, agents should prefer explicit JSON output. `datasets search --json` and `datasets inspect --json` include stable machine fields: `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`. Curated index entries that cannot be replayed return `DATASET_INDEX_NOT_REPLAYABLE` from `datasets replay`.
+
 ---
 
 ## J1939 expectations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * Added `candid` (CANdid) dataset to the built-in catalog: VehicleSec 2025 paper dataset with 10-passenger-vehicle candump-format CAN logs, annotations, GPS, metadata, and video. Ref: `catalog:candid`. Closes #225.
 * Added `canarchy datasets replay` for Netflix-style streaming playback from a direct candump URL or replayable dataset ref such as `catalog:candid`, with candump/JSONL stdout output, rate control, and JSON summary mode. Closes #233.
 * Added `canarchy datasets replay --dry-run` so operators and agents can resolve replay metadata for dataset refs or direct URLs without opening the remote stream. Closes #247.
+* Added stable machine-friendly dataset JSON fields (`ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`) for dataset search and inspect results. Closes #242.
 * Added `pivot-auto-datasets` to the built-in catalog as a curated source index for CAN, CAN-FD, J1939, and broader automotive datasets listed by the PIVOT Project. Closes #235.
 
 ### Fixed
@@ -20,6 +21,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * Made `canarchy datasets provider list` and `canarchy datasets search <query>` default to compact readable output instead of dumping raw Python result dictionaries, added `--verbose` for detailed search result blocks, and preserved explicit JSON output for automation.
 * Fixed MCP `stats` and `filter` tool argument mapping so they invoke the current CLI grammar (`stats --file <file>` and `filter <expr> --file <file>`) and return successful canonical envelopes. Closes #237.
 * Made `canarchy datasets replay` stop cleanly on closed stdout pipes instead of printing a Python `BrokenPipeError` traceback. Closes #240.
+* Made dataset replay return `DATASET_INDEX_NOT_REPLAYABLE` for curated dataset indexes so automation can distinguish index entries from other non-replayable datasets. Closes #242.
 
 ## [0.6.0] - 2026-04-28
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -96,6 +96,8 @@ Current exclusions:
 * CLI-only workflows such as `j1939 faults` and `re signals` that are not yet exposed as MCP tools
 * interactive or service commands such as `shell`, `tui`, and `mcp serve`
 
+For CLI-only dataset workflows, agents should prefer explicit JSON output. `datasets search --json` and `datasets inspect --json` include stable machine fields: `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`. Curated index entries that cannot be replayed return `DATASET_INDEX_NOT_REPLAYABLE` from `datasets replay`.
+
 ### Skills Workflow
 
 CANarchy skills are phase-1 workflow descriptors, not MCP tools. Agents should discover and fetch skills through the CLI provider workflow, inspect the cached manifest and entry file, then run the referenced CANarchy commands explicitly through either the CLI or the MCP tools that already exist.

--- a/docs/command_spec.md
+++ b/docs/command_spec.md
@@ -462,6 +462,7 @@ canarchy datasets inspect catalog:pivot-auto-datasets --json
 
 Notes:
 
+* JSON `datasets search` and `datasets inspect` results include stable machine fields: `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`
 * `catalog:pivot-auto-datasets` is a curated external source index, not a directly downloadable or replayable dataset
 * inspect linked source pages for per-dataset access terms, file formats, and conversion/replay suitability
 
@@ -545,6 +546,7 @@ Notes:
 * with `--json`, stdout contains a clean standard result envelope with replay metadata and no frame records
 * replay downloads incrementally from the remote HTTP response and does not require a complete local dataset file
 * `--dry-run` resolves replay source metadata without opening the remote stream
+* replaying a curated index entry fails with `DATASET_INDEX_NOT_REPLAYABLE`; other non-replayable datasets fail with `DATASET_REPLAY_UNAVAILABLE`
 * `catalog:candid` currently resolves to the CANdid `2_brakes_CAN.log` Figshare file as its default replay source
 
 ### session save

--- a/docs/design/dataset-provider-workflow.md
+++ b/docs/design/dataset-provider-workflow.md
@@ -5,7 +5,7 @@
 | Field | Value |
 |-------|-------|
 | Status | Implemented (Phase 2) |
-| Issue | #216, #220, #233, #235 |
+| Issue | #216, #220, #233, #235, #242 |
 | Implementation | `src/canarchy/dataset_provider.py`, `dataset_cache.py`, `dataset_catalog.py`, `dataset_convert.py` |
 
 ---
@@ -134,6 +134,7 @@ No network access is required for `search`, `inspect`, or `provider list`.
 | REQ-DATASET-CATALOG-01 | Ubiquitous | The system shall expose built-in catalog entries through `datasets search` and `datasets inspect` without network access. |
 | REQ-DATASET-CATALOG-02 | Ubiquitous | The system shall include source URL, license or access terms, protocol family, formats, size description, description, and metadata for each built-in catalog entry. |
 | REQ-DATASET-CATALOG-03 | Optional feature | Where a catalog entry represents a curated external index instead of a directly downloadable dataset, the system shall mark the entry as an index in metadata and describe that linked sources have their own access terms and formats. |
+| REQ-DATASET-CATALOG-04 | Ubiquitous | The system shall include stable machine fields for JSON dataset search and inspect results: `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`. |
 
 ---
 
@@ -206,6 +207,7 @@ building a full in-memory frame list.
 | REQ-DATASET-REPLAY-05 | Optional feature | Where `--json` is specified, the system shall emit a standard result envelope without interleaving frame records. |
 | REQ-DATASET-REPLAY-06 | Unwanted behaviour | If replay stdout is closed by a downstream pipeline consumer, the system shall stop replay cleanly without printing a Python traceback. |
 | REQ-DATASET-REPLAY-07 | Optional feature | Where `--dry-run` is specified, the system shall resolve replay source metadata without opening the remote stream. |
+| REQ-DATASET-REPLAY-08 | Unwanted behaviour | If a curated dataset index is requested as a replay source, the system shall return a structured `DATASET_INDEX_NOT_REPLAYABLE` error. |
 
 ---
 

--- a/docs/tests/dataset-provider-workflow.md
+++ b/docs/tests/dataset-provider-workflow.md
@@ -6,7 +6,7 @@
 |-------|-------|
 | Status | Implemented |
 | Related design spec | `docs/design/dataset-provider-workflow.md` |
-| Issues | #216, #220, #233, #235 |
+| Issues | #216, #220, #233, #235, #242 |
 | Test module | `tests/test_dataset_provider.py` |
 
 ---
@@ -34,6 +34,18 @@ Then the results include `pivot-auto-datasets`
 ```
 
 **Fixture:** embedded catalog metadata in `src/canarchy/dataset_catalog.py`
+
+### TEST-DATASET-CATALOG-03: Search And Inspect Expose Machine Fields
+
+```gherkin
+Given the built-in public dataset catalog provider
+When the operator requests dataset search and inspect JSON output
+Then each descriptor includes `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`
+And replayable datasets identify their default replay file
+And curated index datasets identify themselves as indexes
+```
+
+**Fixture:** embedded catalog metadata and CLI JSON assertions in `tests/test_dataset_provider.py`
 
 ### TEST-DATASET-STREAM-01: Stream HCRL CSV To JSONL With Chunk Metadata
 
@@ -139,6 +151,17 @@ And no remote stream is opened
 
 **Fixture:** mocked `requests.get` assertion in `tests/test_dataset_provider.py`
 
+### TEST-DATASET-REPLAY-05: Curated Index Replay Returns Specific Error
+
+```gherkin
+Given `catalog:pivot-auto-datasets` is a curated index entry
+When the operator requests dataset replay for that ref
+Then the command fails with `DATASET_INDEX_NOT_REPLAYABLE`
+And no remote stream is opened
+```
+
+**Fixture:** embedded catalog metadata and mocked `requests.get` assertion in `tests/test_dataset_provider.py`
+
 ---
 
 ## Traceability
@@ -148,6 +171,7 @@ And no remote stream is opened
 | REQ-DATASET-CATALOG-01 | TEST-DATASET-CATALOG-01, TEST-DATASET-CATALOG-02 |
 | REQ-DATASET-CATALOG-02 | TEST-DATASET-CATALOG-01 |
 | REQ-DATASET-CATALOG-03 | TEST-DATASET-CATALOG-01 |
+| REQ-DATASET-CATALOG-04 | TEST-DATASET-CATALOG-03 |
 | REQ-DATASET-STREAM-01 | TEST-DATASET-STREAM-01, TEST-DATASET-STREAM-02, TEST-DATASET-STREAM-04 |
 | REQ-DATASET-STREAM-02 | TEST-DATASET-STREAM-01, TEST-DATASET-STREAM-02 |
 | REQ-DATASET-STREAM-03 | TEST-DATASET-STREAM-01, TEST-DATASET-STREAM-04 |
@@ -161,6 +185,7 @@ And no remote stream is opened
 | REQ-DATASET-REPLAY-05 | TEST-DATASET-REPLAY-02 |
 | REQ-DATASET-REPLAY-06 | TEST-DATASET-REPLAY-03 |
 | REQ-DATASET-REPLAY-07 | TEST-DATASET-REPLAY-04 |
+| REQ-DATASET-REPLAY-08 | TEST-DATASET-REPLAY-05 |
 
 ---
 

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -2672,22 +2672,7 @@ def datasets_payload(args: argparse.Namespace) -> tuple[dict[str, Any], list[dic
         provider_filter = [args.provider] if getattr(args, "provider", None) else None
         limit = getattr(args, "limit", 20)
         results = registry.search(query, providers=provider_filter, limit=limit)
-        items = [
-            {
-                "provider": d.provider,
-                "name": d.name,
-                "version": d.version,
-                "protocol_family": d.protocol_family,
-                "formats": list(d.formats),
-                "size_description": d.size_description,
-                "license": d.license,
-                "source_url": d.source_url,
-                "description": d.description,
-                "conversion_targets": list(d.conversion_targets),
-                "access_notes": d.access_notes,
-            }
-            for d in results
-        ]
+        items = [dataset_descriptor_payload(d, include_metadata=False) for d in results]
         warns: list[str] = []
         if not items:
             warns.append("No datasets matched the query.")
@@ -2702,25 +2687,7 @@ def datasets_payload(args: argparse.Namespace) -> tuple[dict[str, Any], list[dic
                 exit_code=EXIT_USER_ERROR,
                 errors=[ErrorDetail(code=exc.code, message=str(exc), hint=exc.hint)],
             ) from exc
-        return (
-            {
-                "ref": args.ref,
-                "provider": descriptor.provider,
-                "name": descriptor.name,
-                "version": descriptor.version,
-                "source_url": descriptor.source_url,
-                "license": descriptor.license,
-                "access_notes": descriptor.access_notes,
-                "protocol_family": descriptor.protocol_family,
-                "formats": list(descriptor.formats),
-                "size_description": descriptor.size_description,
-                "description": descriptor.description,
-                "conversion_targets": list(descriptor.conversion_targets),
-                "metadata": descriptor.metadata,
-            },
-            [],
-            [],
-        )
+        return (dataset_descriptor_payload(descriptor, include_metadata=True), [], [])
 
     if args.command == "datasets fetch":
         try:
@@ -2854,6 +2821,10 @@ def resolve_dataset_replay_source(source: str, registry: Any) -> dict[str, Any]:
         return {
             "source": source,
             "source_type": "url",
+            "is_replayable": True,
+            "is_index": False,
+            "default_replay_file": None,
+            "download_url_available": True,
             "download_url": source,
             "source_format": "candump",
         }
@@ -2863,6 +2834,13 @@ def resolve_dataset_replay_source(source: str, registry: Any) -> dict[str, Any]:
     descriptor = registry.inspect(source)
     replay = descriptor.metadata.get("replay") if isinstance(descriptor.metadata, dict) else None
     if not isinstance(replay, dict) or not replay.get("download_url"):
+        machine = dataset_machine_fields(descriptor)
+        if machine["is_index"]:
+            raise DatasetError(
+                code="DATASET_INDEX_NOT_REPLAYABLE",
+                message=f"Dataset index '{source}' does not define a replayable remote file.",
+                hint="Use `canarchy datasets inspect <ref>` to review linked dataset sources, then pass a replayable dataset ref or direct candump URL.",
+            )
         raise DatasetError(
             code="DATASET_REPLAY_UNAVAILABLE",
             message=f"Dataset '{source}' does not define a replayable remote file.",
@@ -2873,13 +2851,55 @@ def resolve_dataset_replay_source(source: str, registry: Any) -> dict[str, Any]:
         "source": source,
         "source_type": "dataset_ref",
         "is_replayable": True,
+        "is_index": False,
         "provider": descriptor.provider,
         "name": descriptor.name,
         "ref": f"{descriptor.provider}:{descriptor.name}",
         "default_file": replay.get("default_file"),
+        "default_replay_file": replay.get("default_file"),
+        "download_url_available": True,
         "download_url": replay["download_url"],
         "source_format": replay.get("source_format", "candump"),
     }
+
+
+def dataset_machine_fields(descriptor: Any) -> dict[str, Any]:
+    """Return stable machine fields for dataset catalog results."""
+    metadata = descriptor.metadata if isinstance(descriptor.metadata, dict) else {}
+    replay = metadata.get("replay") if isinstance(metadata, dict) else None
+    replay_download_url = replay.get("download_url") if isinstance(replay, dict) else None
+    default_replay_file = replay.get("default_file") if isinstance(replay, dict) else None
+    source_type = metadata.get("source_type") if isinstance(metadata, dict) else None
+    is_index = source_type == "curated-index" or "catalog" in descriptor.formats
+    return {
+        "ref": f"{descriptor.provider}:{descriptor.name}",
+        "is_replayable": bool(replay_download_url),
+        "is_index": is_index,
+        "default_replay_file": default_replay_file,
+        "download_url_available": bool(replay_download_url),
+        "source_type": source_type or ("index" if is_index else "dataset"),
+    }
+
+
+def dataset_descriptor_payload(descriptor: Any, *, include_metadata: bool) -> dict[str, Any]:
+    """Return JSON-stable dataset descriptor fields for search and inspect."""
+    payload = {
+        **dataset_machine_fields(descriptor),
+        "provider": descriptor.provider,
+        "name": descriptor.name,
+        "version": descriptor.version,
+        "protocol_family": descriptor.protocol_family,
+        "formats": list(descriptor.formats),
+        "size_description": descriptor.size_description,
+        "license": descriptor.license,
+        "source_url": descriptor.source_url,
+        "description": descriptor.description,
+        "conversion_targets": list(descriptor.conversion_targets),
+        "access_notes": descriptor.access_notes,
+    }
+    if include_metadata:
+        payload["metadata"] = descriptor.metadata
+    return payload
 
 
 def dataset_replay_plan(args: argparse.Namespace, replay_source: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_dataset_provider.py
+++ b/tests/test_dataset_provider.py
@@ -467,7 +467,10 @@ class CliIntegrationTests(unittest.TestCase):
         self.assertTrue(data["ok"])
         self.assertGreater(data["data"]["count"], 0)
         result = data["data"]["results"][0]
-        for key in ("name", "protocol_family", "license", "source_url", "conversion_targets"):
+        for key in (
+            "ref", "name", "protocol_family", "license", "source_url", "conversion_targets",
+            "is_replayable", "is_index", "default_replay_file", "download_url_available", "source_type",
+        ):
             self.assertIn(key, result)
 
     def test_datasets_search_query(self) -> None:
@@ -507,6 +510,36 @@ class CliIntegrationTests(unittest.TestCase):
         self.assertEqual(data["data"]["name"], "road")
         self.assertIn("description", data["data"])
         self.assertIn("source_url", data["data"])
+        self.assertEqual(data["data"]["ref"], "catalog:road")
+        self.assertFalse(data["data"]["is_replayable"])
+        self.assertFalse(data["data"]["is_index"])
+        self.assertFalse(data["data"]["download_url_available"])
+        self.assertIsNone(data["data"]["default_replay_file"])
+        self.assertEqual(data["data"]["source_type"], "dataset")
+
+    def test_datasets_inspect_replayable_dataset_has_machine_fields(self) -> None:
+        code, out, _ = run_cli("datasets", "inspect", "catalog:candid", "--json")
+        self.assertEqual(code, 0)
+        data = json.loads(out)
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["data"]["ref"], "catalog:candid")
+        self.assertTrue(data["data"]["is_replayable"])
+        self.assertFalse(data["data"]["is_index"])
+        self.assertTrue(data["data"]["download_url_available"])
+        self.assertEqual(data["data"]["default_replay_file"], "2_brakes_CAN.log")
+        self.assertEqual(data["data"]["source_type"], "dataset")
+
+    def test_datasets_inspect_index_dataset_has_machine_fields(self) -> None:
+        code, out, _ = run_cli("datasets", "inspect", "catalog:pivot-auto-datasets", "--json")
+        self.assertEqual(code, 0)
+        data = json.loads(out)
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["data"]["ref"], "catalog:pivot-auto-datasets")
+        self.assertFalse(data["data"]["is_replayable"])
+        self.assertTrue(data["data"]["is_index"])
+        self.assertFalse(data["data"]["download_url_available"])
+        self.assertIsNone(data["data"]["default_replay_file"])
+        self.assertEqual(data["data"]["source_type"], "curated-index")
 
     def test_datasets_inspect_unknown_fails(self) -> None:
         code, out, _ = run_cli("datasets", "inspect", "nonexistent-xyz", "--json")
@@ -726,4 +759,4 @@ class CliIntegrationTests(unittest.TestCase):
         get.assert_not_called()
         data = json.loads(out)
         self.assertFalse(data["ok"])
-        self.assertEqual(data["errors"][0]["code"], "DATASET_REPLAY_UNAVAILABLE")
+        self.assertEqual(data["errors"][0]["code"], "DATASET_INDEX_NOT_REPLAYABLE")


### PR DESCRIPTION
## Summary
- Add stable dataset JSON fields for `datasets search --json` and `datasets inspect --json`: `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`.
- Return `DATASET_INDEX_NOT_REPLAYABLE` when curated index entries are passed to `datasets replay`, while keeping `DATASET_REPLAY_UNAVAILABLE` for other non-replayable datasets.
- Update command docs, design/test specs, agent guidance, changelog, and dataset provider tests.

## Verification
- `uv run pytest tests/test_dataset_provider.py -v`
- `uv run canarchy datasets inspect catalog:candid --json`
- `uv run canarchy datasets replay catalog:pivot-auto-datasets --dry-run --json`
- `uv run pytest --tb=short`

## Acceptance Criteria
- Issue referenced: refs #242
- Tests pass: yes, 582 passed, 1 skipped
- Changelog updated: yes
- Design spec current: yes
- Test spec current: yes
- Agent guide current: yes
- No stale documentation left: command spec and agent docs updated

Refs #242