### PR TITLE
Expose dataset workflows through MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -483,7 +483,7 @@ canarchy
 
 This tree is a starting point, not a lock.
 
-For dataset automation, agents should prefer explicit JSON output. `datasets search --json` and `datasets inspect --json` include stable machine fields: `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`. Curated index entries that cannot be replayed return `DATASET_INDEX_NOT_REPLAYABLE` from `datasets replay`.
+For dataset automation, agents should prefer MCP dataset tools when available, or explicit CLI JSON output otherwise. `datasets_search` / `datasets search --json` and `datasets_inspect` / `datasets inspect --json` include stable machine fields: `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`. Use MCP `datasets_replay_plan` or CLI `datasets replay --dry-run --json` for safe replay preflight; actual dataset frame streaming remains CLI-only. Curated index entries that cannot be replayed return `DATASET_INDEX_NOT_REPLAYABLE`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * Added `canarchy datasets replay` for Netflix-style streaming playback from a direct candump URL or replayable dataset ref such as `catalog:candid`, with candump/JSONL stdout output, rate control, and JSON summary mode. Closes #233.
 * Added `canarchy datasets replay --dry-run` so operators and agents can resolve replay metadata for dataset refs or direct URLs without opening the remote stream. Closes #247.
 * Added stable machine-friendly dataset JSON fields (`ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`) for dataset search and inspect results. Closes #242.
+* Added MCP tools for dataset provider discovery, search, inspect, fetch, cache operations, and safe replay planning so agents can use dataset metadata without shelling out. Closes #239.
 * Added `pivot-auto-datasets` to the built-in catalog as a curated source index for CAN, CAN-FD, J1939, and broader automotive datasets listed by the PIVOT Project. Closes #235.
 
 ### Fixed

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -66,6 +66,13 @@ The current MCP surface exposes a curated non-interactive subset of the CLI. Spa
 | `dbc_cache_list` | `canarchy dbc cache list` |
 | `dbc_cache_prune` | `canarchy dbc cache prune` |
 | `dbc_cache_refresh` | `canarchy dbc cache refresh` |
+| `datasets_provider_list` | `canarchy datasets provider list` |
+| `datasets_search` | `canarchy datasets search` |
+| `datasets_inspect` | `canarchy datasets inspect` |
+| `datasets_fetch` | `canarchy datasets fetch` |
+| `datasets_cache_list` | `canarchy datasets cache list` |
+| `datasets_cache_refresh` | `canarchy datasets cache refresh` |
+| `datasets_replay_plan` | `canarchy datasets replay --dry-run` |
 | `export` | `canarchy export` |
 | `session_save` | `canarchy session save` |
 | `session_load` | `canarchy session load` |
@@ -91,12 +98,12 @@ The current MCP surface exposes a curated non-interactive subset of the CLI. Spa
 Current exclusions:
 
 * skills provider and cache commands such as `skills search` and `skills fetch`
-* dataset provider and streaming commands such as `datasets search`, `datasets fetch`, `datasets stream`, and `datasets replay`
+* dataset streaming commands that emit frame records, such as `datasets stream` and non-dry-run `datasets replay`
 * CLI-only workflows such as `j1939 compare` that are not yet exposed as MCP tools
 * CLI-only workflows such as `j1939 faults` and `re signals` that are not yet exposed as MCP tools
 * interactive or service commands such as `shell`, `tui`, and `mcp serve`
 
-For CLI-only dataset workflows, agents should prefer explicit JSON output. `datasets search --json` and `datasets inspect --json` include stable machine fields: `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`. Curated index entries that cannot be replayed return `DATASET_INDEX_NOT_REPLAYABLE` from `datasets replay`.
+For dataset workflows, agents should prefer MCP dataset tools when available. `datasets_search` and `datasets_inspect` include stable machine fields: `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`. Use `datasets_replay_plan` for safe replay preflight; actual frame streaming remains CLI-only. Curated index entries that cannot be replayed return `DATASET_INDEX_NOT_REPLAYABLE`.
 
 ### Skills Workflow
 

--- a/docs/design/mcp-server.md
+++ b/docs/design/mcp-server.md
@@ -32,6 +32,7 @@ Agents that already call tools via MCP (Claude, OpenCode, etc.) can integrate CA
 | `REQ-MCP-10` | Ubiquitous | The server shall not expose `shell` or `tui` as MCP tools; those are interactive front-end commands with no RPC equivalent. |
 | `REQ-MCP-11` | Event-driven | The `call_tool` handler shall execute `execute_command` in a thread pool via `asyncio.to_thread` so that the asyncio event loop is not blocked during file I/O or analysis, preventing MCP keepalive timeouts on large captures. |
 | `REQ-MCP-12` | Ubiquitous | File-backed J1939 tools (`j1939_decode`, `j1939_pgn`, `j1939_spn`, `j1939_tp`, `j1939_dm1`, `j1939_summary`, `j1939_inventory`) shall expose optional `max_frames` (integer) and `seconds` (number) parameters that bound analysis to the first N frames or first T seconds of the capture, respectively. |
+| `REQ-MCP-13` | Ubiquitous | Dataset provider workflows selected for MCP shall expose provider list, search, inspect, fetch, cache list, cache refresh, and safe replay planning tools while excluding streaming dataset frame output. |
 
 ## Command Surface
 
@@ -80,6 +81,13 @@ The current MCP tool surface is a curated non-interactive subset of the CLI. It 
 | `uds trace` | `uds_trace` |
 | `uds services` | `uds_services` |
 | `config show` | `config_show` |
+| `datasets provider list` | `datasets_provider_list` |
+| `datasets search` | `datasets_search` |
+| `datasets inspect` | `datasets_inspect` |
+| `datasets fetch` | `datasets_fetch` |
+| `datasets cache list` | `datasets_cache_list` |
+| `datasets cache refresh` | `datasets_cache_refresh` |
+| `datasets replay --dry-run` | `datasets_replay_plan` |
 | `re correlate` | `re_correlate` |
 | `re counters` | `re_counters` |
 | `re entropy` | `re_entropy` |
@@ -131,6 +139,7 @@ In scope:
 * stdio MCP transport only
 * buffered (non-streaming) tool responses for all commands including live-capture variants (scaffold backend returns a fixed event batch)
 * a curated non-interactive CLI subset covering transport, protocol, export, session, and configuration workflows
+* dataset provider metadata workflows and dry-run replay planning for dataset refs or direct URLs
 
 Out of scope:
 
@@ -140,3 +149,4 @@ Out of scope:
 * plugin or custom tool registration
 * exposing every implemented CLI command automatically
 * exposing CANarchy skills as MCP tools, resources, prompts, or a separate MCP discovery surface in phase 1
+* streaming dataset frame output through MCP; agents should use `datasets_replay_plan` for preflight metadata and the CLI for actual stdout streaming

--- a/docs/tests/mcp-server.md
+++ b/docs/tests/mcp-server.md
@@ -24,6 +24,7 @@
 | REQ-MCP-10 | `shell` and `tui` not exposed as MCP tools | TEST-MCP-11 |
 | REQ-MCP-11 | `call_tool` handler runs `execute_command` in a thread pool | TEST-MCP-15 |
 | REQ-MCP-12 | File-backed J1939 tools expose `max_frames` and `seconds` parameters | TEST-MCP-16, TEST-MCP-17 |
+| REQ-MCP-13 | Dataset MCP tools expose provider workflows and safe replay planning | TEST-MCP-22, TEST-MCP-23, TEST-MCP-24, TEST-MCP-25 |
 
 ## Representative Test Cases
 
@@ -45,7 +46,7 @@ And    `canarchy mcp serve --help` shall exit with code `0`
 ```gherkin
 Given  the MCP server is initialised
 When   `handle_list_tools()` is called
-Then   the returned set shall contain at minimum: `capture`, `send`, `filter`, `stats`, `capture_info`, `decode`, `encode`, `dbc_inspect`, `dbc_provider_list`, `dbc_search`, `dbc_fetch`, `dbc_cache_list`, `dbc_cache_prune`, `dbc_cache_refresh`, `j1939_monitor`, `j1939_decode`, `j1939_pgn`, `j1939_spn`, `j1939_tp`, `j1939_dm1`, `j1939_summary`, `j1939_inventory`, `uds_scan`, `uds_trace`, `uds_services`, `config_show`, `replay`, `gateway`, `generate`, `export`, `session_save`, `session_load`, `session_show`, `re_correlate`, `re_counters`, `re_entropy`, `re_match_dbc`, `re_shortlist_dbc`
+Then   the returned set shall contain at minimum: `capture`, `send`, `filter`, `stats`, `capture_info`, `decode`, `encode`, `dbc_inspect`, `dbc_provider_list`, `dbc_search`, `dbc_fetch`, `dbc_cache_list`, `dbc_cache_prune`, `dbc_cache_refresh`, `datasets_provider_list`, `datasets_search`, `datasets_inspect`, `datasets_fetch`, `datasets_cache_list`, `datasets_cache_refresh`, `datasets_replay_plan`, `j1939_monitor`, `j1939_decode`, `j1939_pgn`, `j1939_spn`, `j1939_tp`, `j1939_dm1`, `j1939_summary`, `j1939_inventory`, `uds_scan`, `uds_trace`, `uds_services`, `config_show`, `replay`, `gateway`, `generate`, `export`, `session_save`, `session_load`, `session_show`, `re_correlate`, `re_counters`, `re_entropy`, `re_match_dbc`, `re_shortlist_dbc`
 ```
 
 **Fixture:** none.
@@ -57,7 +58,7 @@ Then   the returned set shall contain at minimum: `capture`, `send`, `filter`, `
 ```gherkin
 Given  the MCP server is initialised
 When   `handle_list_tools()` is called
-Then   at least 38 tools shall be returned — one per registered MCP tool in the current curated surface
+Then   at least 45 tools shall be returned — one per registered MCP tool in the current curated surface
 ```
 
 **Fixture:** none.
@@ -143,6 +144,60 @@ And    the result shall contain one matching frame
 ```
 
 **Fixture:** `tests/fixtures/sample.candump`.
+
+---
+
+### `TEST-MCP-22` — Dataset search returns machine fields
+
+```gherkin
+Given  the MCP server is initialised
+When   `handle_call_tool("datasets_search", {"query": "candid"})` is called
+Then   the response `text` shall parse as JSON with `ok` equal to `true`
+And    `command` shall equal `"datasets search"`
+And    the result shall include stable machine fields such as `ref`, `is_replayable`, and `default_replay_file`
+```
+
+**Fixture:** embedded dataset catalog.
+
+---
+
+### `TEST-MCP-23` — Dataset inspect returns index metadata
+
+```gherkin
+Given  the MCP server is initialised
+When   `handle_call_tool("datasets_inspect", {"ref": "catalog:pivot-auto-datasets"})` is called
+Then   the response `text` shall parse as JSON with `ok` equal to `true`
+And    the result shall report `is_index=true` and `is_replayable=false`
+```
+
+**Fixture:** embedded dataset catalog.
+
+---
+
+### `TEST-MCP-24` — Dataset replay plan does not stream
+
+```gherkin
+Given  the MCP server is initialised
+When   `handle_call_tool("datasets_replay_plan", {"source": "catalog:candid"})` is called
+Then   the response `text` shall parse as JSON with `ok` equal to `true`
+And    `command` shall equal `"datasets replay"`
+And    the result shall report `dry_run=true` and `streamed=false`
+```
+
+**Fixture:** embedded dataset catalog.
+
+---
+
+### `TEST-MCP-25` — Dataset replay plan preserves index errors
+
+```gherkin
+Given  the MCP server is initialised
+When   `handle_call_tool("datasets_replay_plan", {"source": "catalog:pivot-auto-datasets"})` is called
+Then   the response `text` shall parse as JSON with `ok` equal to `false`
+And    `errors[0].code` shall equal `"DATASET_INDEX_NOT_REPLAYABLE"`
+```
+
+**Fixture:** embedded dataset catalog.
 
 ---
 

--- a/src/canarchy/mcp_server.py
+++ b/src/canarchy/mcp_server.py
@@ -380,6 +380,80 @@ _TOOLS: list[types.Tool] = [
         },
     ),
     types.Tool(
+        name="datasets_provider_list",
+        description="List registered dataset providers.",
+        inputSchema={
+            "type": "object",
+            "properties": {},
+        },
+    ),
+    types.Tool(
+        name="datasets_search",
+        description="Search public CAN dataset provider catalogs by name, protocol, or keyword.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Search query; omit or use empty string to list datasets", "default": ""},
+                "provider": {"type": "string", "description": "Restrict search to a specific provider"},
+                "limit": {"type": "integer", "description": "Maximum results to return", "default": 20},
+            },
+        },
+    ),
+    types.Tool(
+        name="datasets_inspect",
+        description="Show full metadata for a dataset ref.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "ref": {"type": "string", "description": "Dataset ref, e.g. catalog:candid"},
+            },
+            "required": ["ref"],
+        },
+    ),
+    types.Tool(
+        name="datasets_fetch",
+        description="Record dataset provenance in the local cache without downloading large dataset payloads.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "ref": {"type": "string", "description": "Dataset ref, e.g. catalog:road"},
+            },
+            "required": ["ref"],
+        },
+    ),
+    types.Tool(
+        name="datasets_cache_list",
+        description="List cached dataset provider manifests and provenance records.",
+        inputSchema={
+            "type": "object",
+            "properties": {},
+        },
+    ),
+    types.Tool(
+        name="datasets_cache_refresh",
+        description="Refresh the dataset provider catalog manifest.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "provider": {"type": "string", "description": "Provider to refresh", "default": "catalog"},
+            },
+        },
+    ),
+    types.Tool(
+        name="datasets_replay_plan",
+        description="Resolve dataset replay metadata for a dataset ref or URL without opening the remote stream.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "source": {"type": "string", "description": "Dataset ref (e.g. catalog:candid) or remote candump URL"},
+                "format": {"type": "string", "description": "Planned output format", "enum": ["candump", "jsonl"], "default": "candump"},
+                "rate": {"type": "number", "description": "Playback rate multiplier for the planned replay", "default": 1.0},
+                "max_frames": {"type": "integer", "description": "Planned frame limit"},
+            },
+            "required": ["source"],
+        },
+    ),
+    types.Tool(
         name="dbc_provider_list",
         description="List all registered DBC providers.",
         inputSchema={
@@ -687,6 +761,37 @@ def _build_argv(tool_name: str, arguments: dict[str, Any]) -> list[str]:
             return ["uds", "services", "--json"]
         case "config_show":
             return ["config", "show", "--json"]
+        case "datasets_provider_list":
+            return ["datasets", "provider", "list", "--json"]
+        case "datasets_search":
+            argv = ["datasets", "search"]
+            if a.get("query"):
+                argv.append(a["query"])
+            if a.get("provider"):
+                argv += ["--provider", a["provider"]]
+            if "limit" in a:
+                argv += ["--limit", str(a["limit"])]
+            return argv + ["--json"]
+        case "datasets_inspect":
+            return ["datasets", "inspect", a["ref"], "--json"]
+        case "datasets_fetch":
+            return ["datasets", "fetch", a["ref"], "--json"]
+        case "datasets_cache_list":
+            return ["datasets", "cache", "list", "--json"]
+        case "datasets_cache_refresh":
+            argv = ["datasets", "cache", "refresh"]
+            if a.get("provider"):
+                argv += ["--provider", a["provider"]]
+            return argv + ["--json"]
+        case "datasets_replay_plan":
+            argv = ["datasets", "replay", a["source"]]
+            if a.get("format"):
+                argv += ["--format", a["format"]]
+            if "rate" in a:
+                argv += ["--rate", str(a["rate"])]
+            if a.get("max_frames") is not None:
+                argv += ["--max-frames", str(a["max_frames"])]
+            return argv + ["--dry-run", "--json"]
         case "dbc_provider_list":
             return ["dbc", "provider", "list", "--json"]
         case "dbc_search":

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -18,6 +18,8 @@ _EXPECTED_TOOLS = {
     "j1939_monitor", "j1939_decode", "j1939_pgn", "j1939_spn", "j1939_tp", "j1939_dm1", "j1939_inventory",
     "uds_scan", "uds_trace", "uds_services",
     "config_show",
+    "datasets_provider_list", "datasets_search", "datasets_inspect", "datasets_fetch", "datasets_cache_list",
+    "datasets_cache_refresh", "datasets_replay_plan",
 }
 
 
@@ -109,6 +111,56 @@ def test_call_tool_filter_orders_expression_before_file_flag():
     assert len(payload["data"]["events"]) == 1
     frame = payload["data"]["events"][0]["payload"]["frame"]
     assert frame["arbitration_id"] == 0x18FEEE31
+
+
+def test_call_tool_datasets_search_returns_machine_fields():
+    results = asyncio.run(handle_call_tool("datasets_search", {"query": "candid"}))
+    assert len(results) == 1
+    payload = json.loads(results[0].text)
+    assert payload["ok"] is True
+    assert payload["command"] == "datasets search"
+    assert payload["data"]["count"] >= 1
+    result = payload["data"]["results"][0]
+    assert result["ref"] == "catalog:candid"
+    assert result["is_replayable"] is True
+    assert result["default_replay_file"] == "2_brakes_CAN.log"
+
+
+def test_call_tool_datasets_inspect_index_returns_machine_fields():
+    results = asyncio.run(handle_call_tool("datasets_inspect", {"ref": "catalog:pivot-auto-datasets"}))
+    assert len(results) == 1
+    payload = json.loads(results[0].text)
+    assert payload["ok"] is True
+    assert payload["command"] == "datasets inspect"
+    assert payload["data"]["is_index"] is True
+    assert payload["data"]["is_replayable"] is False
+    assert payload["data"]["source_type"] == "curated-index"
+
+
+def test_call_tool_datasets_replay_plan_does_not_stream():
+    results = asyncio.run(
+        handle_call_tool(
+            "datasets_replay_plan",
+            {"source": "catalog:candid", "format": "jsonl", "rate": 10.0, "max_frames": 5},
+        )
+    )
+    assert len(results) == 1
+    payload = json.loads(results[0].text)
+    assert payload["ok"] is True
+    assert payload["command"] == "datasets replay"
+    assert payload["data"]["dry_run"] is True
+    assert payload["data"]["streamed"] is False
+    assert payload["data"]["would_stream"] is True
+    assert payload["data"]["output_format"] == "jsonl"
+    assert payload["data"]["max_frames"] == 5
+
+
+def test_call_tool_datasets_replay_plan_index_error():
+    results = asyncio.run(handle_call_tool("datasets_replay_plan", {"source": "catalog:pivot-auto-datasets"}))
+    payload = json.loads(results[0].text)
+    assert payload["ok"] is False
+    assert payload["command"] == "datasets replay"
+    assert payload["errors"][0]["code"] == "DATASET_INDEX_NOT_REPLAYABLE"
 
 
 # --- TEST-MCP-07: invalid frame_id returns structured error ----------------
@@ -236,6 +288,22 @@ def test_build_argv_generate_with_options():
     assert "5" in argv
     assert "--extended" in argv
     assert argv[-1] == "--json"
+
+
+def test_build_argv_datasets_search_with_options():
+    argv = _build_argv("datasets_search", {"query": "j1939", "provider": "catalog", "limit": 5})
+    assert argv == ["datasets", "search", "j1939", "--provider", "catalog", "--limit", "5", "--json"]
+
+
+def test_build_argv_datasets_replay_plan_forces_dry_run():
+    argv = _build_argv(
+        "datasets_replay_plan",
+        {"source": "catalog:candid", "format": "jsonl", "rate": 10.0, "max_frames": 100},
+    )
+    assert argv == [
+        "datasets", "replay", "catalog:candid", "--format", "jsonl", "--rate", "10.0",
+        "--max-frames", "100", "--dry-run", "--json",
+    ]
 
 
 # --- TEST-MCP-13: _build_argv raises for unknown tool ---------------------


### PR DESCRIPTION
## Summary
- Add MCP tools for dataset provider list, search, inspect, fetch, cache list, and cache refresh.
- Add `datasets_replay_plan`, which maps to `canarchy datasets replay --dry-run --json` for safe replay metadata resolution without streaming frames.
- Update MCP docs, test spec, agent guidance, and changelog.

## Verification
- `uv run pytest tests/test_mcp.py -v`
- `uv run canarchy datasets replay catalog:candid --dry-run --json`
- `uv run pytest --tb=short`

## Acceptance Criteria
- Issue referenced: refs #239
- Tests pass: yes, 588 passed, 1 skipped
- Changelog updated: yes
- Design spec current: yes
- Test spec current: yes
- Agent guide current: yes
- No stale documentation left: MCP design/test docs and agent docs updated

Refs #239