### PR TITLE
Add dataset replay limits and JSONL provenance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -483,7 +483,7 @@ canarchy
 
 This tree is a starting point, not a lock.
 
-For dataset automation, agents should prefer MCP dataset tools when available, or explicit CLI JSON output otherwise. `datasets_search` / `datasets search --json` and `datasets_inspect` / `datasets inspect --json` include stable machine fields: `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`. Use MCP `datasets_replay_plan` or CLI `datasets replay --dry-run --json` for safe replay preflight; actual dataset frame streaming remains CLI-only. Curated index entries that cannot be replayed return `DATASET_INDEX_NOT_REPLAYABLE`.
+For dataset automation, agents should prefer MCP dataset tools when available, or explicit CLI JSON output otherwise. `datasets_search` / `datasets search --json` and `datasets_inspect` / `datasets inspect --json` include stable machine fields: `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`. Use MCP `datasets_replay_plan` or CLI `datasets replay --dry-run --json` for safe replay preflight; use `--max-frames` or `--max-seconds` to bound replay. Actual dataset frame streaming remains CLI-only. Curated index entries that cannot be replayed return `DATASET_INDEX_NOT_REPLAYABLE`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * Added `candid` (CANdid) dataset to the built-in catalog: VehicleSec 2025 paper dataset with 10-passenger-vehicle candump-format CAN logs, annotations, GPS, metadata, and video. Ref: `catalog:candid`. Closes #225.
 * Added `canarchy datasets replay` for Netflix-style streaming playback from a direct candump URL or replayable dataset ref such as `catalog:candid`, with candump/JSONL stdout output, rate control, and JSON summary mode. Closes #233.
 * Added `canarchy datasets replay --dry-run` so operators and agents can resolve replay metadata for dataset refs or direct URLs without opening the remote stream. Closes #247.
+* Added `canarchy datasets replay --max-seconds` and JSONL replay provenance metadata so operators can time-bound remote replay and trace emitted frames back to their dataset ref or URL. Closes #245.
 * Added stable machine-friendly dataset JSON fields (`ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`) for dataset search and inspect results. Closes #242.
 * Added MCP tools for dataset provider discovery, search, inspect, fetch, cache operations, and safe replay planning so agents can use dataset metadata without shelling out. Closes #239.
 * Added `pivot-auto-datasets` to the built-in catalog as a curated source index for CAN, CAN-FD, J1939, and broader automotive datasets listed by the PIVOT Project. Closes #235.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -103,7 +103,7 @@ Current exclusions:
 * CLI-only workflows such as `j1939 faults` and `re signals` that are not yet exposed as MCP tools
 * interactive or service commands such as `shell`, `tui`, and `mcp serve`
 
-For dataset workflows, agents should prefer MCP dataset tools when available. `datasets_search` and `datasets_inspect` include stable machine fields: `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`. Use `datasets_replay_plan` for safe replay preflight; actual frame streaming remains CLI-only. Curated index entries that cannot be replayed return `DATASET_INDEX_NOT_REPLAYABLE`.
+For dataset workflows, agents should prefer MCP dataset tools when available. `datasets_search` and `datasets_inspect` include stable machine fields: `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`. Use `datasets_replay_plan` for safe replay preflight; use `max_frames` or `max_seconds` to bound replay. Actual frame streaming remains CLI-only. Curated index entries that cannot be replayed return `DATASET_INDEX_NOT_REPLAYABLE`.
 
 ### Skills Workflow
 

--- a/docs/command_spec.md
+++ b/docs/command_spec.md
@@ -527,7 +527,7 @@ Notes:
 Stream a remote candump dataset file directly to stdout with replay timing. The source may be a direct candump download URL or a replayable dataset ref such as `catalog:candid`.
 
 ```bash
-canarchy datasets replay <dataset-ref-or-url> [--format candump|jsonl] [--rate <multiplier>] [--max-frames <n>] [--dry-run] [--json]
+canarchy datasets replay <dataset-ref-or-url> [--format candump|jsonl] [--rate <multiplier>] [--max-frames <n>] [--max-seconds <seconds>] [--dry-run] [--json]
 ```
 
 Examples:
@@ -535,6 +535,7 @@ Examples:
 ```bash
 canarchy datasets replay catalog:candid --rate 1.0
 canarchy datasets replay catalog:candid --format jsonl --rate 10 --max-frames 1000
+canarchy datasets replay catalog:candid --format jsonl --rate 10 --max-seconds 30
 canarchy datasets replay https://ndownloader.figshare.com/files/54551156 --rate 1000 --max-frames 10
 canarchy datasets replay catalog:candid --rate 1000 --max-frames 10 --json
 canarchy datasets replay catalog:candid --dry-run --json
@@ -543,7 +544,9 @@ canarchy datasets replay catalog:candid --dry-run --json
 Notes:
 
 * without `--json`, replayed frames are written directly to stdout as candump or JSONL records for piping
+* JSONL replay frame events include `payload.dataset.provider_ref`, `source_url`, `replay_file`, `default_replay_file`, `source_format`, `source_type`, and `frame_offset`
 * with `--json`, stdout contains a clean standard result envelope with replay metadata and no frame records
+* JSON summary output reports `stop_reason`, including `eof`, `max_frames`, `max_seconds`, `broken_pipe`, or `interrupted`
 * replay downloads incrementally from the remote HTTP response and does not require a complete local dataset file
 * `--dry-run` resolves replay source metadata without opening the remote stream
 * replaying a curated index entry fails with `DATASET_INDEX_NOT_REPLAYABLE`; other non-replayable datasets fail with `DATASET_REPLAY_UNAVAILABLE`

--- a/docs/design/dataset-provider-workflow.md
+++ b/docs/design/dataset-provider-workflow.md
@@ -5,7 +5,7 @@
 | Field | Value |
 |-------|-------|
 | Status | Implemented (Phase 2) |
-| Issue | #216, #220, #233, #235, #242 |
+| Issue | #216, #220, #233, #235, #242, #245 |
 | Implementation | `src/canarchy/dataset_provider.py`, `dataset_cache.py`, `dataset_catalog.py`, `dataset_convert.py` |
 
 ---
@@ -32,7 +32,7 @@ canarchy datasets cache list
 canarchy datasets cache refresh [--provider <name>]
 canarchy datasets convert <file> --source-format hcrl-csv --format candump|jsonl [--output <path>]
 canarchy datasets stream <file> --source-format hcrl-csv --format candump|jsonl [--chunk-size N] [--provider-ref <ref>] [--output <path>]
-canarchy datasets replay <dataset-ref-or-url> [--format candump|jsonl] [--rate N] [--max-frames N] [--dry-run]
+canarchy datasets replay <dataset-ref-or-url> [--format candump|jsonl] [--rate N] [--max-frames N] [--max-seconds N] [--dry-run]
 ```
 
 All commands follow the standard `--json`, `--jsonl`, `--table`, `--raw` output modes.
@@ -208,6 +208,8 @@ building a full in-memory frame list.
 | REQ-DATASET-REPLAY-06 | Unwanted behaviour | If replay stdout is closed by a downstream pipeline consumer, the system shall stop replay cleanly without printing a Python traceback. |
 | REQ-DATASET-REPLAY-07 | Optional feature | Where `--dry-run` is specified, the system shall resolve replay source metadata without opening the remote stream. |
 | REQ-DATASET-REPLAY-08 | Unwanted behaviour | If a curated dataset index is requested as a replay source, the system shall return a structured `DATASET_INDEX_NOT_REPLAYABLE` error. |
+| REQ-DATASET-REPLAY-09 | Optional feature | Where `--max-seconds` is specified, the system shall stop replay after the requested capture-time window and report `stop_reason=max_seconds`. |
+| REQ-DATASET-REPLAY-10 | Optional feature | Where JSONL replay output is specified, the system shall include dataset provenance metadata on each frame event, including provider ref or URL, source URL, replay file, default replay file, frame offset, source format, and source type. |
 
 ---
 

--- a/docs/tests/dataset-provider-workflow.md
+++ b/docs/tests/dataset-provider-workflow.md
@@ -6,7 +6,7 @@
 |-------|-------|
 | Status | Implemented |
 | Related design spec | `docs/design/dataset-provider-workflow.md` |
-| Issues | #216, #220, #233, #235, #242 |
+| Issues | #216, #220, #233, #235, #242, #245 |
 | Test module | `tests/test_dataset_provider.py` |
 
 ---
@@ -162,6 +162,29 @@ And no remote stream is opened
 
 **Fixture:** embedded catalog metadata and mocked `requests.get` assertion in `tests/test_dataset_provider.py`
 
+### TEST-DATASET-REPLAY-06: Replay Stops At Max Seconds
+
+```gherkin
+Given a mocked remote candump HTTP response with frames beyond a one-second capture-time window
+When the operator runs `canarchy datasets replay catalog:candid --max-seconds 1.0 --json`
+Then stdout contains a standard JSON result envelope
+And the result reports only frames inside the window
+And the result reports `stop_reason` as `max_seconds`
+```
+
+**Fixture:** mocked `requests.get` response in `tests/test_dataset_provider.py`
+
+### TEST-DATASET-REPLAY-07: JSONL Replay Includes Dataset Provenance
+
+```gherkin
+Given the CANdid catalog entry defines default replay metadata
+When the operator runs `canarchy datasets replay catalog:candid --format jsonl`
+Then each emitted frame event includes dataset provenance metadata
+And the metadata identifies provider ref, source URL, replay file, default replay file, source format, source type, and frame offset
+```
+
+**Fixture:** mocked `requests.get` response in `tests/test_dataset_provider.py`
+
 ---
 
 ## Traceability
@@ -186,6 +209,8 @@ And no remote stream is opened
 | REQ-DATASET-REPLAY-06 | TEST-DATASET-REPLAY-03 |
 | REQ-DATASET-REPLAY-07 | TEST-DATASET-REPLAY-04 |
 | REQ-DATASET-REPLAY-08 | TEST-DATASET-REPLAY-05 |
+| REQ-DATASET-REPLAY-09 | TEST-DATASET-REPLAY-06 |
+| REQ-DATASET-REPLAY-10 | TEST-DATASET-REPLAY-07 |
 
 ---
 

--- a/docs/tests/mcp-server.md
+++ b/docs/tests/mcp-server.md
@@ -178,10 +178,11 @@ And    the result shall report `is_index=true` and `is_replayable=false`
 
 ```gherkin
 Given  the MCP server is initialised
-When   `handle_call_tool("datasets_replay_plan", {"source": "catalog:candid"})` is called
+When   `handle_call_tool("datasets_replay_plan", {"source": "catalog:candid", "max_seconds": 2.5})` is called
 Then   the response `text` shall parse as JSON with `ok` equal to `true`
 And    `command` shall equal `"datasets replay"`
 And    the result shall report `dry_run=true` and `streamed=false`
+And    the result shall preserve the requested `max_seconds` value
 ```
 
 **Fixture:** embedded dataset catalog.

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -468,6 +468,7 @@ def build_parser() -> CanarchyArgumentParser:
     )
     datasets_replay.add_argument("--rate", type=float, default=1.0, help="playback rate multiplier (default: 1.0 real-time)")
     datasets_replay.add_argument("--max-frames", type=int, default=None, help="stop after N frames")
+    datasets_replay.add_argument("--max-seconds", type=float, default=None, help="stop after N seconds of capture time")
     datasets_replay.add_argument("--dry-run", action="store_true", help="resolve replay source metadata without opening the stream")
     add_output_arguments(datasets_replay)
     datasets_replay.set_defaults(command="datasets replay")
@@ -2796,6 +2797,8 @@ def datasets_payload(args: argparse.Namespace) -> tuple[dict[str, Any], list[dic
                 output_format=args.output_format,
                 rate=args.rate,
                 max_frames=getattr(args, "max_frames", None),
+                max_seconds=getattr(args, "max_seconds", None),
+                provenance=dataset_replay_provenance(replay_source),
                 emit_frames=False,
             )
         except ConversionError as exc:
@@ -2827,6 +2830,7 @@ def resolve_dataset_replay_source(source: str, registry: Any) -> dict[str, Any]:
             "download_url_available": True,
             "download_url": source,
             "source_format": "candump",
+            "replay_file": None,
         }
 
     from canarchy.dataset_provider import DatasetError
@@ -2860,6 +2864,7 @@ def resolve_dataset_replay_source(source: str, registry: Any) -> dict[str, Any]:
         "download_url_available": True,
         "download_url": replay["download_url"],
         "source_format": replay.get("source_format", "candump"),
+        "replay_file": replay.get("default_file"),
     }
 
 
@@ -2911,8 +2916,20 @@ def dataset_replay_plan(args: argparse.Namespace, replay_source: dict[str, Any])
         "output_format": args.output_format,
         "rate": args.rate,
         "max_frames": getattr(args, "max_frames", None),
+        "max_seconds": getattr(args, "max_seconds", None),
         "streamed": False,
         "would_stream": True,
+    }
+
+
+def dataset_replay_provenance(replay_source: dict[str, Any]) -> dict[str, Any]:
+    """Return JSONL provenance metadata for replayed dataset frames."""
+    return {
+        "provider_ref": replay_source.get("ref") or replay_source.get("source"),
+        "source_url": replay_source.get("download_url"),
+        "replay_file": replay_source.get("replay_file") or replay_source.get("default_replay_file"),
+        "default_replay_file": replay_source.get("default_replay_file"),
+        "source_type": replay_source.get("source_type"),
     }
 
 
@@ -2932,6 +2949,13 @@ def validate_dataset_replay_options(args: argparse.Namespace, replay_source: dic
             code="INVALID_RATE",
             message=f"Replay rate must be positive, got {args.rate}.",
             hint="Use a positive rate like 1.0 (real-time) or 0.5 (half-speed).",
+        )
+    max_seconds = getattr(args, "max_seconds", None)
+    if max_seconds is not None and max_seconds <= 0:
+        raise ConversionError(
+            code="INVALID_MAX_SECONDS",
+            message=f"Replay max seconds must be positive, got {max_seconds}.",
+            hint="Use `--max-seconds` with a positive duration.",
         )
 
 
@@ -4246,6 +4270,8 @@ def emit_dataset_replay(args: argparse.Namespace) -> int:
             output_format=args.output_format,
             rate=args.rate,
             max_frames=getattr(args, "max_frames", None),
+            max_seconds=getattr(args, "max_seconds", None),
+            provenance=dataset_replay_provenance(replay_source),
         )
     except ConversionError as exc:
         result = error_result(

--- a/src/canarchy/dataset_convert.py
+++ b/src/canarchy/dataset_convert.py
@@ -165,6 +165,8 @@ def stream_replay(
     output_format: str = "candump",
     rate: float = 1.0,
     max_frames: int | None = None,
+    max_seconds: float | None = None,
+    provenance: dict | None = None,
     emit_frames: bool = True,
     handle: IO[str] | None = None,
 ) -> dict:
@@ -193,9 +195,16 @@ def stream_replay(
             message=f"Replay rate must be positive, got {rate}.",
             hint="Use a positive rate like 1.0 (real-time) or 0.5 (half-speed).",
         )
+    if max_seconds is not None and max_seconds <= 0:
+        raise ConversionError(
+            code="INVALID_MAX_SECONDS",
+            message=f"Replay max seconds must be positive, got {max_seconds}.",
+            hint="Use `--max-seconds` with a positive duration.",
+        )
 
     frame_count = 0
     last_timestamp = None
+    first_timestamp = None
     start_time = time.monotonic()
     output = handle or sys.stdout
     stop_reason = "eof"
@@ -216,9 +225,16 @@ def stream_replay(
                 if frame is None:
                     continue
 
+                if first_timestamp is None:
+                    first_timestamp = frame["timestamp"]
+                capture_elapsed = frame["timestamp"] - first_timestamp
+                if max_seconds is not None and capture_elapsed > max_seconds:
+                    stop_reason = "max_seconds"
+                    break
                 if max_frames is not None and frame_count >= max_frames:
                     stop_reason = "max_frames"
                     break
+                frame_offset = frame_count
                 frame_count += 1
 
                 # Timing: sleep to maintain original timing * rate
@@ -233,7 +249,13 @@ def stream_replay(
                     if output_format == "candump":
                         output_line = f"({frame['timestamp']:.6f}) {frame.get('interface') or 'can0'} {frame['arbitration_id']:X}#{frame['data'].hex().upper()}"
                     elif output_format == "jsonl":
-                        output_line = json.dumps(_frame_to_event(frame, source=source_format))
+                        event = _frame_to_event(frame, source=source_format)
+                        event["payload"]["dataset"] = {
+                            **(provenance or {}),
+                            "frame_offset": frame_offset,
+                            "source_format": source_format,
+                        }
+                        output_line = json.dumps(event)
                     else:
                         raise AssertionError(f"unhandled output format: {output_format}")
                     try:
@@ -242,6 +264,8 @@ def stream_replay(
                         stop_reason = "broken_pipe"
                         _silence_broken_stdout(output)
                         break
+    except KeyboardInterrupt:
+        stop_reason = "interrupted"
     except requests.RequestException as exc:
         raise ConversionError(
             code="DATASET_REPLAY_FETCH_FAILED",
@@ -255,6 +279,7 @@ def stream_replay(
         "source_format": source_format,
         "output_format": output_format,
         "rate": rate,
+        "max_seconds": max_seconds,
         "frame_count": frame_count,
         "elapsed_seconds": elapsed,
         "stop_reason": stop_reason,

--- a/src/canarchy/mcp_server.py
+++ b/src/canarchy/mcp_server.py
@@ -449,6 +449,7 @@ _TOOLS: list[types.Tool] = [
                 "format": {"type": "string", "description": "Planned output format", "enum": ["candump", "jsonl"], "default": "candump"},
                 "rate": {"type": "number", "description": "Playback rate multiplier for the planned replay", "default": 1.0},
                 "max_frames": {"type": "integer", "description": "Planned frame limit"},
+                "max_seconds": {"type": "number", "description": "Planned capture-time limit in seconds"},
             },
             "required": ["source"],
         },
@@ -791,6 +792,8 @@ def _build_argv(tool_name: str, arguments: dict[str, Any]) -> list[str]:
                 argv += ["--rate", str(a["rate"])]
             if a.get("max_frames") is not None:
                 argv += ["--max-frames", str(a["max_frames"])]
+            if a.get("max_seconds") is not None:
+                argv += ["--max-seconds", str(a["max_seconds"])]
             return argv + ["--dry-run", "--json"]
         case "dbc_provider_list":
             return ["dbc", "provider", "list", "--json"]

--- a/tests/test_dataset_provider.py
+++ b/tests/test_dataset_provider.py
@@ -433,6 +433,45 @@ class DatasetConvertTests(unittest.TestCase):
         self.assertEqual(result["frame_count"], 1)
         self.assertEqual(result["stop_reason"], "broken_pipe")
 
+    def test_stream_replay_max_seconds_stops_by_capture_time(self) -> None:
+        response = FakeStreamingResponse([
+            "(10.000000) can0 316#0000000000000000",
+            "(10.500000) can0 18F#0000000000600000",
+            "(11.100000) can0 123#AA",
+        ])
+        with patch("canarchy.dataset_convert.requests.get", return_value=response):
+            with patch("sys.stdout", new_callable=io.StringIO) as stdout:
+                result = stream_replay("https://example.test/candid.log", rate=1000.0, max_seconds=1.0)
+        self.assertEqual(result["frame_count"], 2)
+        self.assertEqual(result["stop_reason"], "max_seconds")
+        self.assertNotIn("123#AA", stdout.getvalue())
+
+    def test_stream_replay_jsonl_includes_dataset_provenance(self) -> None:
+        response = FakeStreamingResponse(["(0.000000) can0 316#0000000000000000"])
+        provenance = {
+            "provider_ref": "catalog:candid",
+            "source_url": "https://example.test/candid.log",
+            "replay_file": "2_brakes_CAN.log",
+            "default_replay_file": "2_brakes_CAN.log",
+            "source_type": "dataset_ref",
+        }
+        with patch("canarchy.dataset_convert.requests.get", return_value=response):
+            with patch("sys.stdout", new_callable=io.StringIO) as stdout:
+                result = stream_replay(
+                    "https://example.test/candid.log",
+                    output_format="jsonl",
+                    provenance=provenance,
+                )
+        self.assertEqual(result["frame_count"], 1)
+        event = json.loads(stdout.getvalue())
+        dataset = event["payload"]["dataset"]
+        self.assertEqual(dataset["provider_ref"], "catalog:candid")
+        self.assertEqual(dataset["source_url"], "https://example.test/candid.log")
+        self.assertEqual(dataset["replay_file"], "2_brakes_CAN.log")
+        self.assertEqual(dataset["default_replay_file"], "2_brakes_CAN.log")
+        self.assertEqual(dataset["source_format"], "candump")
+        self.assertEqual(dataset["frame_offset"], 0)
+
 
 # ---------------------------------------------------------------------------
 # CLI integration
@@ -675,6 +714,25 @@ class CliIntegrationTests(unittest.TestCase):
         self.assertEqual(data["data"]["frame_count"], 1)
         self.assertNotIn("316#", out.splitlines()[0])
 
+    def test_datasets_replay_max_seconds_json_summary(self) -> None:
+        response = FakeStreamingResponse([
+            "(0.000000) can0 316#0000000000000000",
+            "(0.500000) can0 18F#0000000000600000",
+            "(1.100000) can0 123#AA",
+        ])
+        with patch("canarchy.dataset_convert.requests.get", return_value=response):
+            code, out, _ = run_cli(
+                "datasets", "replay", "catalog:candid",
+                "--rate", "1000",
+                "--max-seconds", "1.0",
+                "--json",
+            )
+        self.assertEqual(code, 0)
+        data = json.loads(out)
+        self.assertEqual(data["data"]["frame_count"], 2)
+        self.assertEqual(data["data"]["max_seconds"], 1.0)
+        self.assertEqual(data["data"]["stop_reason"], "max_seconds")
+
     def test_datasets_replay_direct_url_streams_frames(self) -> None:
         response = FakeStreamingResponse(["(0.000000) can0 316#0000000000000000"])
         with patch("canarchy.dataset_convert.requests.get", return_value=response):
@@ -685,6 +743,25 @@ class CliIntegrationTests(unittest.TestCase):
         )
         self.assertEqual(code, 0)
         self.assertEqual(out.strip(), "(0.000000) can0 316#0000000000000000")
+
+    def test_datasets_replay_catalog_ref_jsonl_includes_provenance(self) -> None:
+        response = FakeStreamingResponse(["(0.000000) can0 316#0000000000000000"])
+        with patch("canarchy.dataset_convert.requests.get", return_value=response):
+            code, out, _ = run_cli(
+                "datasets", "replay", "catalog:candid",
+                "--format", "jsonl",
+                "--rate", "1000",
+                "--max-frames", "1",
+            )
+        self.assertEqual(code, 0)
+        event = json.loads(out)
+        dataset = event["payload"]["dataset"]
+        self.assertEqual(dataset["provider_ref"], "catalog:candid")
+        self.assertEqual(dataset["source_url"], "https://ndownloader.figshare.com/files/54551156")
+        self.assertEqual(dataset["replay_file"], "2_brakes_CAN.log")
+        self.assertEqual(dataset["default_replay_file"], "2_brakes_CAN.log")
+        self.assertEqual(dataset["frame_offset"], 0)
+        self.assertEqual(dataset["source_format"], "candump")
 
     def test_datasets_replay_http_failure_returns_structured_error(self) -> None:
         with patch("canarchy.dataset_convert.requests.get", side_effect=requests.ConnectionError("offline")):
@@ -704,6 +781,7 @@ class CliIntegrationTests(unittest.TestCase):
                 "--format", "jsonl",
                 "--rate", "10",
                 "--max-frames", "5",
+                "--max-seconds", "2.5",
                 "--dry-run",
                 "--json",
             )
@@ -716,6 +794,7 @@ class CliIntegrationTests(unittest.TestCase):
         self.assertEqual(data["data"]["output_format"], "jsonl")
         self.assertEqual(data["data"]["rate"], 10.0)
         self.assertEqual(data["data"]["max_frames"], 5)
+        self.assertEqual(data["data"]["max_seconds"], 2.5)
         self.assertTrue(data["data"]["dry_run"])
         self.assertTrue(data["data"]["would_stream"])
         self.assertFalse(data["data"]["streamed"])

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -141,7 +141,7 @@ def test_call_tool_datasets_replay_plan_does_not_stream():
     results = asyncio.run(
         handle_call_tool(
             "datasets_replay_plan",
-            {"source": "catalog:candid", "format": "jsonl", "rate": 10.0, "max_frames": 5},
+            {"source": "catalog:candid", "format": "jsonl", "rate": 10.0, "max_frames": 5, "max_seconds": 2.5},
         )
     )
     assert len(results) == 1
@@ -153,6 +153,7 @@ def test_call_tool_datasets_replay_plan_does_not_stream():
     assert payload["data"]["would_stream"] is True
     assert payload["data"]["output_format"] == "jsonl"
     assert payload["data"]["max_frames"] == 5
+    assert payload["data"]["max_seconds"] == 2.5
 
 
 def test_call_tool_datasets_replay_plan_index_error():
@@ -298,11 +299,11 @@ def test_build_argv_datasets_search_with_options():
 def test_build_argv_datasets_replay_plan_forces_dry_run():
     argv = _build_argv(
         "datasets_replay_plan",
-        {"source": "catalog:candid", "format": "jsonl", "rate": 10.0, "max_frames": 100},
+        {"source": "catalog:candid", "format": "jsonl", "rate": 10.0, "max_frames": 100, "max_seconds": 2.5},
     )
     assert argv == [
         "datasets", "replay", "catalog:candid", "--format", "jsonl", "--rate", "10.0",
-        "--max-frames", "100", "--dry-run", "--json",
+        "--max-frames", "100", "--max-seconds", "2.5", "--dry-run", "--json",
     ]
 
 


### PR DESCRIPTION
## Summary
- Add `canarchy datasets replay --max-seconds` to bound replay by capture-time duration and report `stop_reason=max_seconds`.
- Add JSONL replay provenance under `payload.dataset` with provider ref or URL, source URL, replay/default file, source format/type, and frame offset.
- Thread `max_seconds` through dry-run planning and the MCP `datasets_replay_plan` mapping.
- Update command docs, dataset design/test specs, MCP test spec, agent guidance, and changelog.

## Verification
- `uv run pytest tests/test_dataset_provider.py tests/test_mcp.py -q`
- `uv run canarchy datasets replay catalog:candid --dry-run --max-seconds 2.5 --json`
- `uv run pytest --tb=short`

## Acceptance Criteria
- Issue referenced: refs #245
- Tests pass: yes, 592 passed, 1 skipped
- Changelog updated: yes
- Design spec current: yes
- Test spec current: yes
- Agent guide current: yes
- No stale documentation left: command spec, MCP test spec, and agent docs updated

Refs #245