### PR TITLE
Expose candump as dataset stream source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * Added `canarchy datasets replay --dry-run` so operators and agents can resolve replay metadata for dataset refs or direct URLs without opening the remote stream. Closes #247.
 * Added `canarchy datasets replay --max-seconds` and JSONL replay provenance metadata so operators can time-bound remote replay and trace emitted frames back to their dataset ref or URL. Closes #245.
 * Added replay file manifests and `canarchy datasets replay --list-files` / `--file <id-or-name>` selection for replayable dataset refs such as `catalog:candid`. Closes #241.
+* Added `candump` as a public `canarchy datasets stream --source-format` option so downloaded candump logs can be streamed to candump or JSONL with provenance metadata. Closes #243.
 * Added stable machine-friendly dataset JSON fields (`ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`) for dataset search and inspect results. Closes #242.
 * Added MCP tools for dataset provider discovery, search, inspect, fetch, cache operations, and safe replay planning so agents can use dataset metadata without shelling out. Closes #239.
 * Added `pivot-auto-datasets` to the built-in catalog as a curated source index for CAN, CAN-FD, J1939, and broader automotive datasets listed by the PIVOT Project. Closes #235.

--- a/docs/command_spec.md
+++ b/docs/command_spec.md
@@ -503,13 +503,14 @@ canarchy datasets convert <file> --source-format hcrl-csv --format candump|jsonl
 Stream a downloaded dataset file to candump or JSONL without loading the full conversion into memory.
 
 ```bash
-canarchy datasets stream <file> --source-format hcrl-csv --format candump|jsonl [--chunk-size <n>] [--provider-ref <ref>] [--output <path>] [--json]
+canarchy datasets stream <file> --source-format hcrl-csv|candump --format candump|jsonl [--chunk-size <n>] [--provider-ref <ref>] [--output <path>] [--json]
 ```
 
 Examples:
 
 ```bash
 canarchy datasets stream sample.csv --source-format hcrl-csv --format jsonl --provider-ref catalog:hcrl-car-hacking
+canarchy datasets stream sample.log --source-format candump --format jsonl --provider-ref catalog:candid
 canarchy datasets stream sample.csv --source-format hcrl-csv --format candump --output sample.candump
 canarchy datasets stream sample.csv --source-format hcrl-csv --format jsonl --json
 ```

--- a/docs/design/dataset-provider-workflow.md
+++ b/docs/design/dataset-provider-workflow.md
@@ -5,7 +5,7 @@
 | Field | Value |
 |-------|-------|
 | Status | Implemented (Phase 2) |
-| Issue | #216, #220, #233, #235, #241, #242, #245 |
+| Issue | #216, #220, #233, #235, #241, #242, #243, #245 |
 | Implementation | `src/canarchy/dataset_provider.py`, `dataset_cache.py`, `dataset_catalog.py`, `dataset_convert.py` |
 
 ---
@@ -31,7 +31,7 @@ canarchy datasets fetch <ref>
 canarchy datasets cache list
 canarchy datasets cache refresh [--provider <name>]
 canarchy datasets convert <file> --source-format hcrl-csv --format candump|jsonl [--output <path>]
-canarchy datasets stream <file> --source-format hcrl-csv --format candump|jsonl [--chunk-size N] [--provider-ref <ref>] [--output <path>]
+canarchy datasets stream <file> --source-format hcrl-csv|candump --format candump|jsonl [--chunk-size N] [--provider-ref <ref>] [--output <path>]
 canarchy datasets replay <dataset-ref-or-url> [--file <id-or-name>] [--list-files] [--format candump|jsonl] [--rate N] [--max-frames N] [--max-seconds N] [--dry-run]
 ```
 
@@ -148,6 +148,7 @@ file into a CANarchy-native format.
 | Source format | Description | Output formats |
 |--------------|-------------|----------------|
 | `hcrl-csv` | HCRL Car-Hacking CSV: `Timestamp,ID,DLC,Data[,Label]` | `candump`, `jsonl` |
+| `candump` | can-utils timestamped log lines such as `(0.000000) can0 123#AABB` | `candump`, `jsonl` |
 
 ### candump output
 

--- a/docs/tests/dataset-provider-workflow.md
+++ b/docs/tests/dataset-provider-workflow.md
@@ -6,7 +6,7 @@
 |-------|-------|
 | Status | Implemented |
 | Related design spec | `docs/design/dataset-provider-workflow.md` |
-| Issues | #216, #220, #233, #235, #241, #242, #245 |
+| Issues | #216, #220, #233, #235, #241, #242, #243, #245 |
 | Test module | `tests/test_dataset_provider.py` |
 
 ---
@@ -103,6 +103,27 @@ And frame events are not emitted to stdout
 ```
 
 **Fixture:** `tests/fixtures/dataset_hcrl_sample.csv`
+
+### TEST-DATASET-STREAM-06: CLI Streams Candump Source To JSONL
+
+```gherkin
+Given a small candump fixture
+When the operator runs `canarchy datasets stream --source-format candump --format jsonl`
+Then stdout contains JSONL frame events
+And the provider ref is preserved in dataset provenance metadata
+```
+
+**Fixture:** `tests/fixtures/sample.candump`
+
+### TEST-DATASET-STREAM-07: Help Lists Supported Source Formats
+
+```gherkin
+Given the dataset stream command is available
+When the operator runs `canarchy datasets stream --help`
+Then help text lists both `hcrl-csv` and `candump` source formats
+```
+
+**Fixture:** CLI parser help text
 
 ### TEST-DATASET-REPLAY-01: Remote Candump Replay Without Local File
 
@@ -230,7 +251,7 @@ And no remote stream is opened
 | REQ-DATASET-CATALOG-03 | TEST-DATASET-CATALOG-01 |
 | REQ-DATASET-CATALOG-04 | TEST-DATASET-CATALOG-03 |
 | REQ-DATASET-STREAM-01 | TEST-DATASET-STREAM-01, TEST-DATASET-STREAM-02, TEST-DATASET-STREAM-04 |
-| REQ-DATASET-STREAM-02 | TEST-DATASET-STREAM-01, TEST-DATASET-STREAM-02 |
+| REQ-DATASET-STREAM-02 | TEST-DATASET-STREAM-01, TEST-DATASET-STREAM-02, TEST-DATASET-STREAM-06, TEST-DATASET-STREAM-07 |
 | REQ-DATASET-STREAM-03 | TEST-DATASET-STREAM-01, TEST-DATASET-STREAM-04 |
 | REQ-DATASET-STREAM-04 | TEST-DATASET-STREAM-01, TEST-DATASET-STREAM-04 |
 | REQ-DATASET-STREAM-05 | TEST-DATASET-STREAM-03 |

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -441,8 +441,8 @@ def build_parser() -> CanarchyArgumentParser:
     datasets_stream.add_argument(
         "--source-format",
         required=True,
-        choices=["hcrl-csv"],
-        help="source file format (hcrl-csv: HCRL Timestamp,ID,DLC,Data CSV)",
+        choices=["hcrl-csv", "candump"],
+        help="source file format (hcrl-csv: HCRL Timestamp,ID,DLC,Data CSV; candump: can-utils log)",
     )
     datasets_stream.add_argument(
         "--format",

--- a/tests/test_dataset_provider.py
+++ b/tests/test_dataset_provider.py
@@ -658,6 +658,29 @@ class CliIntegrationTests(unittest.TestCase):
         self.assertEqual(len(events), 6)
         self.assertEqual(events[2]["payload"]["dataset"]["chunk_index"], 1)
 
+    def test_datasets_stream_candump_to_stdout_jsonl(self) -> None:
+        src = str(FIXTURES / "sample.candump")
+        code, out, _ = run_cli(
+            "datasets", "stream", src,
+            "--source-format", "candump",
+            "--format", "jsonl",
+            "--provider-ref", "catalog:candid",
+        )
+        self.assertEqual(code, 0)
+        events = [json.loads(line) for line in out.splitlines()]
+        self.assertEqual(len(events), 3)
+        self.assertEqual(events[0]["source"], "candump")
+        self.assertEqual(events[0]["payload"]["dataset"]["provider_ref"], "catalog:candid")
+
+    def test_datasets_stream_help_lists_candump_source_format(self) -> None:
+        from canarchy.cli import main
+
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout), self.assertRaises(SystemExit) as ctx:
+            main(("datasets", "stream", "--help"))
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("{hcrl-csv,candump}", stdout.getvalue())
+
     def test_datasets_stream_json_summary_does_not_emit_frames(self) -> None:
         src = str(FIXTURES / "dataset_hcrl_sample.csv")
         code, out, _ = run_cli(


### PR DESCRIPTION
## Summary
- Expose `candump` as a supported `canarchy datasets stream --source-format` CLI choice.
- Add CLI tests for candump-to-JSONL streaming and help text listing both supported source formats.
- Update command docs, dataset design/test specs, and changelog.

## Verification
- `uv run pytest tests/test_dataset_provider.py -q`
- `uv run canarchy datasets stream --help`
- `uv run canarchy datasets stream tests/fixtures/sample.candump --source-format candump --format jsonl --provider-ref catalog:candid`
- `uv run pytest --tb=short`

## Acceptance Criteria
- Issue referenced: refs #243
- Tests pass: yes, 597 passed, 1 skipped
- Changelog updated: yes
- Design spec current: yes
- Test spec current: yes
- Agent guide current: no agent workflow change beyond existing dataset stream guidance
- No stale documentation left: command spec updated

Refs #243