### PR TITLE
Clarify datasets fetch wording for curated index entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * Added MCP tools for dataset provider discovery, search, inspect, fetch, cache operations, and safe replay planning so agents can use dataset metadata without shelling out. Closes #239.
 * Added `pivot-auto-datasets` to the built-in catalog as a curated source index for CAN, CAN-FD, J1939, and broader automotive datasets listed by the PIVOT Project. Closes #235.
 * Added human-readable dataset search and inspect output improvements: empty search shows "All datasets" instead of "Datasets matching \"all\"", search table includes TYPE column (INDEX/PLAY), verbose output shows type labels and index notes, and inspect output now has separated sections (Basic information, Format support, Source information) with clear replay URLs and index notes. Closes #244.
+* Clarified `datasets fetch` output for curated index entries: responses now include `is_index` field, `index_instructions` with guidance to visit the index page and discover datasets, and clearer human-readable messaging. Normal dataset fetch continues to use `download_instructions`. Closes #246.
 
 ### Fixed
 

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -2701,6 +2701,28 @@ def datasets_payload(args: argparse.Namespace) -> tuple[dict[str, Any], list[dic
                 exit_code=EXIT_USER_ERROR,
                 errors=[ErrorDetail(code=exc.code, message=str(exc), hint=exc.hint)],
             ) from exc
+        
+        # Determine if this is a curated index
+        metadata = resolution.descriptor.metadata if isinstance(resolution.descriptor.metadata, dict) else {}
+        source_type = metadata.get("source_type") if isinstance(metadata, dict) else None
+        is_index = source_type == "curated-index" or "catalog" in resolution.descriptor.formats
+        
+        # Build appropriate instructions
+        if is_index:
+            index_instructions = (
+                f"Curated index entry. Visit the index page to discover datasets: "
+                f"{resolution.descriptor.source_url}"
+                + (f" — Note: {resolution.descriptor.access_notes}" if resolution.descriptor.access_notes else "")
+                + f"\n  Use `canarchy datasets search` to find specific datasets from this index."
+            )
+            download_instructions = index_instructions
+        else:
+            download_instructions = (
+                f"Dataset provenance recorded. Download the data manually from: "
+                f"{resolution.descriptor.source_url}"
+                + (f" — Note: {resolution.descriptor.access_notes}" if resolution.descriptor.access_notes else "")
+            )
+        
         return (
             {
                 "ref": args.ref,
@@ -2710,11 +2732,9 @@ def datasets_payload(args: argparse.Namespace) -> tuple[dict[str, Any], list[dic
                 "is_cached": resolution.is_cached,
                 "provenance": resolution.provenance,
                 "source_url": resolution.descriptor.source_url,
-                "download_instructions": (
-                    f"Dataset provenance recorded. Download the data manually from: "
-                    f"{resolution.descriptor.source_url}"
-                    + (f" — Note: {resolution.descriptor.access_notes}" if resolution.descriptor.access_notes else "")
-                ),
+                "is_index": is_index,
+                "index_instructions": index_instructions if is_index else None,
+                "download_instructions": download_instructions,
             },
             [],
             [],

--- a/tests/test_dataset_provider.py
+++ b/tests/test_dataset_provider.py
@@ -983,3 +983,44 @@ class HumanReadableOutputTests(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertIn("Use `canarchy datasets search", out)
         self.assertIn("curated index, not directly replayable", out)
+
+
+class FetchWordingTests(unittest.TestCase):
+    """Tests for clarified fetch wording for curated index entries (issue #246)."""
+
+    def test_fetch_normal_dataset_returns_download_instructions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("canarchy.dataset_cache.cache_root", return_value=Path(tmp) / "cache"):
+                code, out, _ = run_cli("datasets", "fetch", "catalog:road", "--json")
+        self.assertEqual(code, 0)
+        data = json.loads(out)
+        self.assertTrue(data["ok"])
+        self.assertIn("Download the data manually", data["data"]["download_instructions"])
+        self.assertIn("index_instructions", data["data"])
+        self.assertIsNone(data["data"]["index_instructions"])
+
+    def test_fetch_curated_index_returns_index_instructions(self) -> None:
+        code, out, _ = run_cli("datasets", "fetch", "catalog:pivot-auto-datasets", "--json")
+        self.assertEqual(code, 0)
+        data = json.loads(out)
+        self.assertTrue(data["ok"])
+        self.assertIn("is_index", data["data"])
+        self.assertTrue(data["data"]["is_index"])
+        self.assertIn("index_instructions", data["data"])
+        self.assertIn("Curated index entry", data["data"]["index_instructions"])
+        self.assertIn("Visit the index page", data["data"]["index_instructions"])
+        self.assertIn("Use `canarchy datasets search`", data["data"]["index_instructions"])
+
+    def test_fetch_curated_index_human_output_shows_index_note(self) -> None:
+        code, out, _ = run_cli("datasets", "fetch", "catalog:pivot-auto-datasets")
+        self.assertEqual(code, 0)
+        self.assertIn("Curated index entry", out)
+        self.assertIn("Visit the index page", out)
+
+    def test_fetch_normal_dataset_human_output_shows_download_note(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("canarchy.dataset_cache.cache_root", return_value=Path(tmp) / "cache"):
+                code, out, _ = run_cli("datasets", "fetch", "catalog:road")
+        self.assertEqual(code, 0)
+        self.assertIn("Download the data manually", out)
+        self.assertNotIn("Curated index entry", out)


### PR DESCRIPTION
## Summary
- Fetch responses now include `is_index` field to distinguish index entries
- Curated indexes return `index_instructions` with guidance to visit the index page and discover datasets
- Normal datasets continue to use `download_instructions`
- Human output shows appropriate messaging for both types
- Added 4 tests for fetch output (index and normal dataset)

## Changes
- Modified `datasets fetch` handler in `cli.py` to detect curated indexes
- Added `is_index` and `index_instructions` fields to fetch response
- Updated human-readable output to show appropriate messaging
- Added `FetchWordingTests` class with 4 test cases

## Related Issue
Closes #246

## Acceptance Criteria Checklist
- [x] Fetch output distinguishes dataset payloads from curated index entries
- [x] Curated index fetch responses use `index_instructions` field
- [x] Human and JSON output remain backward-compatible where practical
- [x] Tests cover fetch output for at least one index entry and one normal dataset entry