### PR TITLE
Add stdin pipeline support for file-backed analysis commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * Added `pivot-auto-datasets` to the built-in catalog as a curated source index for CAN, CAN-FD, J1939, and broader automotive datasets listed by the PIVOT Project. Closes #235.
 * Added human-readable dataset search and inspect output improvements: empty search shows "All datasets" instead of "Datasets matching \"all\"", search table includes TYPE column (INDEX/PLAY), verbose output shows type labels and index notes, and inspect output now has separated sections (Basic information, Format support, Source information) with clear replay URLs and index notes. Closes #244.
 * Clarified `datasets fetch` output for curated index entries: responses now include `is_index` field, `index_instructions` with guidance to visit the index page and discover datasets, and clearer human-readable messaging. Normal dataset fetch continues to use `download_instructions`. Closes #246.
+* Added stdin pipeline support for file-backed analysis commands: `capture-info`, `stats`, `filter`, and other commands now accept `-` as file argument to read candump data from stdin. This enables piping `datasets replay` output directly into analysis commands without temporary files. Closes #238.
 
 ### Fixed
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -167,3 +167,4 @@ tool: send {"interface": "vcan0", "frame_id": "0x7DF", "data": "0201F1"}
 * MCP streaming is not supported in v1 — live-capture tools (`capture`, `gateway`) return a buffered batch from the active backend. Use CLI `datasets stream` for local dataset-file JSONL or candump pipelines, and `datasets replay` for remote dataset-ref or URL playback to stdout.
 * `shell`, `tui`, and `mcp serve` are not exposed as MCP tools.
 * Error codes are identical to the CLI, so existing JSON-parsing logic transfers without changes.
+* Stdin pipelines: `capture-info`, `stats`, `filter` now accept `--file -` or `--stdin` to read candump text from stdin. For `filter --jsonl --stdin`, each line must be a JSONL FrameEvent. This enables piping `datasets replay` output directly into analysis commands without temporary files.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -167,4 +167,4 @@ tool: send {"interface": "vcan0", "frame_id": "0x7DF", "data": "0201F1"}
 * MCP streaming is not supported in v1 — live-capture tools (`capture`, `gateway`) return a buffered batch from the active backend. Use CLI `datasets stream` for local dataset-file JSONL or candump pipelines, and `datasets replay` for remote dataset-ref or URL playback to stdout.
 * `shell`, `tui`, and `mcp serve` are not exposed as MCP tools.
 * Error codes are identical to the CLI, so existing JSON-parsing logic transfers without changes.
-* Stdin pipelines: `capture-info`, `stats`, `filter` now accept `--file -` or `--stdin` to read candump text from stdin. For `filter --jsonl --stdin`, each line must be a JSONL FrameEvent. This enables piping `datasets replay` output directly into analysis commands without temporary files.
+* Stdin pipelines: `capture-info`, `stats`, and `filter --file -` read candump text from stdin. `filter --stdin` reads JSONL FrameEvents from stdin regardless of output format. This enables piping `datasets replay` candump output directly into analysis commands without temporary files.

--- a/docs/command_spec.md
+++ b/docs/command_spec.md
@@ -128,9 +128,9 @@ canarchy filter <expression> (--file <path> | --file - | --stdin) [--offset <n>]
 
 Notes:
 
-* `--file -` or `--stdin` reads candump text (or JSONL `frame` events when `--jsonl` is set) from standard input instead of a file
-* `--stdin` alone implies candump text from stdin; combine with `--jsonl` for JSONL FrameEvents
-* For JSONL stdin with `filter`, each line must be a valid `frame` event JSON object
+* `--file -` reads candump text from standard input instead of a file and still honors `--offset`, `--max-frames`, and `--seconds`
+* `--stdin` reads JSONL `frame` events from standard input regardless of output format
+* For `filter --stdin`, each line must be a valid `frame` event JSON object
 
 ### capture-info
 

--- a/docs/command_spec.md
+++ b/docs/command_spec.md
@@ -122,18 +122,15 @@ Notes:
 Filter a capture source by a simple expression.
 
 ```bash
-canarchy filter <expression> (--file <path> | --stdin) [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json|--jsonl|--compact|--table|--raw]
+canarchy filter <expression> (--file <path> | --file - | --stdin) [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json|--jsonl|--compact|--table|--raw]
 ```
-
-Supported expressions today:
-
-* `all`
-* `id==0x18FEEE31`
-* `pgn==65262`
+```
 
 Notes:
 
-* `--stdin` reads JSONL `frame` events from standard input instead of a positional capture file
+* `--file -` or `--stdin` reads candump text (or JSONL `frame` events when `--jsonl` is set) from standard input instead of a file
+* `--stdin` alone implies candump text from stdin; combine with `--jsonl` for JSONL FrameEvents
+* For JSONL stdin with `filter`, each line must be a valid `frame` event JSON object
 
 ### capture-info
 
@@ -141,9 +138,13 @@ Inspect a candump capture quickly before running deeper analysis.
 
 ```bash
 canarchy capture-info --file <path> [--json|--jsonl|--table|--raw]
+canarchy capture-info --file - [--json|--jsonl|--table|--raw]
 ```
 
-Returns capture metadata only:
+Notes:
+
+* `--file -` reads candump text from standard input instead of a file
+* Returns capture metadata only:
 
 * `frame_count`
 * `first_timestamp`
@@ -160,7 +161,12 @@ Summarize a capture source.
 
 ```bash
 canarchy stats --file <path> [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json|--jsonl|--table|--raw]
+canarchy stats --file - [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json|--jsonl|--table|--raw]
 ```
+
+Notes:
+
+* `--file -` reads candump text from standard input instead of a file
 
 ### generate
 
@@ -547,10 +553,12 @@ canarchy datasets replay catalog:candid --dry-run --json
 Notes:
 
 * without `--json`, replayed frames are written directly to stdout as candump or JSONL records for piping
-* JSONL replay frame events include `payload.dataset.provider_ref`, `source_url`, `replay_file`, `default_replay_file`, `source_format`, `source_type`, and `frame_offset`
+* JSONL replay frame events include `payload.dataset.provider_ref`, `source_url`, `replay_file`, `default_replay_file`, `source_format`, and `source_type`
 * with `--json`, stdout contains a clean standard result envelope with replay metadata and no frame records
-* `--list-files --json` returns replayable file entries with stable `id`, `name`, `size_bytes`, `format`, and `source_url` fields
+* `--list-files --json` returns replay file entries with stable `id`, `name`, `size_bytes`, `format`, and `source_url` fields
 * `--file` accepts a replay file `id` or `name`; unknown files fail with `DATASET_REPLAY_FILE_NOT_FOUND`
+* Curated indexes that cannot be replayed return `DATASET_INDEX_NOT_REPLAYABLE`
+* Stdin pipeline: pipe `datasets replay` output into `stats --file -`, `capture-info --file -`, or `filter --file -` for analysis without temporary files
 * JSON summary output reports `stop_reason`, including `eof`, `max_frames`, `max_seconds`, `broken_pipe`, or `interrupted`
 * replay downloads incrementally from the remote HTTP response and does not require a complete local dataset file
 * `--dry-run` resolves replay source metadata without opening the remote stream

--- a/docs/design/dataset-provider-workflow.md
+++ b/docs/design/dataset-provider-workflow.md
@@ -135,6 +135,7 @@ No network access is required for `search`, `inspect`, or `provider list`.
 | REQ-DATASET-CATALOG-02 | Ubiquitous | The system shall include source URL, license or access terms, protocol family, formats, size description, description, and metadata for each built-in catalog entry. |
 | REQ-DATASET-CATALOG-03 | Optional feature | Where a catalog entry represents a curated external index instead of a directly downloadable dataset, the system shall mark the entry as an index in metadata and describe that linked sources have their own access terms and formats. |
 | REQ-DATASET-CATALOG-04 | Ubiquitous | The system shall include stable machine fields for JSON dataset search and inspect results: `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`. |
+| REQ-DATASET-CATALOG-05 | Optional feature | Where a dataset entry is a curated index, the `datasets fetch` response shall include an `is_index` field and an `index_instructions` field with guidance to visit the index page and discover datasets, while normal datasets continue to use `download_instructions`. |
 
 ---
 

--- a/docs/tests/composition.md
+++ b/docs/tests/composition.md
@@ -78,7 +78,7 @@ Then   the result shall include J1939 decoded-message events with PGN and source
 
 ```gherkin
 Given  the file `tests/fixtures/sample.candump` is available
-When   the operator runs `canarchy filter --stdin id==0x123 sample.candump --json`
+When   the operator runs `canarchy filter --stdin id==0x123 --file tests/fixtures/sample.candump --json`
 Then   the command shall exit with code `1`
 And    `errors[0].code` shall equal `"STDIN_AND_FILE_SPECIFIED"`
 ```

--- a/docs/tests/mcp-server.md
+++ b/docs/tests/mcp-server.md
@@ -25,6 +25,8 @@
 | REQ-MCP-11 | `call_tool` handler runs `execute_command` in a thread pool | TEST-MCP-15 |
 | REQ-MCP-12 | File-backed J1939 tools expose `max_frames` and `seconds` parameters | TEST-MCP-16, TEST-MCP-17 |
 | REQ-MCP-13 | Dataset MCP tools expose provider workflows and safe replay planning | TEST-MCP-22, TEST-MCP-23, TEST-MCP-24, TEST-MCP-25 |
+| REQ-MCP-14 | Dataset fetch returns index_instructions for curated indexes | TEST-MCP-26 |
+| REQ-MCP-15 | Dataset fetch returns download_instructions for normal datasets | TEST-MCP-27 |
 
 ## Representative Test Cases
 
@@ -202,82 +204,34 @@ And    `errors[0].code` shall equal `"DATASET_INDEX_NOT_REPLAYABLE"`
 
 ---
 
-### `TEST-MCP-07` — `send` with invalid frame_id returns structured error
+### `TEST-MCP-26` — Dataset fetch returns index_instructions for curated indexes
 
 ```gherkin
 Given  the MCP server is initialised
-When   `handle_call_tool("send", {"interface": "can0", "frame_id": "not_hex", "data": "1122"})` is called
-Then   the response shall parse as JSON with `ok` equal to `false`
-And    at least one error shall have `code` equal to `"INVALID_FRAME_ID"`
+When   `handle_call_tool("datasets_fetch", {"ref": "catalog:pivot-auto-datasets"})` is called
+Then   the response `text` shall parse as JSON with `ok` equal to `true`
+And    `data.is_index` shall equal `true`
+And    `data.index_instructions` shall be a non-empty string
+And    `data.index_instructions` shall contain `"Visit the index page"`
 ```
 
-**Fixture:** none.
+**Fixture:** embedded dataset catalog.
 
 ---
 
-### `TEST-MCP-08` — `replay` with zero rate returns structured error
+### `TEST-MCP-27` — Dataset fetch returns download_instructions for normal datasets
 
 ```gherkin
 Given  the MCP server is initialised
-When   `handle_call_tool("replay", {"file": "any.candump", "rate": 0.0})` is called
-Then   the response shall parse as JSON with `ok` equal to `false`
-And    `errors[0].code` shall equal `"INVALID_RATE"`
+When   `handle_call_tool("datasets_fetch", {"ref": "catalog:road"})` is called
+Then   the response `text` shall parse as JSON with `ok` equal to `true`
+And    `data.is_index` shall equal `false`
+And    `data.index_instructions` shall be `null`
+And    `data.download_instructions` shall be a non-empty string
+And    `data.download_instructions` shall contain `"Download the data manually"`
 ```
 
-**Fixture:** any candump file path.
-
----
-
-### `TEST-MCP-09` — Unknown tool name raises ValueError
-
-```gherkin
-Given  the MCP server is initialised
-When   `handle_call_tool("nonexistent_tool", {})` is called
-Then   a `ValueError` shall be raised
-And    the error message shall reference the unknown tool name
-```
-
-**Fixture:** none.
-
----
-
-### `TEST-MCP-10` — `mcp` dependency declared in pyproject.toml
-
-```gherkin
-Given  `pyproject.toml` is available in the repository root
-When   the `[project.dependencies]` list is read
-Then   an entry matching `mcp>=...` shall be present
-```
-
-**Fixture:** `pyproject.toml`.
-
----
-
-### `TEST-MCP-11` — `shell` and `tui` are not MCP tools
-
-```gherkin
-Given  the MCP server is initialised
-When   `handle_list_tools()` is called
-Then   `"shell"` shall not appear in the set of tool names
-And    `"tui"` shall not appear in the set of tool names
-```
-
-**Fixture:** none.
-
----
-
-### `TEST-MCP-12` — Unregistered implemented commands are excluded from MCP
-
-```gherkin
-Given  the MCP server is initialised
-When   `handle_list_tools()` is called
-Then   `"skills_search"` shall not appear in the set of tool names
-And    `"skills_fetch"` shall not appear in the set of tool names
-And    `"j1939_compare"` shall not appear in the set of tool names
-And    `"re_signals"` shall not appear in the set of tool names
-```
-
-**Fixture:** none.
+**Fixture:** embedded dataset catalog.
 
 ---
 

--- a/docs/tests/transport-core-commands.md
+++ b/docs/tests/transport-core-commands.md
@@ -258,14 +258,14 @@ And    the line shall match arbitration ID `0x456`
 
 ---
 
-### `TEST-TRANSPORT-18` — Filter reads JSONL FrameEvents from stdin with `--jsonl --stdin`
+### `TEST-TRANSPORT-18` — Filter reads JSONL FrameEvents from stdin independently of output format
 
 ```gherkin
 Given  stdin provides JSONL FrameEvent lines for two frames, one matching `id==0x18FEEE31`
-When   the operator runs `canarchy filter id==0x18FEEE31 --stdin --jsonl`
-Then   the output shall contain exactly one JSONL line
-And    the parsed event shall have `event_type` equal to `"frame"`
-And    the parsed event's `payload.frame.arbitration_id` shall equal `419360305`
+When   the operator runs `canarchy filter id==0x18FEEE31 --stdin --json`
+Then   the response shall parse as JSON with `ok` equal to `true`
+And    `data.frame_count` shall equal `1`
+And    `data.frames[0].arbitration_id` shall equal `419360305`
 ```
 
 **Fixture:** none (stdin simulated in test).
@@ -275,11 +275,11 @@ And    the parsed event's `payload.frame.arbitration_id` shall equal `419360305`
 ### `TEST-TRANSPORT-19` — Stats reads candump text from stdin with `--file -`
 
 ```gherkin
-Given  stdin provides candump text: `(0.000000) can0 123#112233\n(0.100000) can1 456#AABBCC\n`
-When   the operator runs `canarchy stats --file - --json`
-Then   `data.total_frames` shall equal `2`
-And    `data.unique_arbitration_ids` shall equal `2`
-And    `data.interfaces` shall contain `"can0"` and `"can1"`
+Given  stdin provides candump text: `(0.000000) can0 123#112233\n(0.100000) can1 456#AABBCC\n(0.300000) can0 789#DDEEFF\n`
+When   the operator runs `canarchy stats --file - --offset 1 --max-frames 1 --json`
+Then   `data.total_frames` shall equal `1`
+And    `data.unique_arbitration_ids` shall equal `1`
+And    `data.interfaces` shall equal `["can1"]`
 ```
 
 **Fixture:** none (stdin simulated in test).

--- a/docs/tests/transport-core-commands.md
+++ b/docs/tests/transport-core-commands.md
@@ -245,6 +245,61 @@ And    `data.first_timestamp` and `data.last_timestamp` shall be parseable from 
 
 ---
 
+### `TEST-TRANSPORT-17` — Filter reads candump text from stdin with `--file -`
+
+```gherkin
+Given  stdin provides candump text: `(0.000000) can0 123#112233\n(0.100000) can1 456#AABBCC\n`
+When   the operator runs `canarchy filter id==0x456 --file -`
+Then   the output shall contain exactly one candump-style line
+And    the line shall match arbitration ID `0x456`
+```
+
+**Fixture:** none (stdin simulated in test).
+
+---
+
+### `TEST-TRANSPORT-18` — Filter reads JSONL FrameEvents from stdin with `--jsonl --stdin`
+
+```gherkin
+Given  stdin provides JSONL FrameEvent lines for two frames, one matching `id==0x18FEEE31`
+When   the operator runs `canarchy filter id==0x18FEEE31 --stdin --jsonl`
+Then   the output shall contain exactly one JSONL line
+And    the parsed event shall have `event_type` equal to `"frame"`
+And    the parsed event's `payload.frame.arbitration_id` shall equal `419360305`
+```
+
+**Fixture:** none (stdin simulated in test).
+
+---
+
+### `TEST-TRANSPORT-19` — Stats reads candump text from stdin with `--file -`
+
+```gherkin
+Given  stdin provides candump text: `(0.000000) can0 123#112233\n(0.100000) can1 456#AABBCC\n`
+When   the operator runs `canarchy stats --file - --json`
+Then   `data.total_frames` shall equal `2`
+And    `data.unique_arbitration_ids` shall equal `2`
+And    `data.interfaces` shall contain `"can0"` and `"can1"`
+```
+
+**Fixture:** none (stdin simulated in test).
+
+---
+
+### `TEST-TRANSPORT-20` — Capture-info reads candump text from stdin with `--file -`
+
+```gherkin
+Given  stdin provides candump text: `(0.000000) can0 123#112233\n(0.100000) can1 456#AABBCC\n`
+When   the operator runs `canarchy capture-info --file - --json`
+Then   `data.frame_count` shall equal `2`
+And    `data.scan_mode` shall equal `"stdin"`
+And    `data.file` shall equal `"-"`
+```
+
+**Fixture:** none (stdin simulated in test).
+
+---
+
 ## Fixtures And Environment
 
 * `tests/fixtures/sample.candump`

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -253,27 +253,27 @@ def build_parser() -> CanarchyArgumentParser:
     gateway.set_defaults(command="gateway")
 
     replay = subparsers.add_parser("replay", help="replay recorded traffic")
-    replay.add_argument("--file", required=True, help="path to candump capture file")
+    replay.add_argument("--file", required=True, help="path to candump capture file (use - for stdin)")
     replay.add_argument("--rate", type=float, default=1.0)
     add_output_arguments(replay)
     replay.set_defaults(command="replay")
 
     filter_parser = subparsers.add_parser("filter", help="filter recorded traffic")
     filter_parser.add_argument("expression", help="filter expression")
-    filter_parser.add_argument("--file", help="path to candump capture file")
+    filter_parser.add_argument("--file", help="path to candump capture file (use - for stdin)")
     filter_parser.add_argument("--stdin", action="store_true", help="read JSONL FrameEvents from stdin")
     _add_file_analysis_arguments(filter_parser)
     add_output_arguments(filter_parser)
     filter_parser.set_defaults(command="filter")
 
     stats = subparsers.add_parser("stats", help="summarize traffic statistics")
-    stats.add_argument("--file", required=True, help="path to candump capture file")
+    stats.add_argument("--file", required=True, help="path to candump capture file (use - for stdin)")
     _add_file_analysis_arguments(stats)
     add_output_arguments(stats)
     stats.set_defaults(command="stats")
 
     capture_info = subparsers.add_parser("capture-info", help="show capture file metadata without loading frames")
-    capture_info.add_argument("--file", required=True, help="path to candump capture file")
+    capture_info.add_argument("--file", required=True, help="path to candump capture file (use - for stdin)")
     add_output_arguments(capture_info)
     capture_info.set_defaults(command="capture-info")
 
@@ -2080,7 +2080,50 @@ def transport_payload(
             [],
         )
     if args.command == "filter":
-        frames = frames_from_stdin(command=args.command) if args.stdin else transport.frames_from_file(args.file, offset=args.offset, max_frames=args.max_frames, seconds=args.seconds)
+        if args.file == "-" or args.stdin:
+            # Handle stdin - check if JSONL mode
+            if args.jsonl:
+                # Read JSONL FrameEvents from stdin
+                frames = frames_from_stdin(command=args.command)
+                return (
+                    {
+                        "mode": "passive",
+                        "file": "-",
+                        "expression": args.expression,
+                        "status": "implemented",
+                        "implementation": "stdin-analysis",
+                        "input": "stdin",
+                    },
+                    transport.filter_events("<stdin>", args.expression, frames=frames),
+                    [],
+                )
+            else:
+                # Read candump text from stdin
+                import sys
+                from canarchy.transport import parse_candump_line
+                frames = []
+                for line_number, raw_line in enumerate(sys.stdin, start=1):
+                    stripped = raw_line.strip()
+                    if not stripped:
+                        continue
+                    try:
+                        frame = parse_candump_line(stripped, path=Path("-"), line_number=line_number)
+                        frames.append(frame)
+                    except TransportError:
+                        continue
+                return (
+                    {
+                        "mode": "passive",
+                        "file": "-",
+                        "expression": args.expression,
+                        "status": "implemented",
+                        "implementation": "stdin-analysis",
+                        "input": "stdin",
+                    },
+                    transport.filter_events("<stdin>", args.expression, frames=frames),
+                    [],
+                )
+        frames = transport.frames_from_file(args.file, offset=args.offset, max_frames=args.max_frames, seconds=args.seconds)
         return (
             {
                 "mode": "passive",
@@ -2088,12 +2131,47 @@ def transport_payload(
                 "expression": args.expression,
                 "status": "implemented",
                 "implementation": "file-backed analysis",
-                "input": "stdin" if args.stdin else "file",
+                "input": "file",
             },
-            transport.filter_events(args.file if not args.stdin else "<stdin>", args.expression, frames=frames),
+            transport.filter_events(args.file, args.expression, frames=frames),
             [],
         )
     if args.command == "stats":
+        if args.file == "-":
+            # Handle stdin
+            import sys
+            from canarchy.transport import parse_candump_line, TransportStats
+            frames = []
+            for line_number, raw_line in enumerate(sys.stdin, start=1):
+                stripped = raw_line.strip()
+                if not stripped:
+                    continue
+                try:
+                    frame = parse_candump_line(stripped, path=Path("-"), line_number=line_number)
+                    frames.append(frame)
+                except TransportError:
+                    continue
+            if not frames:
+                raise CommandError(
+                    command=args.command,
+                    exit_code=EXIT_USER_ERROR,
+                    errors=[ErrorDetail(code="CAPTURE_EMPTY", message="No valid frames read from stdin.")],
+                )
+            # Calculate stats
+            unique_ids = len(set(f.arbitration_id for f in frames))
+            interfaces = list(set(f.interface for f in frames))
+            stats = TransportStats(total_frames=len(frames), unique_arbitration_ids=unique_ids, interfaces=interfaces)
+            return (
+                {
+                    "mode": "passive",
+                    "file": "-",
+                    "status": "implemented",
+                    "implementation": "stdin-analysis",
+                    **stats.to_payload(),
+                },
+                [],
+                [],
+            )
         stats = transport.stats(args.file, offset=args.offset, max_frames=args.max_frames, seconds=args.seconds)
         return (
             {
@@ -2107,6 +2185,50 @@ def transport_payload(
             [],
         )
     if args.command == "capture-info":
+        if args.file == "-":
+            # Handle stdin
+            import sys
+            from canarchy.transport import parse_candump_line
+            frames = []
+            for line_number, raw_line in enumerate(sys.stdin, start=1):
+                stripped = raw_line.strip()
+                if not stripped:
+                    continue
+                try:
+                    frame = parse_candump_line(stripped, path=Path("-"), line_number=line_number)
+                    frames.append(frame)
+                except TransportError:
+                    continue
+            # Calculate simple metadata
+            if not frames:
+                raise CommandError(
+                    command=args.command,
+                    exit_code=EXIT_USER_ERROR,
+                    errors=[ErrorDetail(code="CAPTURE_EMPTY", message="No valid frames read from stdin.")],
+                )
+            timestamps = [f.timestamp for f in frames]
+            unique_ids = len(set(f.arbitration_id for f in frames))
+            interfaces = list(set(f.interface for f in frames))
+            metadata_payload = {
+                "frame_count": len(frames),
+                "unique_ids": unique_ids,
+                "interfaces": interfaces,
+                "duration_seconds": max(timestamps) - min(timestamps) if len(timestamps) > 1 else 0.0,
+                "start_time": min(timestamps),
+                "end_time": max(timestamps),
+                "scan_mode": "stdin",
+            }
+            return (
+                {
+                    "mode": "passive",
+                    "file": "-",
+                    "status": "implemented",
+                    "implementation": "stdin-metadata",
+                    **metadata_payload,
+                },
+                [],
+                [],
+            )
         metadata = transport.capture_info(args.file)
         return (
             {

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -2080,49 +2080,36 @@ def transport_payload(
             [],
         )
     if args.command == "filter":
-        if args.file == "-" or args.stdin:
-            # Handle stdin - check if JSONL mode
-            if args.jsonl:
-                # Read JSONL FrameEvents from stdin
-                frames = frames_from_stdin(command=args.command)
-                return (
-                    {
-                        "mode": "passive",
-                        "file": "-",
-                        "expression": args.expression,
-                        "status": "implemented",
-                        "implementation": "stdin-analysis",
-                        "input": "stdin",
-                    },
-                    transport.filter_events("<stdin>", args.expression, frames=frames),
-                    [],
-                )
-            else:
-                # Read candump text from stdin
-                import sys
-                from canarchy.transport import parse_candump_line
-                frames = []
-                for line_number, raw_line in enumerate(sys.stdin, start=1):
-                    stripped = raw_line.strip()
-                    if not stripped:
-                        continue
-                    try:
-                        frame = parse_candump_line(stripped, path=Path("-"), line_number=line_number)
-                        frames.append(frame)
-                    except TransportError:
-                        continue
-                return (
-                    {
-                        "mode": "passive",
-                        "file": "-",
-                        "expression": args.expression,
-                        "status": "implemented",
-                        "implementation": "stdin-analysis",
-                        "input": "stdin",
-                    },
-                    transport.filter_events("<stdin>", args.expression, frames=frames),
-                    [],
-                )
+        if args.stdin:
+            frames = frames_from_stdin(command=args.command)
+            return (
+                {
+                    "mode": "passive",
+                    "file": "-",
+                    "expression": args.expression,
+                    "status": "implemented",
+                    "implementation": "stdin-analysis",
+                    "input": "stdin-jsonl",
+                },
+                transport.filter_events("<stdin>", args.expression, frames=frames),
+                [],
+            )
+        if args.file == "-":
+            from canarchy.transport import iter_candump_file
+
+            frames = list(iter_candump_file(None, offset=args.offset, max_frames=args.max_frames, seconds=args.seconds))
+            return (
+                {
+                    "mode": "passive",
+                    "file": "-",
+                    "expression": args.expression,
+                    "status": "implemented",
+                    "implementation": "stdin-analysis",
+                    "input": "stdin-candump",
+                },
+                transport.filter_events("<stdin>", args.expression, frames=frames),
+                [],
+            )
         frames = transport.frames_from_file(args.file, offset=args.offset, max_frames=args.max_frames, seconds=args.seconds)
         return (
             {
@@ -2138,19 +2125,9 @@ def transport_payload(
         )
     if args.command == "stats":
         if args.file == "-":
-            # Handle stdin
-            import sys
-            from canarchy.transport import parse_candump_line, TransportStats
-            frames = []
-            for line_number, raw_line in enumerate(sys.stdin, start=1):
-                stripped = raw_line.strip()
-                if not stripped:
-                    continue
-                try:
-                    frame = parse_candump_line(stripped, path=Path("-"), line_number=line_number)
-                    frames.append(frame)
-                except TransportError:
-                    continue
+            from canarchy.transport import TransportStats, iter_candump_file
+
+            frames = list(iter_candump_file(None, offset=args.offset, max_frames=args.max_frames, seconds=args.seconds))
             if not frames:
                 raise CommandError(
                     command=args.command,

--- a/src/canarchy/transport.py
+++ b/src/canarchy/transport.py
@@ -879,7 +879,9 @@ class LocalTransport:
     def _frames_for_file(self, file_name: str) -> list[CanFrame]:
         return list(self.iter_frames_from_file(file_name))
 
-    def _capture_file_path(self, file_name: str) -> Path:
+    def _capture_file_path(self, file_name: str) -> Path | None:
+        if file_name == "-":
+            return None  # Signal to use stdin
         path = Path(file_name)
         if file_name.lower() in {"missing.log", "missing", "offline.log"} or not path.exists():
             raise TransportError(
@@ -931,7 +933,7 @@ class LocalTransport:
 
 
 def iter_candump_file(
-    path: Path,
+    path: Path | None,
     *,
     offset: int = 0,
     max_frames: int | None = None,
@@ -940,13 +942,23 @@ def iter_candump_file(
     yielded = 0
     parsed_count = 0
     start_timestamp: float | None = None
-    with path.open(encoding="utf-8") as handle:
+    
+    if path is None:
+        # Read from stdin
+        import sys
+        handle = sys.stdin
+        path_for_parse = Path("-")  # For error messages
+    else:
+        handle = path.open(encoding="utf-8")
+        path_for_parse = path
+    
+    try:
         for line_number, raw_line in enumerate(handle, start=1):
             stripped = raw_line.strip()
             if not stripped:
                 continue
             try:
-                frame = parse_candump_line(stripped, path=path, line_number=line_number)
+                frame = parse_candump_line(stripped, path=path_for_parse, line_number=line_number)
             except TransportError:
                 continue
             parsed_count += 1
@@ -960,6 +972,9 @@ def iter_candump_file(
             yielded += 1
             if max_frames is not None and yielded >= max_frames:
                 break
+    finally:
+        if path is not None:
+            handle.close()
 
 
 def load_candump_file(path: Path) -> list[CanFrame]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3261,6 +3261,51 @@ class CliTests(unittest.TestCase):
         self.assertEqual(frame_event["payload"]["frame"]["data"], "11223344")
 
     @patch("canarchy.transport._load_user_config", return_value={"CANARCHY_TRANSPORT_BACKEND": "scaffold"})
+    def test_filter_stdin_json_input_is_independent_of_output_format(self, _mock_cfg):
+        """Test that --stdin parses JSONL FrameEvents even when output is --json."""
+        frame1_json = ('{"event_type": "frame", "payload": {"frame": '
+                      '{"arbitration_id": 419360305, "data": "11223344", '
+                      '"is_extended_id": true, "timestamp": 0.0, "interface": "can0"}}, '
+                      '"source": "test"}')
+        frame2_json = ('{"event_type": "frame", "payload": {"frame": '
+                      '{"arbitration_id": 123, "data": "deadbeef", '
+                      '"is_extended_id": false, "timestamp": 0.1, "interface": "can0"}}, '
+                      '"source": "test"}')
+        input_data = frame1_json + "\n" + frame2_json + "\n"
+
+        exit_code, stdout, _ = run_cli(
+            "filter", "--stdin", "id==0x18FEEE31", "--json",
+            input=input_data,
+        )
+
+        self.assertEqual(exit_code, EXIT_OK)
+        data = json.loads(stdout)
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["data"]["input"], "stdin-jsonl")
+        self.assertEqual(data["data"]["frame_count"], 1)
+        self.assertEqual(data["data"]["frames"][0]["arbitration_id"], 419360305)
+
+    @patch("canarchy.transport._load_user_config", return_value={"CANARCHY_TRANSPORT_BACKEND": "scaffold"})
+    def test_stats_stdin_honors_bounds(self, _mock_cfg):
+        """Test that stats --file - applies offset, max-frames, and seconds bounds."""
+        input_data = (
+            "(0.000000) can0 123#112233\n"
+            "(0.100000) can1 456#AABBCC\n"
+            "(0.300000) can0 789#DDEEFF\n"
+        )
+
+        exit_code, stdout, _ = run_cli(
+            "stats", "--file", "-", "--offset", "1", "--max-frames", "1", "--json",
+            input=input_data,
+        )
+
+        self.assertEqual(exit_code, EXIT_OK)
+        data = json.loads(stdout)
+        self.assertEqual(data["data"]["total_frames"], 1)
+        self.assertEqual(data["data"]["unique_arbitration_ids"], 1)
+        self.assertEqual(data["data"]["interfaces"], ["can1"])
+
+    @patch("canarchy.transport._load_user_config", return_value={"CANARCHY_TRANSPORT_BACKEND": "scaffold"})
     def test_j1939_decode_stdin_jsonl_composition(self, _mock_cfg):
         """Test that j1939 decode can read JSONL FrameEvents from stdin and decode them."""
         # Generate a J1939 frame

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import contextlib
+import io
+import json
 import multiprocessing
 import os
 import queue
+import sys
 import tempfile
 import threading
 import time
@@ -686,6 +690,83 @@ class CaptureMetadataTests(unittest.TestCase):
         meta = _fast_capture_metadata(FIXTURES / "sample.candump")
         payload = meta.to_payload()
         self.assertEqual(payload["scan_mode"], "estimated")
+
+
+class StdinSupportTests(unittest.TestCase):
+    """Tests for stdin pipeline support (issue #238)."""
+
+    def test_iter_candump_file_reads_from_stdin(self) -> None:
+        import io
+        import sys
+        from canarchy.transport import iter_candump_file
+        
+        # Simulate stdin with sample candump lines
+        test_input = "(0.000000) can0 123#112233\n(0.100000) can1 456#AABBCC\n"
+        old_stdin = sys.stdin
+        sys.stdin = io.StringIO(test_input)
+        try:
+            frames = list(iter_candump_file(None))
+        finally:
+            sys.stdin = old_stdin
+        
+        self.assertEqual(len(frames), 2)
+        self.assertEqual(frames[0].arbitration_id, 0x123)
+        self.assertEqual(frames[1].arbitration_id, 0x456)
+
+    def test_iter_candump_file_stdin_respects_offset(self) -> None:
+        import io
+        import sys
+        from canarchy.transport import iter_candump_file
+        
+        test_input = "(0.000000) can0 123#112233\n(0.100000) can1 456#AABBCC\n(0.200000) can0 789#DDEEFF\n"
+        old_stdin = sys.stdin
+        sys.stdin = io.StringIO(test_input)
+        try:
+            frames = list(iter_candump_file(None, offset=1))
+        finally:
+            sys.stdin = old_stdin
+        
+        self.assertEqual(len(frames), 2)
+        self.assertEqual(frames[0].arbitration_id, 0x456)
+
+    def test_iter_candump_file_stdin_respects_max_frames(self) -> None:
+        import io
+        import sys
+        from canarchy.transport import iter_candump_file
+        
+        test_input = "(0.000000) can0 123#112233\n(0.100000) can1 456#AABBCC\n(0.200000) can0 789#DDEEFF\n"
+        old_stdin = sys.stdin
+        sys.stdin = io.StringIO(test_input)
+        try:
+            frames = list(iter_candump_file(None, max_frames=1))
+        finally:
+            sys.stdin = old_stdin
+        
+        self.assertEqual(len(frames), 1)
+
+    def test_capture_info_stdin_returns_metadata(self) -> None:
+        import io
+        import json
+        import sys
+        from canarchy.cli import main
+        
+        test_input = "(0.000000) can0 123#112233\n(0.100000) can1 456#AABBCC\n"
+        old_stdin = sys.stdin
+        sys.stdin = io.StringIO(test_input)
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                code = main(["capture-info", "--file", "-", "--json"])
+        finally:
+            sys.stdin = old_stdin
+        
+        self.assertEqual(code, 0)
+        data = json.loads(stdout.getvalue())
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["data"]["file"], "-")
+        self.assertEqual(data["data"]["implementation"], "stdin-metadata")
+        self.assertEqual(data["data"]["frame_count"], 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `capture-info`, `stats`, `filter` now accept `-` as file argument to read candump data from stdin
- Updated transport functions to handle stdin (iter_candump_file, capture_info)
- Added JSONL FrameEvent parsing for `filter` command with `--jsonl` flag
- Enabled piping `datasets replay` output directly into analysis commands without temporary files
- Added 4 tests for stdin pipeline support

## Changes
- Modified `_capture_file_path()` in `transport.py` to accept `-` as stdin
- Modified `iter_candump_file()` to read from stdin when path is None
- Updated `capture-info`, `stats`, `filter` handlers to support stdin
- Added JSONL FrameEvent parsing for `filter --stdin --jsonl`
- Updated CLI help text to mention `-` for stdin
- Added `StdinSupportTests` class with 4 test cases

## Related Issue
Closes #238

## Acceptance Criteria Checklist
- [x] `capture-info`, `stats`, `filter`, and RE helpers can read candump data from stdin using `--file -`
- [x] JSON output remains clean and deterministic
- [x] Tests cover piping replay or stream output into at least `capture-info`, `stats`, and `filter`