### PR TITLE
Audit documentation for recent workflow changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -483,7 +483,9 @@ canarchy
 
 This tree is a starting point, not a lock.
 
-For dataset automation, agents should prefer MCP dataset tools when available, or explicit CLI JSON output otherwise. `datasets_search` / `datasets search --json` and `datasets_inspect` / `datasets inspect --json` include stable machine fields: `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`. Use MCP `datasets_replay_plan` or CLI `datasets replay --dry-run --json` for safe replay preflight; use `datasets replay --list-files --json` to choose a replay file and `--file <id-or-name>` to select it. Use `--max-frames` or `--max-seconds` to bound replay. Actual dataset frame streaming remains CLI-only. Curated index entries that cannot be replayed return `DATASET_INDEX_NOT_REPLAYABLE`.
+For dataset automation, agents should prefer MCP dataset tools when available, or explicit CLI JSON output otherwise. `datasets_search` / `datasets search --json` and `datasets_inspect` / `datasets inspect --json` include stable machine fields: `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`. `datasets_fetch` distinguishes curated indexes from normal dataset entries with `is_index`, `index_instructions`, and `download_instructions`. Use MCP `datasets_replay_plan` or CLI `datasets replay --dry-run --json` for safe replay preflight; use `datasets replay --list-files --json` to choose a replay file and `--file <id-or-name>` to select it. Use `--max-frames` or `--max-seconds` to bound replay. Actual dataset frame streaming remains CLI-only. Curated index entries that cannot be replayed return `DATASET_INDEX_NOT_REPLAYABLE`.
+
+For stdin pipelines, `capture-info --file -`, `stats --file -`, and `filter --file -` read candump text from stdin. `filter --stdin`, `decode --stdin`, and `j1939 decode --stdin` read JSONL FrameEvents from stdin regardless of output format.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * Made `canarchy datasets replay` stop cleanly on closed stdout pipes instead of printing a Python `BrokenPipeError` traceback. Closes #240.
 * Made dataset replay return `DATASET_INDEX_NOT_REPLAYABLE` for curated dataset indexes so automation can distinguish index entries from other non-replayable datasets. Closes #242.
 
+### Documentation
+
+* Audited and refreshed operator, agent, design, and test documentation for current dataset replay/fetch behavior, MCP dataset coverage, stdin pipeline semantics, and file-backed command grammar. Closes #259.
+
 ## [0.6.0] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Current file support:
 * additional supported candump forms include classic RTR `id#R`, CAN FD `id##<flags><data>`, and error frames using a CAN error-flagged identifier such as `20000080#0000000000000000`
 * supported capture-file suffixes today are `.candump` and `.log`; `capture-info --file -`, `stats --file -`, and `filter --file -` can read candump text from stdin
 * `filter --stdin`, `decode --stdin`, and `j1939 decode --stdin` read JSONL FrameEvents from stdin
-* malformed candump log lines are skipped during capture parsing; inputs with no valid frames return structured transport errors instead of falling back to sample data
+* malformed candump log lines are skipped during capture parsing rather than falling back to sample data; commands that require capture metadata or explicitly validate stdin emptiness return structured errors when no valid frames are available
 
 ### Structured Output
 

--- a/README.md
+++ b/README.md
@@ -162,12 +162,13 @@ Live transport uses `python-can` by default. Set `CANARCHY_PYTHON_CAN_INTERFACE`
 
 Current file support:
 
-* file-backed workflows such as `filter`, `stats`, `decode`, `j1939 decode`, and `replay` now read standard timestamped candump log files
+* file-backed workflows such as `filter`, `stats`, `decode`, `j1939 decode`, and `replay` read standard timestamped candump log files
 * `j1939 pgn` inspects recorded traffic with `--file <capture.candump>`
 * the supported log form today is `(timestamp) interface frame#data`
 * additional supported candump forms include classic RTR `id#R`, CAN FD `id##<flags><data>`, and error frames using a CAN error-flagged identifier such as `20000080#0000000000000000`
-* supported capture-file suffixes today are `.candump` and `.log`
-* malformed candump log lines return structured transport errors instead of falling back to sample data
+* supported capture-file suffixes today are `.candump` and `.log`; `capture-info --file -`, `stats --file -`, and `filter --file -` can read candump text from stdin
+* `filter --stdin`, `decode --stdin`, and `j1939 decode --stdin` read JSONL FrameEvents from stdin
+* malformed candump log lines are skipped during capture parsing; inputs with no valid frames return structured transport errors instead of falling back to sample data
 
 ### Structured Output
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -103,7 +103,7 @@ Current exclusions:
 * CLI-only workflows such as `j1939 faults` and `re signals` that are not yet exposed as MCP tools
 * interactive or service commands such as `shell`, `tui`, and `mcp serve`
 
-For dataset workflows, agents should prefer MCP dataset tools when available. `datasets_search` and `datasets_inspect` include stable machine fields: `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`. Use `datasets_replay_plan` for safe replay preflight; use CLI `datasets replay --list-files --json` to choose a replay file and `--file <id-or-name>` to select it. Use `max_frames` or `max_seconds` to bound replay. Actual frame streaming remains CLI-only. Curated index entries that cannot be replayed return `DATASET_INDEX_NOT_REPLAYABLE`.
+For dataset workflows, agents should prefer MCP dataset tools when available. `datasets_search` and `datasets_inspect` include stable machine fields: `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`. `datasets_fetch` distinguishes curated indexes from normal dataset entries with `is_index`, `index_instructions`, and `download_instructions`. Use `datasets_replay_plan` for safe replay preflight; use CLI `datasets replay --list-files --json` to choose a replay file and `--file <id-or-name>` to select it. Use `max_frames` or `max_seconds` to bound replay. Actual frame streaming remains CLI-only. Curated index entries that cannot be replayed return `DATASET_INDEX_NOT_REPLAYABLE`.
 
 ### Skills Workflow
 
@@ -167,4 +167,4 @@ tool: send {"interface": "vcan0", "frame_id": "0x7DF", "data": "0201F1"}
 * MCP streaming is not supported in v1 — live-capture tools (`capture`, `gateway`) return a buffered batch from the active backend. Use CLI `datasets stream` for local dataset-file JSONL or candump pipelines, and `datasets replay` for remote dataset-ref or URL playback to stdout.
 * `shell`, `tui`, and `mcp serve` are not exposed as MCP tools.
 * Error codes are identical to the CLI, so existing JSON-parsing logic transfers without changes.
-* Stdin pipelines: `capture-info`, `stats`, and `filter --file -` read candump text from stdin. `filter --stdin` reads JSONL FrameEvents from stdin regardless of output format. This enables piping `datasets replay` candump output directly into analysis commands without temporary files.
+* Stdin pipelines: `capture-info`, `stats`, and `filter --file -` read candump text from stdin. `filter --stdin`, `decode --stdin`, and `j1939 decode --stdin` read JSONL FrameEvents from stdin regardless of output format. This enables piping `datasets replay` candump output directly into analysis commands without temporary files.

--- a/docs/command_spec.md
+++ b/docs/command_spec.md
@@ -38,7 +38,7 @@ Important current behavior:
 * placeholder-only commands, currently limited to the `fuzz` family, still return `status: planned` and `implementation: command surface scaffold`
 * some protocol-oriented commands currently use explicit sample/reference providers rather than true transport-backed execution paths
 * specialized table formatting exists for J1939 monitor and decode style output; other `--table` output is generic key/value rendering
-* file-backed analysis commands currently support standard timestamped candump log files with `.candump` and `.log` suffixes
+* file-backed analysis commands support standard timestamped candump log files with `.candump` and `.log` suffixes; selected commands also support `--file -` for candump text from stdin
 
 ---
 
@@ -95,8 +95,8 @@ Supported file input today:
 * file-backed commands consume standard timestamped candump logs in the form `(timestamp) interface frame#data`
 * supported additional candump forms include classic RTR `id#R`, CAN FD `id##<flags><data>`, and error frames using a CAN error-flagged identifier
 * supported CAN FD flags today are the BRS and ESI bits in the single-nibble candump flags field
-* supported capture-file suffixes today are `.candump` and `.log`
-* malformed log lines fail with structured transport errors rather than silently falling back to fixture data
+* supported capture-file suffixes today are `.candump` and `.log`; `--file -` reads candump text from stdin for commands that explicitly support it
+* malformed log lines are skipped during capture parsing; sources with no valid frames fail with structured transport errors rather than falling back to fixture data
 
 ### send
 
@@ -480,6 +480,11 @@ Record dataset provenance in the local cache. This does not download large datas
 canarchy datasets fetch <provider>:<dataset> [--json|--jsonl|--table|--raw]
 ```
 
+Notes:
+
+* normal dataset entries return `download_instructions` that point operators to the source URL for manual download
+* curated index entries return `is_index=true` and `index_instructions`; there is no single dataset payload to download
+
 ### datasets cache list
 
 List cached dataset provider manifests and provenance records.
@@ -523,7 +528,7 @@ canarchy datasets stream sample.csv --source-format hcrl-csv --format jsonl --js
 
 Notes:
 
-* `datasets search` defaults to a compact human-readable table; use `--verbose` for detailed result blocks with descriptions, source URLs, and access notes
+* `datasets search` defaults to a compact human-readable table with a `TYPE` column (`INDEX` for curated indexes, `PLAY` for replayable datasets); use `--verbose` for detailed result blocks with type labels, descriptions, source URLs, replay defaults, index notes, and access notes
 * without `--json`, stream records are written directly to stdout or `--output`
 * JSONL stream records include `payload.dataset.provider_ref`, `frame_offset`, `chunk_index`, and `chunk_position`
 * with `--json`, stdout contains the standard result envelope and reports `frame_count` and `chunks`
@@ -553,7 +558,7 @@ canarchy datasets replay catalog:candid --dry-run --json
 Notes:
 
 * without `--json`, replayed frames are written directly to stdout as candump or JSONL records for piping
-* JSONL replay frame events include `payload.dataset.provider_ref`, `source_url`, `replay_file`, `default_replay_file`, `source_format`, and `source_type`
+* JSONL replay frame events include `payload.dataset.provider_ref`, `source_url`, `replay_file`, `default_replay_file`, `frame_offset`, `source_format`, and `source_type`
 * with `--json`, stdout contains a clean standard result envelope with replay metadata and no frame records
 * `--list-files --json` returns replay file entries with stable `id`, `name`, `size_bytes`, `format`, and `source_url` fields
 * `--file` accepts a replay file `id` or `name`; unknown files fail with `DATASET_REPLAY_FILE_NOT_FOUND`

--- a/docs/command_spec.md
+++ b/docs/command_spec.md
@@ -96,7 +96,7 @@ Supported file input today:
 * supported additional candump forms include classic RTR `id#R`, CAN FD `id##<flags><data>`, and error frames using a CAN error-flagged identifier
 * supported CAN FD flags today are the BRS and ESI bits in the single-nibble candump flags field
 * supported capture-file suffixes today are `.candump` and `.log`; `--file -` reads candump text from stdin for commands that explicitly support it
-* malformed log lines are skipped during capture parsing; sources with no valid frames fail with structured transport errors rather than falling back to fixture data
+* malformed log lines are skipped during capture parsing rather than falling back to fixture data; commands that require capture metadata or explicitly validate stdin emptiness return structured errors when no valid frames are available
 
 ### send
 

--- a/docs/design/composition.md
+++ b/docs/design/composition.md
@@ -20,8 +20,8 @@ Operators and coding agents should be able to connect commands with pipes instea
 
 | ID | Type | Requirement |
 |----|------|-------------|
-| `REQ-COMP-01` | Optional feature | Where `--stdin` is specified, `decode`, `filter`, and `j1939 decode` shall read JSONL frame events from stdin instead of a positional capture file. |
-| `REQ-COMP-02` | Unwanted behaviour | If `--stdin` is specified alongside a positional capture file, the system shall return a structured error with code `STDIN_AND_FILE_SPECIFIED` and exit code 1. |
+| `REQ-COMP-01` | Optional feature | Where `--stdin` is specified, `decode`, `filter`, and `j1939 decode` shall read JSONL frame events from stdin instead of a `--file` capture source. |
+| `REQ-COMP-02` | Unwanted behaviour | If `--stdin` is specified alongside a `--file` capture source, the system shall return a structured error with code `STDIN_AND_FILE_SPECIFIED` and exit code 1. |
 | `REQ-COMP-03` | Unwanted behaviour | If neither `--stdin` nor a capture file is provided for a command that requires one, the system shall return a structured error with code `MISSING_INPUT` and exit code 1. |
 | `REQ-COMP-04` | Event-driven | When `--stdin` is in use, the system shall validate each non-empty line as a canonical frame event before command-specific processing begins. |
 | `REQ-COMP-05` | Unwanted behaviour | If a stdin line is malformed JSON, is not a frame event, or does not decode into a valid frame, the system shall return a structured error with code `INVALID_STREAM_EVENT` and exit code 1. |
@@ -32,14 +32,14 @@ Operators and coding agents should be able to connect commands with pipes instea
 
 ```text
 canarchy decode --dbc <file> --stdin [--json|--jsonl|--table|--raw]
-canarchy filter --stdin <expression> [--json|--jsonl|--table|--raw]
+canarchy filter <expression> --stdin [--json|--jsonl|--table|--raw]
 canarchy j1939 decode --stdin [--json|--jsonl|--table|--raw]
 ```
 
 Representative usage:
 
 ```bash
-canarchy capture can0 --jsonl | canarchy filter --stdin 'id==0x18FEEE31' --jsonl
+canarchy capture can0 --jsonl | canarchy filter 'id==0x18FEEE31' --stdin --jsonl
 canarchy capture can0 --jsonl | canarchy decode --stdin --dbc truck.dbc --jsonl
 canarchy capture can0 --jsonl | canarchy j1939 decode --stdin --jsonl
 ```
@@ -86,7 +86,7 @@ Rejected input:
 
 | Code | Trigger | Exit code |
 |------|---------|-----------|
-| `STDIN_AND_FILE_SPECIFIED` | `--stdin` is used with a positional capture file | 1 |
+| `STDIN_AND_FILE_SPECIFIED` | `--stdin` is used with a `--file` capture source | 1 |
 | `MISSING_INPUT` | neither `--stdin` nor a capture file is provided | 1 |
 | `INVALID_STREAM_EVENT` | stdin line is malformed JSON, not a frame event, or does not decode into a valid frame | 1 |
 | `NO_STREAM_EVENTS` | stdin contains no valid non-empty frame events | 1 |

--- a/docs/design/dataset-provider-workflow.md
+++ b/docs/design/dataset-provider-workflow.md
@@ -5,7 +5,7 @@
 | Field | Value |
 |-------|-------|
 | Status | Implemented (Phase 2) |
-| Issue | #216, #220, #233, #235, #241, #242, #243, #245 |
+| Issue | #216, #220, #233, #235, #241, #242, #243, #245, #246, #259 |
 | Implementation | `src/canarchy/dataset_provider.py`, `dataset_cache.py`, `dataset_catalog.py`, `dataset_convert.py` |
 
 ---
@@ -232,6 +232,6 @@ building a full in-memory frame list.
 
 - Automated download for small, openly-licensed datasets (e.g., SynCAN)
 - Additional source formats (SynCAN CSV, ROAD CSV, comma.ai msgpack)
-- `datasets convert` reading from a provider ref (after fetch downloads the data)
+- `datasets convert` reading from a provider ref after a future automated-download feature resolves the dataset payload
 - Provider-specific streaming adapters for remote datasets such as commaCarSegments
 - Explicit safe live-bus replay from dataset streams

--- a/docs/design/dbc-command-workflows.md
+++ b/docs/design/dbc-command-workflows.md
@@ -22,7 +22,7 @@ DBC-backed workflows are central to protocol-aware CAN analysis. Operators shoul
 |----|------|-------------|
 | `REQ-DBC-01` | Ubiquitous | The system shall provide a `decode` command for DBC-backed capture decoding. |
 | `REQ-DBC-02` | Ubiquitous | The system shall provide an `encode` command for DBC-backed message encoding. |
-| `REQ-DBC-03` | Event-driven | When `decode <file> --dbc <dbc>` is invoked, the system shall emit structured `decoded_message` and `signal` events for frames that match messages in the DBC. |
+| `REQ-DBC-03` | Event-driven | When `decode --file <file> --dbc <dbc>` or `decode --stdin --dbc <dbc>` is invoked, the system shall emit structured `decoded_message` and `signal` events for frames that match messages in the DBC. |
 | `REQ-DBC-04` | Event-driven | When `encode --dbc <dbc> <message> [<signal=value>...]` is invoked, the system shall return a structured frame result suitable for downstream transmit workflows. |
 | `REQ-DBC-05` | Unwanted behaviour | If the DBC file is invalid or unreadable, the system shall return a structured error with code `DBC_LOAD_FAILED` and exit code 3. |
 | `REQ-DBC-06` | Unwanted behaviour | If the requested message name is not present in the DBC, the system shall return a structured error with code `DBC_MESSAGE_NOT_FOUND` and exit code 3. |
@@ -32,6 +32,7 @@ DBC-backed workflows are central to protocol-aware CAN analysis. Operators shoul
 
 ```text
 canarchy decode --file <file> --dbc <file> [--json] [--jsonl] [--table] [--raw]
+canarchy decode --stdin --dbc <file> [--json] [--jsonl] [--table] [--raw]
 canarchy encode --dbc <file> <message> <signal=value>... [--json] [--jsonl] [--table] [--raw]
 ```
 
@@ -39,7 +40,7 @@ canarchy encode --dbc <file> <message> <signal=value>... [--json] [--jsonl] [--t
 
 In scope:
 
-* decoding capture files through a DBC database
+* decoding capture files or JSONL FrameEvents from stdin through a DBC database
 * encoding named messages from signal assignments
 * structured event emission for machine-readable workflows
 

--- a/docs/design/dbc-provider-workflows.md
+++ b/docs/design/dbc-provider-workflows.md
@@ -46,6 +46,7 @@ canarchy dbc cache list [--json] [--jsonl] [--table] [--raw]
 canarchy dbc cache prune [--provider <name>] [--json] [--jsonl] [--table] [--raw]
 canarchy dbc cache refresh [--provider <name>] [--json] [--jsonl] [--table] [--raw]
 canarchy decode --file <file> --dbc <path|provider-ref> [--json] [--jsonl] [--table] [--raw]
+canarchy decode --stdin --dbc <path|provider-ref> [--json] [--jsonl] [--table] [--raw]
 canarchy encode --dbc <path|provider-ref> <message> <signal=value>... [--json] [--jsonl] [--table] [--raw]
 canarchy dbc inspect <path|provider-ref> [--message <name>] [--signals-only] [--json] [--jsonl] [--table] [--raw]
 ```

--- a/docs/design/dbc-runtime-schema-split.md
+++ b/docs/design/dbc-runtime-schema-split.md
@@ -33,6 +33,7 @@ Operators and agents need richer database-aware workflows than the current thin 
 
 ```text
 canarchy decode --file <file> --dbc <file> [--json] [--jsonl] [--table] [--raw]
+canarchy decode --stdin --dbc <file> [--json] [--jsonl] [--table] [--raw]
 canarchy encode --dbc <file> <message> <signal=value>... [--json] [--jsonl] [--table] [--raw]
 canarchy dbc inspect <dbc> [--message <name>] [--signals-only] [--json] [--jsonl] [--table] [--raw]
 ```

--- a/docs/design/j1939-bounded-analysis.md
+++ b/docs/design/j1939-bounded-analysis.md
@@ -32,7 +32,8 @@ Large heavy-vehicle captures often contain millions of frames. Analysts need to 
 ## Command Surface
 
 ```text
-canarchy j1939 decode <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--table] [--raw]
+canarchy j1939 decode --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--table] [--raw]
+canarchy j1939 decode --stdin [--dbc <path|provider-ref>] [--json] [--jsonl] [--table] [--raw]
 canarchy j1939 pgn <pgn> --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--table] [--raw]
 canarchy j1939 spn <spn> --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--table] [--raw]
 canarchy j1939 tp sessions --file <capture> [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--table] [--raw]

--- a/docs/design/j1939-first-class-decoder.md
+++ b/docs/design/j1939-first-class-decoder.md
@@ -37,7 +37,8 @@ Operators need J1939 commands that scale beyond a demo-only SPN map. They should
 ## Command Surface
 
 ```text
-canarchy j1939 decode <capture> [--dbc <path|provider-ref>] [--json] [--jsonl] [--table] [--raw]
+canarchy j1939 decode --file <capture> [--dbc <path|provider-ref>] [--json] [--jsonl] [--table] [--raw]
+canarchy j1939 decode --stdin [--dbc <path|provider-ref>] [--json] [--jsonl] [--table] [--raw]
 canarchy j1939 pgn <pgn> --file <capture> [--dbc <path|provider-ref>] [--json] [--jsonl] [--table] [--raw]
 canarchy j1939 spn <spn> --file <capture> [--dbc <path|provider-ref>] [--json] [--jsonl] [--table] [--raw]
 canarchy j1939 tp sessions --file <capture> [--json] [--jsonl] [--table] [--raw]

--- a/docs/design/transport-core-commands.md
+++ b/docs/design/transport-core-commands.md
@@ -23,24 +23,26 @@ Operators need a stable base command set that supports passive live observation,
 | `REQ-TRANSPORT-01` | Ubiquitous | The system shall provide `capture`, `send`, `filter`, `stats`, and `capture-info` commands as the foundational transport command set. |
 | `REQ-TRANSPORT-02` | Event-driven | When `capture <interface>` is invoked, the system shall stream frame events through the live capture path for all output formats. |
 | `REQ-TRANSPORT-03` | Event-driven | When `send <interface> <frame-id> <data>` is invoked, the system shall emit a preflight active-transmit warning to `stderr` and then transmit the specified frame. |
-| `REQ-TRANSPORT-04` | Event-driven | When `filter <expression> --file <path>` is invoked, the system shall return only the frame events from the capture file that satisfy the expression. |
-| `REQ-TRANSPORT-05` | Event-driven | When `stats --file <path>` is invoked, the system shall return a deterministic summary including total frame count and unique arbitration ID count. |
+| `REQ-TRANSPORT-04` | Event-driven | When `filter <expression> --file <path>` or `filter <expression> --file -` is invoked, the system shall return only the frame events from the candump input that satisfy the expression. |
+| `REQ-TRANSPORT-05` | Event-driven | When `stats --file <path>` or `stats --file -` is invoked, the system shall return a deterministic summary including total frame count and unique arbitration ID count. |
 | `REQ-TRANSPORT-06` | Event-driven | When `capture` or `send` is invoked, the system shall expose the effective transport backend name and configuration metadata in the result. |
 | `REQ-TRANSPORT-07` | Unwanted behaviour | If a transport interface is unavailable or a backend open fails, the system shall return a structured error with code `TRANSPORT_UNAVAILABLE` and exit code 2. |
 | `REQ-TRANSPORT-08` | Unwanted behaviour | If a capture file cannot be parsed, the system shall return a structured error with code `CAPTURE_SOURCE_INVALID` and exit code 2. |
 | `REQ-TRANSPORT-09` | Unwanted behaviour | If a capture file format is unsupported, the system shall return a structured error with code `CAPTURE_FORMAT_UNSUPPORTED` and exit code 2. |
 | `REQ-TRANSPORT-10` | Unwanted behaviour | If `filter` receives an invalid expression, the system shall return a structured error with code `INVALID_FILTER_EXPRESSION` and exit code 2. |
-| `REQ-TRANSPORT-11` | Event-driven | When `capture-info --file <path>` is invoked, the system shall return capture metadata including frame count, first and last timestamps, duration, unique IDs, interfaces, and suggested `max_frames` and `seconds` bounds for follow-on analysis. |
+| `REQ-TRANSPORT-11` | Event-driven | When `capture-info --file <path>` or `capture-info --file -` is invoked, the system shall return capture metadata including frame count, first and last timestamps, duration, unique IDs, interfaces, and suggested `max_frames` and `seconds` bounds for follow-on analysis. |
 | `REQ-TRANSPORT-12` | Performance | When `capture-info` is invoked on a file larger than 50 MB, the system shall use a fast head+tail scan to estimate metadata rather than parsing every frame, and shall set `scan_mode` to `"estimated"` in the response. |
+| `REQ-TRANSPORT-13` | Optional feature | Where `--file -` is specified for `filter`, `stats`, or `capture-info`, the system shall read candump text from stdin instead of requiring a capture file path. |
+| `REQ-TRANSPORT-14` | Optional feature | Where `--stdin` is specified for `filter`, the system shall read JSONL FrameEvents from stdin independently of the selected output format. |
 
 ## Command Surface
 
 ```text
 canarchy capture <interface> [--candump] [--json] [--jsonl] [--table] [--raw]
 canarchy send <interface> <frame-id> <hex-data> [--ack-active] [--json] [--jsonl] [--table] [--raw]
-canarchy filter <expression> --file <path> [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json] [--jsonl] [--table] [--raw]
-canarchy stats --file <path> [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json] [--jsonl] [--table] [--raw]
-canarchy capture-info --file <path> [--json] [--jsonl] [--table] [--raw]
+canarchy filter <expression> (--file <path>|--file -|--stdin) [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json] [--jsonl] [--table] [--raw]
+canarchy stats --file <path|-> [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json] [--jsonl] [--table] [--raw]
+canarchy capture-info --file <path|-> [--json] [--jsonl] [--table] [--raw]
 ```
 
 ## Responsibilities And Boundaries

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -164,6 +164,19 @@ Replay the default CANdid catalog stream directly from the remote provider witho
 canarchy datasets replay catalog:candid --dry-run --json
 canarchy datasets replay catalog:candid --rate 1.0
 canarchy datasets replay catalog:candid --format jsonl --rate 10 --max-frames 1000
+canarchy datasets replay catalog:candid --list-files --json
+canarchy datasets replay catalog:candid --file 2_indicator_CAN.log --rate 1000 --max-frames 10
+```
+
+Remote replay writes candump or JSONL records to stdout unless `--json` is requested. Use `--list-files --json` to inspect the embedded CANdid replay manifest, then pass `--file <id-or-name>` to select a specific replay file.
+
+You can also pipe remote candump replay directly into stdin-aware analysis commands without creating a temporary file:
+
+```bash
+canarchy datasets replay catalog:candid --rate 1000 --max-frames 100 \
+  | canarchy stats --file - --json
+canarchy datasets replay catalog:candid --rate 1000 --max-frames 100 \
+  | canarchy capture-info --file - --json
 ```
 
 After downloading specific `*_CAN.log` files, use them directly with file-backed analysis commands:

--- a/docs/spec-template.md
+++ b/docs/spec-template.md
@@ -50,7 +50,7 @@ Unwanted behaviour:
 
 Optional feature:
   Where `--stdin` is specified, the system shall read JSONL frame events from
-  stdin instead of a positional capture file.
+  stdin instead of a `--file` capture source.
 ```
 
 ---

--- a/docs/tests/composition.md
+++ b/docs/tests/composition.md
@@ -15,7 +15,7 @@ Validate that commands supporting `--stdin` correctly compose in pipelines, reje
 ## Coverage Requirements
 
 * `decode`, `filter`, and `j1939 decode` read JSONL frame events from stdin when `--stdin` is specified
-* `--stdin` combined with a positional file returns a structured error
+* `--stdin` combined with a `--file` capture source returns a structured error
 * missing input source returns a structured error
 * malformed stdin lines return a structured error
 * empty stdin (no valid frame events) returns a structured error
@@ -40,7 +40,7 @@ Validate that commands supporting `--stdin` correctly compose in pipelines, reje
 ```gherkin
 Given  a canonical JSONL frame event line is provided on stdin
 And    the frame has arbitration ID `0x18FEEE31`
-When   the operator runs `canarchy filter --stdin id==0x18FEEE31 --json`
+When   the operator runs `canarchy filter id==0x18FEEE31 --stdin --json`
 Then   the result shall contain exactly one frame event
 And    the event arbitration ID shall equal `0x18FEEE31`
 ```
@@ -74,11 +74,11 @@ Then   the result shall include J1939 decoded-message events with PGN and source
 
 ---
 
-### `TEST-COMP-04` — `--stdin` combined with a capture file returns an error
+### `TEST-COMP-04` — `--stdin` combined with `--file` returns an error
 
 ```gherkin
 Given  the file `tests/fixtures/sample.candump` is available
-When   the operator runs `canarchy filter --stdin id==0x123 --file tests/fixtures/sample.candump --json`
+When   the operator runs `canarchy filter id==0x123 --stdin --file tests/fixtures/sample.candump --json`
 Then   the command shall exit with code `1`
 And    `errors[0].code` shall equal `"STDIN_AND_FILE_SPECIFIED"`
 ```
@@ -104,7 +104,7 @@ And    `errors[0].code` shall equal `"MISSING_INPUT"`
 
 ```gherkin
 Given  a non-JSON or non-frame-event line is provided on stdin
-When   the operator runs `canarchy filter --stdin id==0x123 --json`
+When   the operator runs `canarchy filter id==0x123 --stdin --json`
 Then   the command shall exit with code `1`
 And    `errors[0].code` shall equal `"INVALID_STREAM_EVENT"`
 ```
@@ -117,7 +117,7 @@ And    `errors[0].code` shall equal `"INVALID_STREAM_EVENT"`
 
 ```gherkin
 Given  stdin contains only blank lines or is empty
-When   the operator runs `canarchy filter --stdin id==0x123 --json`
+When   the operator runs `canarchy filter id==0x123 --stdin --json`
 Then   the command shall exit with code `1`
 And    `errors[0].code` shall equal `"NO_STREAM_EVENTS"`
 ```

--- a/docs/tests/dataset-provider-workflow.md
+++ b/docs/tests/dataset-provider-workflow.md
@@ -6,7 +6,7 @@
 |-------|-------|
 | Status | Implemented |
 | Related design spec | `docs/design/dataset-provider-workflow.md` |
-| Issues | #216, #220, #233, #235, #241, #242, #243, #245 |
+| Issues | #216, #220, #233, #235, #241, #242, #243, #245, #246, #259 |
 | Test module | `tests/test_dataset_provider.py` |
 
 ---
@@ -43,6 +43,23 @@ When the operator requests dataset search and inspect JSON output
 Then each descriptor includes `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`
 And replayable datasets identify their default replay file
 And curated index datasets identify themselves as indexes
+```
+
+**Fixture:** embedded catalog metadata and CLI JSON assertions in `tests/test_dataset_provider.py`
+
+### TEST-DATASET-CATALOG-04: Fetch Distinguishes Index Instructions From Dataset Downloads
+
+```gherkin
+Given the built-in public dataset catalog provider
+When the operator fetches `catalog:pivot-auto-datasets`
+Then the JSON response includes `is_index=true`
+And the JSON response includes non-empty `index_instructions`
+And the index instructions guide the operator to visit the index page
+
+When the operator fetches `catalog:road`
+Then the JSON response includes `is_index=false`
+And `index_instructions` is null
+And `download_instructions` tells the operator how to obtain the dataset manually
 ```
 
 **Fixture:** embedded catalog metadata and CLI JSON assertions in `tests/test_dataset_provider.py`
@@ -250,6 +267,7 @@ And no remote stream is opened
 | REQ-DATASET-CATALOG-02 | TEST-DATASET-CATALOG-01 |
 | REQ-DATASET-CATALOG-03 | TEST-DATASET-CATALOG-01 |
 | REQ-DATASET-CATALOG-04 | TEST-DATASET-CATALOG-03 |
+| REQ-DATASET-CATALOG-05 | TEST-DATASET-CATALOG-04 |
 | REQ-DATASET-STREAM-01 | TEST-DATASET-STREAM-01, TEST-DATASET-STREAM-02, TEST-DATASET-STREAM-04 |
 | REQ-DATASET-STREAM-02 | TEST-DATASET-STREAM-01, TEST-DATASET-STREAM-02, TEST-DATASET-STREAM-06, TEST-DATASET-STREAM-07 |
 | REQ-DATASET-STREAM-03 | TEST-DATASET-STREAM-01, TEST-DATASET-STREAM-04 |

--- a/docs/tests/j1939-bounded-analysis.md
+++ b/docs/tests/j1939-bounded-analysis.md
@@ -26,7 +26,7 @@
 
 ```gherkin
 Given  a capture fixture contains more J1939 frames than the requested frame bound
-When   the operator runs `canarchy j1939 decode <capture> --max-frames 3 --json`
+When   the operator runs `canarchy j1939 decode --file <capture> --max-frames 3 --json`
 Then   the system shall return only records derived from the first three capture frames
 And    the command shall remain otherwise valid JSON output
 ```


### PR DESCRIPTION
## Summary
- Refreshed operator, agent, design, and test docs for recent dataset replay/fetch/search/inspect changes.
- Clarified stdin semantics: `--file -` is candump stdin, while `--stdin` is JSONL FrameEvents for supported commands.
- Updated stale command grammar in DBC/J1939/composition specs and added CANdid replay file selection examples.

## Verification
- `uv run mkdocs build --strict`
- `git diff --check`

Closes #259