### PR TITLE
Fix default dataset search heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+* Fixed the default `datasets search` human heading to show `All datasets (N)` instead of `Datasets matching All datasets (N)`. Closes #267.
 * Made `canarchy datasets provider list` and `canarchy datasets search <query>` default to compact readable output instead of dumping raw Python result dictionaries, added `--verbose` for detailed search result blocks, and preserved explicit JSON output for automation.
 * Fixed MCP `stats` and `filter` tool argument mapping so they invoke the current CLI grammar (`stats --file <file>` and `filter <expr> --file <file>`) and return successful canonical envelopes. Closes #237.
 * Made `canarchy datasets replay` stop cleanly on closed stdout pipes instead of printing a Python `BrokenPipeError` traceback. Closes #240.

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -4361,9 +4361,10 @@ def format_datasets_table(result: CommandResult) -> list[str]:
     results = result.data.get("results", [])
     is_empty_query = not query
     title_query = "All datasets" if is_empty_query else f"\"{query}\""
+    title = f"All datasets ({count})" if is_empty_query else f"Datasets matching {title_query} ({count})"
     
     if result.data.get("verbose"):
-        lines = [f"Datasets matching {title_query} ({count})", ""]
+        lines = [title, ""]
         for item in results:
             ref = f"{item['provider']}:{item['name']}"
             is_replayable = item.get("is_replayable", False)
@@ -4429,7 +4430,7 @@ def format_datasets_table(result: CommandResult) -> list[str]:
         key: max([len(header), *(len(row[key]) for row in rows)] or [len(header)])
         for header, key in columns
     }
-    lines = [f"Datasets matching {title_query} ({count})", ""]
+    lines = [title, ""]
     lines.append("  ".join(header.ljust(widths[key]) for header, key in columns))
     for row in rows:
         lines.append("  ".join(row[key].ljust(widths[key]) for _, key in columns))

--- a/tests/test_dataset_provider.py
+++ b/tests/test_dataset_provider.py
@@ -1020,8 +1020,15 @@ class HumanReadableOutputTests(unittest.TestCase):
     def test_datasets_search_empty_query_shows_all_datasets(self) -> None:
         code, out, _ = run_cli("datasets", "search")
         self.assertEqual(code, 0)
-        self.assertIn("All datasets", out)
+        self.assertRegex(out.splitlines()[0], r"^All datasets \(\d+\)$")
+        self.assertNotIn("Datasets matching All datasets", out)
         self.assertNotIn('Datasets matching "all"', out)
+
+    def test_datasets_search_empty_query_verbose_shows_all_datasets(self) -> None:
+        code, out, _ = run_cli("datasets", "search", "--verbose")
+        self.assertEqual(code, 0)
+        self.assertRegex(out.splitlines()[0], r"^All datasets \(\d+\)$")
+        self.assertNotIn("Datasets matching All datasets", out)
 
     def test_datasets_search_table_includes_type_column(self) -> None:
         code, out, _ = run_cli("datasets", "search", "candid")


### PR DESCRIPTION
## Summary

- Fixed empty-query `datasets search` human output to show `All datasets (N)`.
- Preserved query-specific headings like `Datasets matching "hcrl" (N)`.
- Added compact and verbose empty-query regression tests.
- Updated changelog.

## Verification

- `uv run python -m pytest tests/test_dataset_provider.py -q`
- `uv run python -m pytest tests/ -q`
- Manual: `uv run canarchy datasets search`
- `git diff --check`

Closes #267.