### PR TITLE
fix: show signal rows in dbc inspect --signals-only human output closes #263

### DIFF
--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -4202,6 +4202,21 @@ def format_dbc_table(result: CommandResult) -> list[str]:
     db = result.data.get("database", {})
     if db:
         lines.append(f"path: {db.get('path', '')}")
+        if result.data.get("signals_only"):
+            lines.append(f"signals: {result.data.get('signal_count', 0)}")
+            for signal in result.data.get("signals", []):
+                unit = f"  [{signal['unit']}]" if signal.get("unit") else ""
+                lines.append(
+                    f"  {signal['message_name']}.{signal['name']}"
+                    f"  bit={signal['start_bit']}"
+                    f"  len={signal['length']}"
+                    f"  {signal.get('byte_order', '')}"
+                    f"  scale={signal.get('scale')}"
+                    f"  offset={signal.get('offset')}"
+                    f"  {signal.get('minimum')}..{signal.get('maximum')}"
+                    f"{unit}"
+                )
+            return lines
         lines.append(f"messages: {db.get('message_count', 0)}")
         lines.append(f"signals: {db.get('signal_count', 0)}")
     for message in result.data.get("messages", []):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3748,6 +3748,54 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["errors"][0]["code"], "CAPTURE_FORMAT_UNSUPPORTED")
         self.assertIn("unsupported file format", payload["errors"][0]["message"])
 
+    def test_dbc_inspect_signals_only_human_output_lists_signal_rows(self) -> None:
+        exit_code, stdout, stderr = run_cli("dbc", "inspect", str(FIXTURES / "sample.dbc"), "--signals-only")
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(stderr, "")
+        lines = stdout.splitlines()
+        self.assertIn("signals: 6", lines)
+        signal_lines = [l for l in lines if l.startswith("  ")]
+        self.assertEqual(len(signal_lines), 6)
+        coolant = next(l for l in signal_lines if "CoolantTemp" in l)
+        self.assertIn("EngineStatus1.CoolantTemp", coolant)
+        self.assertIn("bit=0", coolant)
+        self.assertIn("len=8", coolant)
+        self.assertIn("little_endian", coolant)
+        self.assertIn("scale=1", coolant)
+        self.assertIn("offset=-40", coolant)
+        self.assertIn("[degC]", coolant)
+        engine_speed = next(l for l in signal_lines if "EngineSpeed" in l and "EngineSpeed1." in l)
+        self.assertIn("EngineSpeed1.EngineSpeed", engine_speed)
+        self.assertIn("scale=0.125", engine_speed)
+        self.assertIn("[rpm]", engine_speed)
+
+    def test_dbc_inspect_signals_only_with_message_filter_limits_rows(self) -> None:
+        exit_code, stdout, _ = run_cli(
+            "dbc", "inspect", str(FIXTURES / "sample.dbc"), "--signals-only", "--message", "EngineStatus1"
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        lines = stdout.splitlines()
+        self.assertIn("signals: 4", lines)
+        signal_lines = [l for l in lines if l.startswith("  ")]
+        self.assertEqual(len(signal_lines), 4)
+        self.assertTrue(all("EngineStatus1." in l for l in signal_lines))
+
+    def test_dbc_inspect_signals_only_json_includes_signals_array(self) -> None:
+        exit_code, stdout, _ = run_cli(
+            "dbc", "inspect", str(FIXTURES / "sample.dbc"), "--signals-only", "--json"
+        )
+        self.assertEqual(exit_code, EXIT_OK)
+        payload = json.loads(stdout)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["data"]["signal_count"], 6)
+        self.assertEqual(len(payload["data"]["signals"]), 6)
+        signal = next(s for s in payload["data"]["signals"] if s["name"] == "CoolantTemp")
+        self.assertEqual(signal["message_name"], "EngineStatus1")
+        self.assertEqual(signal["start_bit"], 0)
+        self.assertEqual(signal["length"], 8)
+        self.assertEqual(signal["offset"], -40)
+        self.assertEqual(signal["unit"], "degC")
+
 
 class CompletionTests(unittest.TestCase):
     """Tests for tab completion in the shell and TUI."""


### PR DESCRIPTION
https://claude.ai/code/session_01S2RT268Rn4b5rCpRiQjACK