### PR TITLE
fix: report signal name, value, and bounds in dbc encode validation errors

### DIFF
--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -78,11 +78,14 @@ class ErrorDetail:
     code: str
     message: str
     hint: str | None = None
+    detail: dict[str, Any] | None = None
 
-    def to_payload(self) -> dict[str, str]:
-        payload = {"code": self.code, "message": self.message}
+    def to_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {"code": self.code, "message": self.message}
         if self.hint:
             payload["hint"] = self.hint
+        if self.detail:
+            payload["detail"] = self.detail
         return payload
 
 
@@ -4898,7 +4901,7 @@ def execute_command(argv: Sequence[str] | None = None) -> tuple[int, CommandResu
             EXIT_DECODE_ERROR,
             error_result(
                 args.command,
-                errors=[ErrorDetail(code=exc.code, message=exc.message, hint=exc.hint)],
+                errors=[ErrorDetail(code=exc.code, message=exc.message, hint=exc.hint, detail=exc.detail)],
             ),
         )
     except SkillError as exc:

--- a/src/canarchy/dbc.py
+++ b/src/canarchy/dbc.py
@@ -24,6 +24,7 @@ class DbcError(Exception):
     code: str
     message: str
     hint: str
+    detail: dict[str, Any] | None = None
 
     def __str__(self) -> str:
         return self.message

--- a/src/canarchy/dbc_runtime.py
+++ b/src/canarchy/dbc_runtime.py
@@ -309,14 +309,14 @@ def encode_message_runtime(
         else:
             minimum = normalize_value(signal.minimum) if signal.minimum is not None else None
             maximum = normalize_value(signal.maximum) if signal.maximum is not None else None
-            if minimum is not None and sig_value < minimum:
+            if isinstance(sig_value, (int, float)) and minimum is not None and sig_value < minimum:
                 raise DbcError(
                     code="DBC_SIGNAL_INVALID",
                     message=f"Signal '{sig_name}' value {sig_value} is below the minimum of {minimum}.",
                     hint=f"'{sig_name}' must be in the range {minimum}..{maximum}.",
                     detail={"signal": sig_name, "supplied": sig_value, "minimum": minimum, "maximum": maximum},
                 )
-            if maximum is not None and sig_value > maximum:
+            if isinstance(sig_value, (int, float)) and maximum is not None and sig_value > maximum:
                 raise DbcError(
                     code="DBC_SIGNAL_INVALID",
                     message=f"Signal '{sig_name}' value {sig_value} exceeds the maximum of {maximum}.",

--- a/src/canarchy/dbc_runtime.py
+++ b/src/canarchy/dbc_runtime.py
@@ -289,6 +289,41 @@ def encode_message_runtime(
             hint="Use only signal names that exist in the selected DBC message.",
         )
 
+    for sig_name, sig_value in signals.items():
+        signal = message.get_signal_by_name(sig_name)
+        choices = getattr(signal, "choices", None)
+        if choices:
+            valid_labels = set(choices.values())
+            valid_keys = set(choices.keys())
+            if sig_value not in valid_labels and sig_value not in valid_keys:
+                raise DbcError(
+                    code="DBC_SIGNAL_INVALID",
+                    message=f"Signal '{sig_name}' value {sig_value!r} is not a valid choice.",
+                    hint=f"Valid choices for '{sig_name}': {', '.join(str(v) for v in sorted(valid_labels))}.",
+                    detail={
+                        "signal": sig_name,
+                        "supplied": sig_value,
+                        "choices": sorted(valid_labels),
+                    },
+                )
+        else:
+            minimum = normalize_value(signal.minimum) if signal.minimum is not None else None
+            maximum = normalize_value(signal.maximum) if signal.maximum is not None else None
+            if minimum is not None and sig_value < minimum:
+                raise DbcError(
+                    code="DBC_SIGNAL_INVALID",
+                    message=f"Signal '{sig_name}' value {sig_value} is below the minimum of {minimum}.",
+                    hint=f"'{sig_name}' must be in the range {minimum}..{maximum}.",
+                    detail={"signal": sig_name, "supplied": sig_value, "minimum": minimum, "maximum": maximum},
+                )
+            if maximum is not None and sig_value > maximum:
+                raise DbcError(
+                    code="DBC_SIGNAL_INVALID",
+                    message=f"Signal '{sig_name}' value {sig_value} exceeds the maximum of {maximum}.",
+                    hint=f"'{sig_name}' must be in the range {minimum}..{maximum}.",
+                    detail={"signal": sig_name, "supplied": sig_value, "minimum": minimum, "maximum": maximum},
+                )
+
     try:
         encoded = message.encode(signals)
     except Exception as exc:  # pragma: no cover

--- a/tests/test_dbc.py
+++ b/tests/test_dbc.py
@@ -120,6 +120,49 @@ class DbcTests(unittest.TestCase):
         payload = json.loads(stdout)
         self.assertEqual(payload["errors"][0]["code"], "DBC_SIGNAL_INVALID")
 
+    def test_encode_out_of_range_value_reports_signal_and_bounds(self) -> None:
+        exit_code, stdout, stderr = run_cli(
+            "encode",
+            "--dbc",
+            str(FIXTURES / "sample.dbc"),
+            "EngineStatus1",
+            "CoolantTemp=999",
+            "--json",
+        )
+        self.assertEqual(exit_code, EXIT_DECODE_ERROR)
+        self.assertEqual(stderr, "")
+
+        payload = json.loads(stdout)
+        error = payload["errors"][0]
+        self.assertEqual(error["code"], "DBC_SIGNAL_INVALID")
+        self.assertIn("CoolantTemp", error["message"])
+        self.assertIn("999", error["message"])
+        detail = error["detail"]
+        self.assertEqual(detail["signal"], "CoolantTemp")
+        self.assertEqual(detail["supplied"], 999)
+        self.assertEqual(detail["minimum"], 0)
+        self.assertEqual(detail["maximum"], 210)
+
+    def test_encode_below_minimum_value_reports_signal_and_bounds(self) -> None:
+        exit_code, stdout, _ = run_cli(
+            "encode",
+            "--dbc",
+            str(FIXTURES / "sample.dbc"),
+            "EngineStatus1",
+            "Load=-5",
+            "--json",
+        )
+        self.assertEqual(exit_code, EXIT_DECODE_ERROR)
+
+        payload = json.loads(stdout)
+        error = payload["errors"][0]
+        self.assertEqual(error["code"], "DBC_SIGNAL_INVALID")
+        detail = error["detail"]
+        self.assertEqual(detail["signal"], "Load")
+        self.assertEqual(detail["supplied"], -5)
+        self.assertEqual(detail["minimum"], 0)
+        self.assertEqual(detail["maximum"], 100)
+
     def test_dbc_inspect_cli_returns_structured_metadata(self) -> None:
         exit_code, stdout, stderr = run_cli(
             "dbc",


### PR DESCRIPTION
## Summary

- Encoding errors now identify the specific failing signal, the supplied value, and the allowed range (or valid choices) in a machine-readable `detail` field
- Previously the error was a generic message with no signal-specific context, making it hard for both humans and agents to diagnose

## Changes

- `dbc.py` — added optional `detail: dict | None` field to `DbcError`
- `dbc_runtime.py` — added per-signal range/choice validation loop before `message.encode()`; raises with populated `detail` on violation
- `cli.py` — `ErrorDetail` gains optional `detail` field surfaced in JSON payloads; `DbcError` handler passes `exc.detail` through
- `tests/test_dbc.py` — two new tests: out-of-range above max (`CoolantTemp=999`) and below min (`Load=-5`), both verifying `detail` contains signal name, supplied value, and bounds

## Before / After

**Before** (`CoolantTemp=999`):
```json
{"code": "DBC_SIGNAL_INVALID", "message": "Failed to encode message 'EngineStatus1' with the provided signals.", "hint": "Check the signal names, types, ranges, and required values for the selected DBC message."}
```

**After**:
```json
{"code": "DBC_SIGNAL_INVALID", "message": "Signal 'CoolantTemp' value 999 exceeds the maximum of 210.", "hint": "'CoolantTemp' must be in the range 0..210.", "detail": {"signal": "CoolantTemp", "supplied": 999, "minimum": 0, "maximum": 210}}
```

## Test plan

- [ ] `uv run pytest tests/test_dbc.py -q` — all 13 pass
- [ ] `canarchy encode --dbc tests/fixtures/sample.dbc EngineStatus1 CoolantTemp=999 --json` returns signal-specific error with `detail`
- [ ] `canarchy encode --dbc tests/fixtures/sample.dbc EngineStatus1 CoolantTemp=55 --json` still succeeds

https://claude.ai/code/session_01S2RT268Rn4b5rCpRiQjACK