### PR TITLE
fix: remove compact field leakage and add dbc search --verbose

### DIFF
--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -3553,7 +3553,7 @@ def build_result(args: argparse.Namespace) -> CommandResult:
         key: value
         for key, value in vars(args).items()
         if not key.endswith("_action")
-        and key not in {"command", "command_name", "json", "jsonl", "table", "raw", "ack_active"}
+        and key not in {"command", "command_name", "json", "jsonl", "compact", "table", "raw", "ack_active"}
         and value is not None
     }
     if args.command in TRANSPORT_COMMANDS:

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -323,6 +323,7 @@ def build_parser() -> CanarchyArgumentParser:
     dbc_search.add_argument("query", help="search query (name, make, or keyword)")
     dbc_search.add_argument("--provider", help="restrict search to a specific provider")
     dbc_search.add_argument("--limit", type=int, default=20, help="maximum results (default: 20)")
+    dbc_search.add_argument("--verbose", action="store_true", help="show provider, version, and path details")
     add_output_arguments(dbc_search)
     dbc_search.set_defaults(command="dbc search")
 
@@ -4245,8 +4246,16 @@ def format_dbc_provider_table(result: CommandResult) -> list[str]:
         lines.append(f"results: {result.data.get('count', 0)}")
         for item in result.data.get("results", []):
             brand = item.get("metadata", {}).get("brand", "")
-            brand_text = f" ({brand})" if brand else ""
-            lines.append(f"  {item['source_ref']}{brand_text}")
+            if result.data.get("verbose"):
+                lines.append(f"  {item['source_ref']}")
+                lines.append(f"    provider: {item.get('provider', '')}")
+                if item.get("version"):
+                    lines.append(f"    version:  {item['version'][:12]}")
+                if brand:
+                    lines.append(f"    brand:    {brand}")
+            else:
+                brand_text = f" ({brand})" if brand else ""
+                lines.append(f"  {item['source_ref']}{brand_text}")
     elif result.command == "dbc fetch":
         lines.append(f"ref: {result.data.get('ref', '')}")
         lines.append(f"name: {result.data.get('name', '')}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3730,6 +3730,11 @@ class CliTests(unittest.TestCase):
         payload = json.loads(stdout)
         self.assertEqual(payload["errors"][0]["code"], "INVALID_FILTER_EXPRESSION")
 
+    def test_compact_flag_not_leaked_into_stats_json_payload(self) -> None:
+        _, stdout, _ = run_cli("stats", "--file", str(FIXTURES / "sample.candump"), "--json")
+        payload = json.loads(stdout)
+        self.assertNotIn("compact", payload["data"])
+
     def test_invalid_candump_file_returns_structured_transport_error(self) -> None:
         exit_code, stdout, stderr = run_cli("stats", "--file", str(FIXTURES / "invalid.candump"), "--json")
         self.assertEqual(exit_code, EXIT_OK)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3735,6 +3735,61 @@ class CliTests(unittest.TestCase):
         payload = json.loads(stdout)
         self.assertNotIn("compact", payload["data"])
 
+    def _mock_dbc_registry(self):
+        from canarchy.dbc_provider import DbcDescriptor
+        from unittest.mock import MagicMock
+        mock_registry = MagicMock()
+        mock_registry.search.return_value = [
+            DbcDescriptor(
+                provider="opendbc",
+                name="toyota_tnga_k_pt_generated",
+                version="abc123def456",
+                source_ref="opendbc:toyota_tnga_k_pt_generated",
+                cache_path=None,
+                sha256=None,
+                metadata={"brand": "toyota"},
+            ),
+            DbcDescriptor(
+                provider="opendbc",
+                name="toyota_new_mc_pt",
+                version="abc123def456",
+                source_ref="opendbc:toyota_new_mc_pt",
+                cache_path=None,
+                sha256=None,
+                metadata={"brand": "toyota"},
+            ),
+        ]
+        return mock_registry
+
+    def test_dbc_search_compact_output_shows_source_ref_and_brand(self) -> None:
+        with patch("canarchy.dbc_provider.get_registry", return_value=self._mock_dbc_registry()):
+            _, stdout, _ = run_cli("dbc", "search", "toyota")
+        lines = stdout.splitlines()
+        self.assertIn("query: toyota", lines)
+        self.assertIn("results: 2", lines)
+        self.assertTrue(any("opendbc:toyota_tnga_k_pt_generated" in l and "(toyota)" in l for l in lines))
+
+    def test_dbc_search_verbose_output_shows_provider_version_brand(self) -> None:
+        with patch("canarchy.dbc_provider.get_registry", return_value=self._mock_dbc_registry()):
+            _, stdout, _ = run_cli("dbc", "search", "toyota", "--verbose")
+        lines = stdout.splitlines()
+        self.assertIn("results: 2", lines)
+        self.assertTrue(any("opendbc:toyota_tnga_k_pt_generated" in l for l in lines))
+        self.assertTrue(any("provider: opendbc" in l for l in lines))
+        self.assertTrue(any("version:  abc123def456" in l for l in lines))
+        self.assertTrue(any("brand:    toyota" in l for l in lines))
+
+    def test_dbc_search_verbose_json_output_unchanged(self) -> None:
+        with patch("canarchy.dbc_provider.get_registry", return_value=self._mock_dbc_registry()):
+            _, stdout, _ = run_cli("dbc", "search", "toyota", "--verbose", "--json")
+        payload = json.loads(stdout)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["data"]["count"], 2)
+        result = payload["data"]["results"][0]
+        self.assertEqual(result["source_ref"], "opendbc:toyota_tnga_k_pt_generated")
+        self.assertEqual(result["provider"], "opendbc")
+        self.assertEqual(result["metadata"]["brand"], "toyota")
+
     def test_invalid_candump_file_returns_structured_transport_error(self) -> None:
         exit_code, stdout, stderr = run_cli("stats", "--file", str(FIXTURES / "invalid.candump"), "--json")
         self.assertEqual(exit_code, EXIT_OK)

--- a/tests/test_dbc.py
+++ b/tests/test_dbc.py
@@ -177,6 +177,17 @@ class DbcTests(unittest.TestCase):
         self.assertEqual(payload["command"], "dbc inspect")
         self.assertEqual(payload["data"]["database"]["message_count"], 2)
         self.assertEqual(payload["data"]["messages"][0]["name"], "EngineSpeed1")
+        self.assertNotIn("compact", payload["data"])
+
+    def test_compact_flag_not_leaked_into_json_payload(self) -> None:
+        for argv in [
+            ("dbc", "inspect", str(FIXTURES / "sample.dbc"), "--json"),
+            ("encode", "--dbc", str(FIXTURES / "sample.dbc"), "EngineStatus1", "CoolantTemp=55", "--json"),
+        ]:
+            with self.subTest(argv=argv):
+                _, stdout, _ = run_cli(*argv)
+                payload = json.loads(stdout)
+                self.assertNotIn("compact", payload["data"])
 
     def test_dbc_inspect_unknown_message_returns_error(self) -> None:
         exit_code, stdout, stderr = run_cli(


### PR DESCRIPTION
## Summary

Two related output-quality fixes:

- **#264** — `compact: false` was leaking into every JSON command response. `build_result` excluded `json`, `jsonl`, `table`, `raw` from `vars(args)` but not `compact`. One-word fix.
- **#262** — `dbc search` now supports `--verbose` to show provider, version, and brand per result. Compact default output is unchanged. JSON output is unchanged.

## Changes

- `cli.py` — add `"compact"` to exclusion set in `build_result`; add `--verbose` arg to `dbc_search` parser; update `format_dbc_provider_table` dbc search branch to render verbose rows
- `tests/test_dbc.py` — regression: `compact` absent from `dbc inspect` and `encode` JSON payloads
- `tests/test_cli.py` — regression: `compact` absent from `stats` JSON payload; 3 new tests for `dbc search` compact output, verbose output, and JSON backward-compatibility

## Test plan

- [ ] `uv run pytest tests/test_cli.py tests/test_dbc.py -q` — all pass
- [ ] `canarchy dbc inspect tests/fixtures/sample.dbc --json` — no `compact` key in `data`
- [ ] `canarchy dbc search toyota --verbose` — shows provider/version/brand per result
- [ ] `canarchy dbc search toyota` — compact output unchanged
- [ ] `canarchy dbc search toyota --verbose --json` — JSON payload includes `results` array, unchanged structure

https://claude.ai/code/session_01S2RT268Rn4b5rCpRiQjACK