### PR TITLE
feat: improve human formatting for datasets fetch and replay --dry-run

### DIFF
--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -4372,6 +4372,81 @@ def format_dataset_inspect(result: CommandResult) -> list[str]:
     return lines
 
 
+def format_datasets_fetch(result: CommandResult) -> list[str]:
+    """Format human-readable output for datasets fetch."""
+    data = result.data
+    lines = []
+    ref = data.get("ref", "")
+    is_index = data.get("is_index", False)
+
+    type_str = " [INDEX]" if is_index else ""
+    lines.append(f"Dataset: {ref}{type_str}")
+    lines.append("")
+
+    lines.append("Provenance")
+    lines.append(f"  Ref: {ref}")
+    lines.append(f"  Provider: {data.get('provider', '')}")
+    lines.append(f"  Name: {data.get('name', '')}")
+    lines.append(f"  Source URL: {data.get('source_url', '')}")
+    lines.append(f"  Cache path: {data.get('cache_path', '')}")
+    lines.append(f"  Cached: {'Yes' if data.get('is_cached') else 'No'}")
+    lines.append("")
+
+    lines.append("Next steps")
+    if is_index:
+        lines.append(f"  Curated index entry. Visit the index page to discover datasets:")
+        lines.append(f"    {data.get('source_url', '')}")
+        lines.append("  Use `canarchy datasets search <keyword>` to find specific datasets from this index.")
+    else:
+        lines.append(f"  Download the data manually from:")
+        lines.append(f"    {data.get('source_url', '')}")
+    lines.append("")
+
+    return lines
+
+
+def format_datasets_replay_dry_run(result: CommandResult) -> list[str]:
+    """Format human-readable output for datasets replay --dry-run."""
+    data = result.data
+    lines = []
+    ref = data.get("ref") or data.get("source", "")
+
+    lines.append(f"Replay plan (dry run): {ref}")
+    lines.append("")
+
+    lines.append("Source")
+    lines.append(f"  Ref: {ref}")
+    source_type = data.get("source_type") or "dataset"
+    lines.append(f"  Type: {source_type}")
+    if data.get("download_url"):
+        lines.append(f"  Download URL: {data['download_url']}")
+    lines.append("")
+
+    replay_file = data.get("replay_file") or data.get("default_replay_file", "")
+    source_format = data.get("source_format", "")
+    lines.append("Selected replay file")
+    lines.append(f"  File: {replay_file}")
+    if source_format:
+        lines.append(f"  Format: {source_format}")
+    lines.append("")
+
+    lines.append("Limits")
+    rate = data.get("rate")
+    lines.append(f"  Rate: {rate} fps" if rate is not None else "  Rate: (default)")
+    max_frames = data.get("max_frames")
+    lines.append(f"  Max frames: {max_frames}" if max_frames is not None else "  Max frames: (none)")
+    max_seconds = data.get("max_seconds")
+    lines.append(f"  Max seconds: {max_seconds}" if max_seconds is not None else "  Max seconds: (none)")
+    lines.append("")
+
+    lines.append("Replay plan")
+    lines.append(f"  Output format: {data.get('output_format', '')}")
+    lines.append(f"  Would stream: {'yes' if data.get('would_stream') else 'no'}")
+    lines.append("")
+
+    return lines
+
+
 def format_datasets_table(result: CommandResult) -> list[str]:
     if result.command == "datasets provider list":
         lines = ["Dataset providers"]
@@ -4762,6 +4837,20 @@ def emit_result(result: CommandResult, output_format: str) -> None:
 
     if output_format == "table" and result.ok and result.command == "datasets inspect":
         for line in format_dataset_inspect(result):
+            print(line)
+        for warning in payload["warnings"]:
+            print(f"warning: {warning}")
+        return
+
+    if output_format == "table" and result.ok and result.command == "datasets fetch":
+        for line in format_datasets_fetch(result):
+            print(line)
+        for warning in payload["warnings"]:
+            print(f"warning: {warning}")
+        return
+
+    if output_format == "table" and result.ok and result.command == "datasets replay" and result.data.get("dry_run"):
+        for line in format_datasets_replay_dry_run(result):
             print(line)
         for warning in payload["warnings"]:
             print(f"warning: {warning}")

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -4393,13 +4393,9 @@ def format_datasets_fetch(result: CommandResult) -> list[str]:
     lines.append("")
 
     lines.append("Next steps")
-    if is_index:
-        lines.append(f"  Curated index entry. Visit the index page to discover datasets:")
-        lines.append(f"    {data.get('source_url', '')}")
-        lines.append("  Use `canarchy datasets search <keyword>` to find specific datasets from this index.")
-    else:
-        lines.append(f"  Download the data manually from:")
-        lines.append(f"    {data.get('source_url', '')}")
+    instruction = data.get("index_instructions") if is_index else data.get("download_instructions", "")
+    for part in (instruction or "").split("\n"):
+        lines.append(f"  {part}" if part.strip() else "")
     lines.append("")
 
     return lines

--- a/tests/test_dataset_provider.py
+++ b/tests/test_dataset_provider.py
@@ -1199,6 +1199,15 @@ class FetchHumanFormattingTests(unittest.TestCase):
         self.assertIn("index_instructions", data["data"])
         self.assertIn("download_instructions", data["data"])
 
+    def test_fetch_dataset_with_access_notes_shows_notes_in_next_steps(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("canarchy.dataset_cache.cache_root", return_value=Path(tmp) / "cache"):
+                code, out, _ = run_cli("datasets", "fetch", "catalog:hcrl-car-hacking")
+        self.assertEqual(code, 0)
+        self.assertIn("Next steps", out)
+        self.assertIn("Research-use agreement", out)
+        self.assertNotIn("download_instructions:", out)
+
 
 class ReplayDryRunHumanFormattingTests(unittest.TestCase):
     """Human-readable formatting for datasets replay --dry-run (issue #269)."""

--- a/tests/test_dataset_provider.py
+++ b/tests/test_dataset_provider.py
@@ -1133,3 +1133,173 @@ class FetchWordingTests(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertIn("Download the data manually", out)
         self.assertNotIn("Curated index entry", out)
+
+
+class FetchHumanFormattingTests(unittest.TestCase):
+    """Human-readable formatting for datasets fetch (issue #266)."""
+
+    def test_fetch_normal_dataset_shows_provenance_section(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("canarchy.dataset_cache.cache_root", return_value=Path(tmp) / "cache"):
+                code, out, _ = run_cli("datasets", "fetch", "catalog:road")
+        self.assertEqual(code, 0)
+        self.assertIn("Provenance", out)
+        self.assertIn("Ref: catalog:road", out)
+        self.assertIn("Provider: catalog", out)
+        self.assertIn("Name: road", out)
+        self.assertIn("Source URL:", out)
+        self.assertIn("Cache path:", out)
+        self.assertIn("Cached:", out)
+
+    def test_fetch_normal_dataset_shows_next_steps_section(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("canarchy.dataset_cache.cache_root", return_value=Path(tmp) / "cache"):
+                code, out, _ = run_cli("datasets", "fetch", "catalog:road")
+        self.assertEqual(code, 0)
+        self.assertIn("Next steps", out)
+        self.assertIn("Download the data manually", out)
+        self.assertNotIn("download_instructions:", out)
+
+    def test_fetch_normal_dataset_title_has_no_type_label(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("canarchy.dataset_cache.cache_root", return_value=Path(tmp) / "cache"):
+                code, out, _ = run_cli("datasets", "fetch", "catalog:road")
+        self.assertEqual(code, 0)
+        self.assertIn("Dataset: catalog:road", out)
+        self.assertNotIn("[INDEX]", out)
+
+    def test_fetch_curated_index_shows_index_label(self) -> None:
+        code, out, _ = run_cli("datasets", "fetch", "catalog:pivot-auto-datasets")
+        self.assertEqual(code, 0)
+        self.assertIn("Dataset: catalog:pivot-auto-datasets [INDEX]", out)
+
+    def test_fetch_curated_index_shows_provenance_section(self) -> None:
+        code, out, _ = run_cli("datasets", "fetch", "catalog:pivot-auto-datasets")
+        self.assertEqual(code, 0)
+        self.assertIn("Provenance", out)
+        self.assertIn("Ref: catalog:pivot-auto-datasets", out)
+        self.assertIn("Provider: catalog", out)
+        self.assertIn("Name: pivot-auto-datasets", out)
+
+    def test_fetch_curated_index_next_steps_no_raw_dict(self) -> None:
+        code, out, _ = run_cli("datasets", "fetch", "catalog:pivot-auto-datasets")
+        self.assertEqual(code, 0)
+        self.assertIn("Next steps", out)
+        self.assertIn("Curated index entry", out)
+        self.assertIn("canarchy datasets search", out)
+        self.assertNotIn("index_instructions:", out)
+        self.assertNotIn("download_instructions:", out)
+
+    def test_fetch_json_output_unchanged(self) -> None:
+        code, out, _ = run_cli("datasets", "fetch", "catalog:pivot-auto-datasets", "--json")
+        self.assertEqual(code, 0)
+        data = json.loads(out)
+        self.assertTrue(data["ok"])
+        self.assertIn("is_index", data["data"])
+        self.assertIn("index_instructions", data["data"])
+        self.assertIn("download_instructions", data["data"])
+
+
+class ReplayDryRunHumanFormattingTests(unittest.TestCase):
+    """Human-readable formatting for datasets replay --dry-run (issue #269)."""
+
+    def test_dry_run_catalog_ref_shows_replay_plan_header(self) -> None:
+        with patch("canarchy.dataset_convert.requests.get"):
+            code, out, _ = run_cli(
+                "datasets", "replay", "catalog:candid",
+                "--format", "jsonl", "--rate", "10",
+                "--max-frames", "5", "--max-seconds", "2.5",
+                "--dry-run",
+            )
+        self.assertEqual(code, 0)
+        self.assertIn("Replay plan (dry run): catalog:candid", out)
+
+    def test_dry_run_shows_source_section(self) -> None:
+        with patch("canarchy.dataset_convert.requests.get"):
+            code, out, _ = run_cli(
+                "datasets", "replay", "catalog:candid",
+                "--format", "jsonl", "--rate", "10",
+                "--dry-run",
+            )
+        self.assertEqual(code, 0)
+        self.assertIn("Source", out)
+        self.assertIn("Ref: catalog:candid", out)
+        self.assertIn("Download URL:", out)
+
+    def test_dry_run_shows_selected_replay_file(self) -> None:
+        with patch("canarchy.dataset_convert.requests.get"):
+            code, out, _ = run_cli(
+                "datasets", "replay", "catalog:candid",
+                "--format", "jsonl", "--rate", "10",
+                "--dry-run",
+            )
+        self.assertEqual(code, 0)
+        self.assertIn("Selected replay file", out)
+        self.assertIn("File:", out)
+        self.assertIn("Format:", out)
+
+    def test_dry_run_shows_limits_section(self) -> None:
+        with patch("canarchy.dataset_convert.requests.get"):
+            code, out, _ = run_cli(
+                "datasets", "replay", "catalog:candid",
+                "--format", "jsonl", "--rate", "10",
+                "--max-frames", "5", "--max-seconds", "2.5",
+                "--dry-run",
+            )
+        self.assertEqual(code, 0)
+        self.assertIn("Limits", out)
+        self.assertIn("Rate: 10.0 fps", out)
+        self.assertIn("Max frames: 5", out)
+        self.assertIn("Max seconds: 2.5", out)
+
+    def test_dry_run_shows_replay_plan_section(self) -> None:
+        with patch("canarchy.dataset_convert.requests.get"):
+            code, out, _ = run_cli(
+                "datasets", "replay", "catalog:candid",
+                "--format", "jsonl", "--rate", "10",
+                "--dry-run",
+            )
+        self.assertEqual(code, 0)
+        self.assertIn("Replay plan", out)
+        self.assertIn("Output format: jsonl", out)
+        self.assertIn("Would stream: yes", out)
+
+    def test_dry_run_no_raw_key_value_dump(self) -> None:
+        with patch("canarchy.dataset_convert.requests.get"):
+            code, out, _ = run_cli(
+                "datasets", "replay", "catalog:candid",
+                "--format", "jsonl", "--rate", "10",
+                "--dry-run",
+            )
+        self.assertEqual(code, 0)
+        self.assertNotIn("dry_run:", out)
+        self.assertNotIn("replay_files:", out)
+        self.assertNotIn("compact:", out)
+        self.assertNotIn("would_stream: True", out)
+
+    def test_dry_run_no_limits_shows_none_labels(self) -> None:
+        with patch("canarchy.dataset_convert.requests.get"):
+            code, out, _ = run_cli(
+                "datasets", "replay", "catalog:candid",
+                "--format", "jsonl", "--rate", "10",
+                "--dry-run",
+            )
+        self.assertEqual(code, 0)
+        self.assertIn("Max frames: (none)", out)
+        self.assertIn("Max seconds: (none)", out)
+
+    def test_dry_run_json_output_unchanged(self) -> None:
+        with patch("canarchy.dataset_convert.requests.get"):
+            code, out, _ = run_cli(
+                "datasets", "replay", "catalog:candid",
+                "--format", "jsonl", "--rate", "10",
+                "--max-frames", "5",
+                "--dry-run", "--json",
+            )
+        self.assertEqual(code, 0)
+        data = json.loads(out)
+        self.assertTrue(data["ok"])
+        self.assertTrue(data["data"]["dry_run"])
+        self.assertTrue(data["data"]["would_stream"])
+        self.assertEqual(data["data"]["ref"], "catalog:candid")
+        self.assertEqual(data["data"]["max_frames"], 5)


### PR DESCRIPTION
## Summary

- Replaces raw key/value / Python-dict dumps in `datasets fetch` human output with structured **Provenance** and **Next steps** sections (closes #266)
- Replaces raw dump in `datasets replay --dry-run` human output with structured **Source**, **Selected replay file**, **Limits**, and **Replay plan** sections (closes #269)
- Preserves access notes (account requirements, research agreements) in Next steps by using `download_instructions`/`index_instructions` from the payload directly — fixes feedback from Codex review
- JSON output is fully backward-compatible in both cases
- Adds 16 new CLI tests covering normal datasets, curated index entries, access-notes preservation, limit labels, section presence, raw-dump absence, and JSON compat

## Test plan

- [ ] `canarchy datasets fetch catalog:road` — shows Provenance + Next steps, no raw dict fields
- [ ] `canarchy datasets fetch catalog:pivot-auto-datasets` — shows `[INDEX]` label, curated index guidance, no `index_instructions:` dump
- [ ] `canarchy datasets fetch catalog:hcrl-car-hacking` — Next steps includes "Research-use agreement" access note
- [ ] `canarchy datasets replay catalog:candid --dry-run` — shows Source / Selected replay file / Limits / Replay plan sections, no `compact:` or `replay_files:` leakage
- [ ] `canarchy datasets fetch catalog:road --json` — JSON payload unchanged
- [ ] `canarchy datasets replay catalog:candid --dry-run --json` — JSON payload unchanged
- [ ] `uv run --group dev --group docs pytest tests/test_dataset_provider.py::FetchHumanFormattingTests tests/test_dataset_provider.py::ReplayDryRunHumanFormattingTests` — all 16 pass

https://claude.ai/code/session_01Pjw16bKMsXU9oSRs5srgXD