### PR TITLE
Prepare 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-09
+
 ### Added
 
 * Added `canarchy datasets stream` for chunked streaming of downloaded dataset files to candump or JSONL, including JSONL provenance metadata for provider refs, frame offsets, and chunk positions so large datasets can be piped into analysis without buffering the full conversion in memory.

--- a/src/canarchy/__init__.py
+++ b/src/canarchy/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.6.1.dev0"
+__version__ = "0.7.0"


### PR DESCRIPTION
## Summary
- Set the package version to `0.7.0` for the release build.
- Promoted the accumulated changelog entries into the `0.7.0` release section.

## Verification
- `uv run canarchy --version`
- `uv run python -m pytest tests/ -q`
- `uv run mkdocs build --strict`
- `uv build`
- `uvx twine check dist/*`
- wheel install smoke: `canarchy --version`

Refs #283