### PR TITLE
Advance development version after 0.7.0 release

### DIFF
--- a/src/canarchy/__init__.py
+++ b/src/canarchy/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.7.0"
+__version__ = "0.7.1.dev0"


### PR DESCRIPTION
## Summary
- Set the post-release development version to `0.7.1.dev0` after publishing `0.7.0`.

## Verification
- `uv run canarchy --version`

Refs #283