### PR TITLE
Rename human output mode to text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,7 +298,7 @@ Every command should support explicit output modes:
 
 * `--json`
 * `--jsonl`
-* `--table`
+* `--text`
 * `--raw`
 
 Do not mix human decoration into JSON output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Changed
+
+* Renamed the canonical human-readable output flag from `--table` to `--text`; `--table` remains accepted as a compatibility alias. Closes #286.
+
 ## [0.7.0] - 2026-05-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Today the repository delivers:
 
 * a stable CLI surface for analysts, scripts, and coding agents
 * J1939-first heavy vehicle workflows: PGN decoding, SPN extraction, TP session reassembly, DM1 fault parsing
-* structured output (`--json`, `--jsonl`, `--table`, `--raw`) on every command
+* structured output (`--json`, `--jsonl`, `--text`, `--raw`) on every command
 * live CAN transport via `python-can` with support for socketcan, virtual bus, and UDP multicast
 * UDS scan and trace, DBC decode/encode, capture/filter/replay, and an interactive shell
 
@@ -142,9 +142,9 @@ canarchy capture can0 --jsonl
 canarchy decode --file trace.candump --dbc vehicle.dbc --jsonl
 
 # J1939 heavy vehicle analysis
-canarchy j1939 decode --file trace.candump --table
-canarchy j1939 spn 110 --file trace.candump --table   # Engine Coolant Temp
-canarchy j1939 dm1 --file trace.candump --table        # Active fault codes
+canarchy j1939 decode --file trace.candump --text
+canarchy j1939 spn 110 --file trace.candump --text   # Engine Coolant Temp
+canarchy j1939 dm1 --file trace.candump --text        # Active fault codes
 
 # Pipe events into downstream tools
 canarchy j1939 spn 110 --file trace.candump --jsonl \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,7 @@ flowchart TD
     REP --> EV
     REF --> EV
 
-    EV --> OUT[JSON / JSONL / table / raw output]
+    EV --> OUT[JSON / JSONL / text / raw output]
     DBC --> PROV[dbc_source provenance]
     PROV --> OUT
 ```
@@ -150,7 +150,7 @@ Primary responsibilities:
 * argument parsing and validation
 * dispatch to transport, DBC provider resolution, protocol, replay, reverse-engineering, export, and session helpers
 * structured error handling and exit codes
-* shaping output for `--json`, `--jsonl`, `--table`, and `--raw`
+* shaping output for `--json`, `--jsonl`, `--text`, and `--raw`
 
 Relevant module:
 
@@ -319,7 +319,7 @@ sequenceDiagram
     Command->>Engine: decode / classify / replay / summarize
     Engine-->>Command: typed events and payloads
     Command->>Output: CommandResult
-    Output-->>User: json / jsonl / table / raw
+    Output-->>User: json / jsonl / text / raw
 ```
 
 ## Current Strengths

--- a/docs/command_spec.md
+++ b/docs/command_spec.md
@@ -37,7 +37,7 @@ Important current behavior:
 * `decode`, `encode`, and `dbc inspect` include `data.dbc_source` in structured output so callers can see the provider, logical DBC name, pinned version, and resolved local path
 * placeholder-only commands, currently limited to the `fuzz` family, still return `status: planned` and `implementation: command surface scaffold`
 * some protocol-oriented commands currently use explicit sample/reference providers rather than true transport-backed execution paths
-* specialized table formatting exists for J1939 monitor and decode style output; other `--table` output is generic key/value rendering
+* specialized text formatting exists for J1939 monitor and decode style output; other `--text` output is generic key/value rendering
 * file-backed analysis commands support standard timestamped candump log files with `.candump` and `.log` suffixes; selected commands also support `--file -` for candump text from stdin
 
 ---
@@ -72,7 +72,7 @@ Examples:
 Capture traffic from a local interface. Structured capture uses the selected transport backend. `--candump` is a live-only mode.
 
 ```bash
-canarchy capture <interface> [--candump] [--json|--jsonl|--table|--raw]
+canarchy capture <interface> [--candump] [--json|--jsonl|--text|--raw]
 ```
 
 Example:
@@ -88,7 +88,7 @@ Notes:
 * `--candump` keeps running and printing frames until interrupted
 * `--candump` changes the human-readable output path to a `candump`-style line format such as `(0.100000) vcan0 18F00431#AABBCCDD`
 * `--candump --json` and `--candump --jsonl` keep structured output for automation, but still require a live backend
-* default table output without `--candump` remains the generic key/value renderer
+* default text output without `--candump` remains the generic key/value renderer
 
 Supported file input today:
 
@@ -103,7 +103,7 @@ Supported file input today:
 Prepare an active transmit frame.
 
 ```bash
-canarchy send <interface> <frame-id> <hex-data> [--ack-active] [--json|--jsonl|--table|--raw]
+canarchy send <interface> <frame-id> <hex-data> [--ack-active] [--json|--jsonl|--text|--raw]
 ```
 
 Example:
@@ -122,7 +122,7 @@ Notes:
 Filter a capture source by a simple expression.
 
 ```bash
-canarchy filter <expression> (--file <path> | --file - | --stdin) [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json|--jsonl|--compact|--table|--raw]
+canarchy filter <expression> (--file <path> | --file - | --stdin) [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json|--jsonl|--compact|--text|--raw]
 ```
 ```
 
@@ -137,8 +137,8 @@ Notes:
 Inspect a candump capture quickly before running deeper analysis.
 
 ```bash
-canarchy capture-info --file <path> [--json|--jsonl|--table|--raw]
-canarchy capture-info --file - [--json|--jsonl|--table|--raw]
+canarchy capture-info --file <path> [--json|--jsonl|--text|--raw]
+canarchy capture-info --file - [--json|--jsonl|--text|--raw]
 ```
 
 Notes:
@@ -160,8 +160,8 @@ Notes:
 Summarize a capture source.
 
 ```bash
-canarchy stats --file <path> [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json|--jsonl|--table|--raw]
-canarchy stats --file - [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json|--jsonl|--table|--raw]
+canarchy stats --file <path> [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json|--jsonl|--text|--raw]
+canarchy stats --file - [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json|--jsonl|--text|--raw]
 ```
 
 Notes:
@@ -173,14 +173,14 @@ Notes:
 Generate CAN frames from explicit, random, or incrementing inputs.
 
 ```bash
-canarchy generate <interface> [--id <hex|R>] [--dlc <0-8|R>] [--data <hex|R|I>] [--count <n>] [--gap <ms>] [--extended] [--ack-active] [--json|--jsonl|--table|--raw]
+canarchy generate <interface> [--id <hex|R>] [--dlc <0-8|R>] [--data <hex|R|I>] [--count <n>] [--gap <ms>] [--extended] [--ack-active] [--json|--jsonl|--text|--raw]
 ```
 
 Examples:
 
 ```bash
 canarchy generate can0 --id 0x123 --dlc 4 --data 11223344 --count 2 --gap 100 --json
-canarchy generate can0 --data I --count 4 --table
+canarchy generate can0 --data I --count 4 --text
 ```
 
 Notes:
@@ -195,7 +195,7 @@ Notes:
 Replay a capture source with deterministic timing derived from relative frame timestamps.
 
 ```bash
-canarchy replay --file <path> [--rate <factor>] [--json|--jsonl|--table|--raw]
+canarchy replay --file <path> [--rate <factor>] [--json|--jsonl|--text|--raw]
 ```
 
 Example:
@@ -209,13 +209,13 @@ canarchy replay --file tests/fixtures/sample.candump --rate 2.0 --json
 Bridge frames from one live CAN interface to another through the `python-can` backend.
 
 ```bash
-canarchy gateway <src> <dst> [--src-backend <type>] [--dst-backend <type>] [--bidirectional] [--count <n>] [--ack-active] [--json|--jsonl|--table|--raw]
+canarchy gateway <src> <dst> [--src-backend <type>] [--dst-backend <type>] [--bidirectional] [--count <n>] [--ack-active] [--json|--jsonl|--text|--raw]
 ```
 
 Examples:
 
 ```bash
-canarchy gateway can0 can1 --table
+canarchy gateway can0 can1 --text
 canarchy gateway can0 239.0.0.1 --dst-backend udp_multicast --count 10 --json
 ```
 
@@ -224,7 +224,7 @@ Notes:
 * `gateway` requires the `python-can` backend (set in `~/.canarchy/config.toml` or via `CANARCHY_TRANSPORT_BACKEND=python-can`)
 * `--src-backend` and `--dst-backend` default to the configured `interface` value
 * `--ack-active` requests an interactive `YES` confirmation before forwarding begins
-* default table and raw output use candump-style forwarded frame lines with direction labels such as `[src->dst]`
+* default text and raw output use candump-style forwarded frame lines with direction labels such as `[src->dst]`
 * `--json` returns a standard command envelope; `--jsonl` emits one forwarded event per line for `gateway`
 
 ### export
@@ -232,7 +232,7 @@ Notes:
 Export structured artifacts for later analysis.
 
 ```bash
-canarchy export <source> <destination> [--json|--jsonl|--table|--raw]
+canarchy export <source> <destination> [--json|--jsonl|--text|--raw]
 ```
 
 Examples:
@@ -255,8 +255,8 @@ Notes:
 Decode frames from a capture source using a DBC file.
 
 ```bash
-canarchy decode --file <file> --dbc <file> [--json|--jsonl|--table|--raw]
-canarchy decode --stdin --dbc <file> [--json|--jsonl|--table|--raw]
+canarchy decode --file <file> --dbc <file> [--json|--jsonl|--text|--raw]
+canarchy decode --stdin --dbc <file> [--json|--jsonl|--text|--raw]
 ```
 
 Example:
@@ -276,7 +276,7 @@ Notes:
 Encode a DBC message into a frame payload.
 
 ```bash
-canarchy encode --dbc <file> <message> <signal=value>... [--json|--jsonl|--table|--raw]
+canarchy encode --dbc <file> <message> <signal=value>... [--json|--jsonl|--text|--raw]
 ```
 
 Example:
@@ -295,7 +295,7 @@ Notes:
 Inspect database, message, and signal metadata for a DBC file or provider ref.
 
 ```bash
-canarchy dbc inspect <dbc> [--message <name>] [--signals-only] [--json|--jsonl|--table|--raw]
+canarchy dbc inspect <dbc> [--message <name>] [--signals-only] [--json|--jsonl|--text|--raw]
 ```
 
 Examples:
@@ -315,7 +315,7 @@ Notes:
 List registered DBC providers.
 
 ```bash
-canarchy dbc provider list [--json|--jsonl|--table|--raw]
+canarchy dbc provider list [--json|--jsonl|--text|--raw]
 ```
 
 ### dbc search
@@ -323,7 +323,7 @@ canarchy dbc provider list [--json|--jsonl|--table|--raw]
 Search DBC catalogs across enabled providers.
 
 ```bash
-canarchy dbc search <query> [--provider <name>] [--limit <n>] [--json|--jsonl|--table|--raw]
+canarchy dbc search <query> [--provider <name>] [--limit <n>] [--json|--jsonl|--text|--raw]
 ```
 
 Example:
@@ -337,7 +337,7 @@ canarchy dbc search toyota --provider opendbc --limit 5 --json
 Fetch and cache a DBC file from a provider.
 
 ```bash
-canarchy dbc fetch <ref> [--json|--jsonl|--table|--raw]
+canarchy dbc fetch <ref> [--json|--jsonl|--text|--raw]
 ```
 
 Example:
@@ -351,7 +351,7 @@ canarchy dbc fetch opendbc:toyota_tnga_k_pt_generated --json
 List cached provider manifests.
 
 ```bash
-canarchy dbc cache list [--json|--jsonl|--table|--raw]
+canarchy dbc cache list [--json|--jsonl|--text|--raw]
 ```
 
 ### dbc cache prune
@@ -359,7 +359,7 @@ canarchy dbc cache list [--json|--jsonl|--table|--raw]
 Remove stale cached provider snapshots while keeping the pinned commit.
 
 ```bash
-canarchy dbc cache prune [--provider <name>] [--json|--jsonl|--table|--raw]
+canarchy dbc cache prune [--provider <name>] [--json|--jsonl|--text|--raw]
 ```
 
 ### dbc cache refresh
@@ -367,7 +367,7 @@ canarchy dbc cache prune [--provider <name>] [--json|--jsonl|--table|--raw]
 Refresh a provider catalog from upstream.
 
 ```bash
-canarchy dbc cache refresh [--provider <name>] [--json|--jsonl|--table|--raw]
+canarchy dbc cache refresh [--provider <name>] [--json|--jsonl|--text|--raw]
 ```
 
 Notes:
@@ -381,7 +381,7 @@ Notes:
 List registered repository-backed skills providers.
 
 ```bash
-canarchy skills provider list [--json|--jsonl|--table|--raw]
+canarchy skills provider list [--json|--jsonl|--text|--raw]
 ```
 
 ### skills search
@@ -389,7 +389,7 @@ canarchy skills provider list [--json|--jsonl|--table|--raw]
 Search repository-backed skills catalogs by name, tag, or keyword.
 
 ```bash
-canarchy skills search <query> [--provider <name>] [--limit <n>] [--json|--jsonl|--table|--raw]
+canarchy skills search <query> [--provider <name>] [--limit <n>] [--json|--jsonl|--text|--raw]
 ```
 
 Example:
@@ -403,7 +403,7 @@ canarchy skills search j1939 --provider github --json
 Fetch and cache a repository-backed skill locally.
 
 ```bash
-canarchy skills fetch <provider>:<skill> [--json|--jsonl|--table|--raw]
+canarchy skills fetch <provider>:<skill> [--json|--jsonl|--text|--raw]
 ```
 
 Example:
@@ -417,7 +417,7 @@ canarchy skills fetch github:j1939_compare_triage --json
 List cached skills provider manifests.
 
 ```bash
-canarchy skills cache list [--json|--jsonl|--table|--raw]
+canarchy skills cache list [--json|--jsonl|--text|--raw]
 ```
 
 ### skills cache refresh
@@ -425,7 +425,7 @@ canarchy skills cache list [--json|--jsonl|--table|--raw]
 Refresh a skills provider catalog from upstream.
 
 ```bash
-canarchy skills cache refresh [--provider <name>] [--json|--jsonl|--table|--raw]
+canarchy skills cache refresh [--provider <name>] [--json|--jsonl|--text|--raw]
 ```
 
 Notes:
@@ -440,7 +440,7 @@ Notes:
 List registered public CAN dataset providers.
 
 ```bash
-canarchy datasets provider list [--json|--jsonl|--table|--raw]
+canarchy datasets provider list [--json|--jsonl|--text|--raw]
 ```
 
 ### datasets search
@@ -448,7 +448,7 @@ canarchy datasets provider list [--json|--jsonl|--table|--raw]
 Search public CAN dataset provider catalogs by name, protocol, or keyword.
 
 ```bash
-canarchy datasets search [query] [--provider <name>] [--limit <n>] [--verbose] [--json|--jsonl|--table|--raw]
+canarchy datasets search [query] [--provider <name>] [--limit <n>] [--verbose] [--json|--jsonl|--text|--raw]
 ```
 
 ### datasets inspect
@@ -456,7 +456,7 @@ canarchy datasets search [query] [--provider <name>] [--limit <n>] [--verbose] [
 Show full metadata for a dataset ref.
 
 ```bash
-canarchy datasets inspect <provider>:<dataset> [--json|--jsonl|--table|--raw]
+canarchy datasets inspect <provider>:<dataset> [--json|--jsonl|--text|--raw]
 ```
 
 Examples:
@@ -477,7 +477,7 @@ Notes:
 Record dataset provenance in the local cache. This does not download large dataset payloads.
 
 ```bash
-canarchy datasets fetch <provider>:<dataset> [--json|--jsonl|--table|--raw]
+canarchy datasets fetch <provider>:<dataset> [--json|--jsonl|--text|--raw]
 ```
 
 Notes:
@@ -490,7 +490,7 @@ Notes:
 List cached dataset provider manifests and provenance records.
 
 ```bash
-canarchy datasets cache list [--json|--jsonl|--table|--raw]
+canarchy datasets cache list [--json|--jsonl|--text|--raw]
 ```
 
 ### datasets cache refresh
@@ -498,7 +498,7 @@ canarchy datasets cache list [--json|--jsonl|--table|--raw]
 Refresh the built-in dataset catalog manifest.
 
 ```bash
-canarchy datasets cache refresh [--provider <name>] [--json|--jsonl|--table|--raw]
+canarchy datasets cache refresh [--provider <name>] [--json|--jsonl|--text|--raw]
 ```
 
 ### datasets convert
@@ -506,7 +506,7 @@ canarchy datasets cache refresh [--provider <name>] [--json|--jsonl|--table|--ra
 Convert a downloaded dataset file to a CANarchy-compatible capture format.
 
 ```bash
-canarchy datasets convert <file> --source-format hcrl-csv --format candump|jsonl [--output <path>] [--json|--jsonl|--table|--raw]
+canarchy datasets convert <file> --source-format hcrl-csv --format candump|jsonl [--output <path>] [--json|--jsonl|--text|--raw]
 ```
 
 ### datasets stream
@@ -578,7 +578,7 @@ Notes:
 Save a named session with useful CLI context.
 
 ```bash
-canarchy session save <name> [--interface <name>] [--dbc <file>] [--capture <file>] [--json|--jsonl|--table|--raw]
+canarchy session save <name> [--interface <name>] [--dbc <file>] [--capture <file>] [--json|--jsonl|--text|--raw]
 ```
 
 ### session load
@@ -586,7 +586,7 @@ canarchy session save <name> [--interface <name>] [--dbc <file>] [--capture <fil
 Load a previously saved session and mark it active.
 
 ```bash
-canarchy session load <name> [--json|--jsonl|--table|--raw]
+canarchy session load <name> [--json|--jsonl|--text|--raw]
 ```
 
 ### session show
@@ -594,7 +594,7 @@ canarchy session load <name> [--json|--jsonl|--table|--raw]
 Show saved sessions and the active session.
 
 ```bash
-canarchy session show [--json|--jsonl|--table|--raw]
+canarchy session show [--json|--jsonl|--text|--raw]
 ```
 
 ### shell
@@ -602,7 +602,7 @@ canarchy session show [--json|--jsonl|--table|--raw]
 Run a single shell command through the shared parser, or start a minimal interactive shell loop.
 
 ```bash
-canarchy shell [--command "capture can0 --raw"] [--json|--jsonl|--table|--raw]
+canarchy shell [--command "capture can0 --raw"] [--json|--jsonl|--text|--raw]
 ```
 
 ### j1939 monitor
@@ -610,7 +610,7 @@ canarchy shell [--command "capture can0 --raw"] [--json|--jsonl|--table|--raw]
 Inspect J1939 traffic and emit PGN-oriented structured events.
 
 ```bash
-canarchy j1939 monitor [<interface>] [--pgn <id>] [--json|--jsonl|--table|--raw]
+canarchy j1939 monitor [<interface>] [--pgn <id>] [--json|--jsonl|--text|--raw]
 ```
 
 Example:
@@ -631,8 +631,8 @@ Notes:
 Decode a capture source into J1939 PGN observations.
 
 ```bash
-canarchy j1939 decode --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--table|--raw]
-canarchy j1939 decode --stdin [--dbc <path|provider-ref>] [--json|--jsonl|--table|--raw]
+canarchy j1939 decode --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--text|--raw]
+canarchy j1939 decode --stdin [--dbc <path|provider-ref>] [--json|--jsonl|--text|--raw]
 ```
 
 Notes:
@@ -645,7 +645,7 @@ Notes:
 Inspect events for a specific PGN from a capture file.
 
 ```bash
-canarchy j1939 pgn <pgn> --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--table|--raw]
+canarchy j1939 pgn <pgn> --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--text|--raw]
 ```
 
 Example:
@@ -659,7 +659,7 @@ canarchy j1939 pgn 65262 --file tests/fixtures/sample.candump --json
 Inspect a curated SPN decoder over recorded J1939 traffic.
 
 ```bash
-canarchy j1939 spn <spn> --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--table|--raw]
+canarchy j1939 spn <spn> --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--text|--raw]
 ```
 
 Example:
@@ -679,7 +679,7 @@ Notes:
 Summarize J1939 transport-protocol sessions from a capture file.
 
 ```bash
-canarchy j1939 tp sessions --file <file> [--json|--jsonl|--table|--raw]
+canarchy j1939 tp sessions --file <file> [--json|--jsonl|--text|--raw]
 ```
 
 Notes:
@@ -691,7 +691,7 @@ Notes:
 Inspect DM1 fault traffic from direct J1939 frames and TP-reassembled payloads.
 
 ```bash
-canarchy j1939 dm1 --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--table|--raw]
+canarchy j1939 dm1 --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--text|--raw]
 ```
 
 ### j1939 faults
@@ -699,7 +699,7 @@ canarchy j1939 dm1 --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--t
 Summarize active DM1 faults by ECU/source address, including lamp state and suspicious DTC markers.
 
 ```bash
-canarchy j1939 faults --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--table|--raw]
+canarchy j1939 faults --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--text|--raw]
 ```
 
 ### j1939 inventory
@@ -707,7 +707,7 @@ canarchy j1939 faults --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|
 Build a source-address inventory from a J1939 capture file, including top PGNs, component-identification strings, vehicle-identification strings, and DM1 presence.
 
 ```bash
-canarchy j1939 inventory --file <file> [--json|--jsonl|--table|--raw]
+canarchy j1939 inventory --file <file> [--json|--jsonl|--text|--raw]
 ```
 
 Example:
@@ -727,7 +727,7 @@ Notes:
 Compare two or more J1939 capture files and highlight common versus capture-unique PGNs, source-address changes, DM1 differences, and printable TP identification changes.
 
 ```bash
-canarchy j1939 compare <file> <file> [<file> ...] [--json|--jsonl|--table|--raw]
+canarchy j1939 compare <file> <file> [<file> ...] [--json|--jsonl|--text|--raw]
 ```
 
 Example:
@@ -763,7 +763,7 @@ Notes:
 Inspect representative UDS responder discovery transactions.
 
 ```bash
-canarchy uds scan <interface> [--ack-active] [--json|--jsonl|--table|--raw]
+canarchy uds scan <interface> [--ack-active] [--json|--jsonl|--text|--raw]
 ```
 
 Notes:
@@ -778,7 +778,7 @@ Notes:
 Inspect representative UDS request and response transactions.
 
 ```bash
-canarchy uds trace <interface> [--json|--jsonl|--table|--raw]
+canarchy uds trace <interface> [--json|--jsonl|--text|--raw]
 ```
 
 Notes:
@@ -793,7 +793,7 @@ Notes:
 Inspect the built-in UDS service catalog.
 
 ```bash
-canarchy uds services [--json|--jsonl|--table|--raw]
+canarchy uds services [--json|--jsonl|--text|--raw]
 ```
 
 Notes:
@@ -806,7 +806,7 @@ Notes:
 Rank likely counter fields from recorded CAN traffic.
 
 ```bash
-canarchy re counters <file> [--json|--jsonl|--table|--raw]
+canarchy re counters <file> [--json|--jsonl|--text|--raw]
 ```
 
 Notes:
@@ -820,7 +820,7 @@ Notes:
 Rank likely signal fields from recorded CAN traffic.
 
 ```bash
-canarchy re signals <file> [--json|--jsonl|--table|--raw]
+canarchy re signals <file> [--json|--jsonl|--text|--raw]
 ```
 
 Notes:
@@ -835,7 +835,7 @@ Notes:
 Correlate candidate bit fields against a timestamped reference series.
 
 ```bash
-canarchy re correlate <file> --reference <ref.json|ref.jsonl> [--json|--jsonl|--table|--raw]
+canarchy re correlate <file> --reference <ref.json|ref.jsonl> [--json|--jsonl|--text|--raw]
 ```
 
 Notes:
@@ -850,7 +850,7 @@ Notes:
 Rank arbitration IDs and byte positions by Shannon entropy over recorded CAN traffic.
 
 ```bash
-canarchy re entropy <file> [--json|--jsonl|--table|--raw]
+canarchy re entropy <file> [--json|--jsonl|--text|--raw]
 ```
 
 Notes:
@@ -864,7 +864,7 @@ Notes:
 Rank candidate DBC files against a capture using provider-backed catalog metadata.
 
 ```bash
-canarchy re match-dbc <capture> [--provider <name>] [--limit <n>] [--json|--jsonl|--table|--raw]
+canarchy re match-dbc <capture> [--provider <name>] [--limit <n>] [--json|--jsonl|--text|--raw]
 ```
 
 Notes:
@@ -878,7 +878,7 @@ Notes:
 Rank candidate DBC files against a capture after pre-filtering by vehicle make.
 
 ```bash
-canarchy re shortlist-dbc <capture> --make <brand> [--provider <name>] [--limit <n>] [--json|--jsonl|--table|--raw]
+canarchy re shortlist-dbc <capture> --make <brand> [--provider <name>] [--limit <n>] [--json|--jsonl|--text|--raw]
 ```
 
 Notes:
@@ -892,7 +892,7 @@ Notes:
 Inspect the effective transport configuration and the source of each setting.
 
 ```bash
-canarchy config show [--json|--jsonl|--table|--raw]
+canarchy config show [--json|--jsonl|--text|--raw]
 ```
 
 ### mcp serve
@@ -916,8 +916,10 @@ All commands support:
 
 * `--json`
 * `--jsonl`
-* `--table`
+* `--text`
 * `--raw`
+
+`--text` is the default when no output mode is specified. `--table` remains accepted as a compatibility alias for `--text`, but new examples and automation should use `--text`.
 
 Current behavior:
 
@@ -926,10 +928,10 @@ Current behavior:
 * event-producing commands emit each event as its own JSON line; command warnings that are not already events are emitted as `alert` event lines
 * event-less successful commands emit a single result object line
 * failed commands emit a single error result object line
-* `--table` emits a human-readable summary view, with protocol-aware pretty-printing for J1939 monitor and decode workflows
+* `--text` emits a human-readable summary view, with protocol-aware pretty-printing for J1939 monitor and decode workflows
 * `--raw` emits the command name on success or the primary error message on failure
 
-J1939 `--table` output includes:
+J1939 `--text` output includes:
 
 * PGN
 * source address

--- a/docs/design/active-command-safety.md
+++ b/docs/design/active-command-safety.md
@@ -33,14 +33,14 @@ Operators and automation need active workflows to remain scriptable, but active 
 ## Command Surface
 
 ```text
-canarchy send <interface> <frame-id> <hex-data> [--ack-active] [--json] [--jsonl] [--table] [--raw]
+canarchy send <interface> <frame-id> <hex-data> [--ack-active] [--json] [--jsonl] [--text] [--raw]
 canarchy generate <interface> [--id <hex|R>] [--dlc <0-8|R>] [--data <hex|R|I>]
                            [--count <n>] [--gap <ms>] [--extended] [--ack-active]
-                           [--json] [--jsonl] [--table] [--raw]
+                           [--json] [--jsonl] [--text] [--raw]
 canarchy gateway <src> <dst> [--src-backend <name>] [--dst-backend <name>]
                             [--bidirectional] [--count <n>] [--ack-active]
-                            [--json] [--jsonl] [--table] [--raw]
-canarchy uds scan <interface> [--ack-active] [--json] [--jsonl] [--table] [--raw]
+                            [--json] [--jsonl] [--text] [--raw]
+canarchy uds scan <interface> [--ack-active] [--json] [--jsonl] [--text] [--raw]
 ```
 
 ## Responsibilities And Boundaries

--- a/docs/design/composition.md
+++ b/docs/design/composition.md
@@ -31,9 +31,9 @@ Operators and coding agents should be able to connect commands with pipes instea
 ## Command Surface
 
 ```text
-canarchy decode --dbc <file> --stdin [--json|--jsonl|--table|--raw]
-canarchy filter <expression> --stdin [--json|--jsonl|--table|--raw]
-canarchy j1939 decode --stdin [--json|--jsonl|--table|--raw]
+canarchy decode --dbc <file> --stdin [--json|--jsonl|--text|--raw]
+canarchy filter <expression> --stdin [--json|--jsonl|--text|--raw]
+canarchy j1939 decode --stdin [--json|--jsonl|--text|--raw]
 ```
 
 Representative usage:

--- a/docs/design/config-show-command.md
+++ b/docs/design/config-show-command.md
@@ -28,12 +28,12 @@ Operators need an inspectable way to answer basic configuration questions such a
 | `REQ-CONFIG-05` | Optional feature | Where a value is set in the config file and not overridden by the environment, the system shall use the config-file value and mark its source as `file`. |
 | `REQ-CONFIG-06` | State-driven | While no environment or config-file override exists for a supported setting, the system shall use the built-in default and mark its source as `default`. |
 | `REQ-CONFIG-07` | Ubiquitous | The `config show` result shall report the resolved config-file path and whether that file currently exists. |
-| `REQ-CONFIG-08` | Ubiquitous | `config show` shall preserve the standard output modes (`--json`, `--jsonl`, `--table`, `--raw`) with command-specific formatting over the same configuration payload. |
+| `REQ-CONFIG-08` | Ubiquitous | `config show` shall preserve the standard output modes (`--json`, `--jsonl`, `--text`, `--raw`) with command-specific formatting over the same configuration payload. |
 
 ## Command Surface
 
 ```text
-canarchy config show [--json] [--jsonl] [--table] [--raw]
+canarchy config show [--json] [--jsonl] [--text] [--raw]
 ```
 
 ## Responsibilities And Boundaries
@@ -78,7 +78,7 @@ The `sources` object includes one source entry for each effective configuration 
 
 ### Table
 
-`--table` renders a human-readable configuration summary that shows each effective value together with its source annotation and ends with the config-file path plus its found/not-found status.
+`--text` renders a human-readable configuration summary that shows each effective value together with its source annotation and ends with the config-file path plus its found/not-found status.
 
 ### Raw
 

--- a/docs/design/dataset-provider-workflow.md
+++ b/docs/design/dataset-provider-workflow.md
@@ -35,7 +35,7 @@ canarchy datasets stream <file> --source-format hcrl-csv|candump --format candum
 canarchy datasets replay <dataset-ref-or-url> [--file <id-or-name>] [--list-files] [--format candump|jsonl] [--rate N] [--max-frames N] [--max-seconds N] [--dry-run]
 ```
 
-All commands follow the standard `--json`, `--jsonl`, `--table`, `--raw` output modes.
+All commands follow the standard `--json`, `--jsonl`, `--text`, `--raw` output modes.
 
 ---
 

--- a/docs/design/dbc-command-workflows.md
+++ b/docs/design/dbc-command-workflows.md
@@ -31,9 +31,9 @@ DBC-backed workflows are central to protocol-aware CAN analysis. Operators shoul
 ## Command Surface
 
 ```text
-canarchy decode --file <file> --dbc <file> [--json] [--jsonl] [--table] [--raw]
-canarchy decode --stdin --dbc <file> [--json] [--jsonl] [--table] [--raw]
-canarchy encode --dbc <file> <message> <signal=value>... [--json] [--jsonl] [--table] [--raw]
+canarchy decode --file <file> --dbc <file> [--json] [--jsonl] [--text] [--raw]
+canarchy decode --stdin --dbc <file> [--json] [--jsonl] [--text] [--raw]
+canarchy encode --dbc <file> <message> <signal=value>... [--json] [--jsonl] [--text] [--raw]
 ```
 
 ## Responsibilities And Boundaries
@@ -65,7 +65,7 @@ Event-producing commands emit one event per line; warnings without corresponding
 
 ### Table and raw
 
-Use the shared table/raw result rendering path.
+Use the shared text/raw result rendering path.
 
 ## Error Contracts
 

--- a/docs/design/dbc-inspect-command.md
+++ b/docs/design/dbc-inspect-command.md
@@ -33,7 +33,7 @@ Operators often need to answer questions such as which messages exist in a datab
 ## Command Surface
 
 ```text
-canarchy dbc inspect <dbc> [--message <name>] [--signals-only] [--json] [--jsonl] [--table] [--raw]
+canarchy dbc inspect <dbc> [--message <name>] [--signals-only] [--json] [--jsonl] [--text] [--raw]
 ```
 
 ### Arguments
@@ -173,7 +173,7 @@ Representative lines:
 
 ### Table
 
-`--table` returns a compact summary view.
+`--text` returns a compact summary view.
 
 ```text
 command: dbc inspect

--- a/docs/design/dbc-provider-workflows.md
+++ b/docs/design/dbc-provider-workflows.md
@@ -39,16 +39,16 @@ Operators often have a capture before they have the matching DBC on disk. CANarc
 ## Command Surface
 
 ```text
-canarchy dbc provider list [--json] [--jsonl] [--table] [--raw]
-canarchy dbc search <query> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--table] [--raw]
-canarchy dbc fetch <ref> [--json] [--jsonl] [--table] [--raw]
-canarchy dbc cache list [--json] [--jsonl] [--table] [--raw]
-canarchy dbc cache prune [--provider <name>] [--json] [--jsonl] [--table] [--raw]
-canarchy dbc cache refresh [--provider <name>] [--json] [--jsonl] [--table] [--raw]
-canarchy decode --file <file> --dbc <path|provider-ref> [--json] [--jsonl] [--table] [--raw]
-canarchy decode --stdin --dbc <path|provider-ref> [--json] [--jsonl] [--table] [--raw]
-canarchy encode --dbc <path|provider-ref> <message> <signal=value>... [--json] [--jsonl] [--table] [--raw]
-canarchy dbc inspect <path|provider-ref> [--message <name>] [--signals-only] [--json] [--jsonl] [--table] [--raw]
+canarchy dbc provider list [--json] [--jsonl] [--text] [--raw]
+canarchy dbc search <query> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--text] [--raw]
+canarchy dbc fetch <ref> [--json] [--jsonl] [--text] [--raw]
+canarchy dbc cache list [--json] [--jsonl] [--text] [--raw]
+canarchy dbc cache prune [--provider <name>] [--json] [--jsonl] [--text] [--raw]
+canarchy dbc cache refresh [--provider <name>] [--json] [--jsonl] [--text] [--raw]
+canarchy decode --file <file> --dbc <path|provider-ref> [--json] [--jsonl] [--text] [--raw]
+canarchy decode --stdin --dbc <path|provider-ref> [--json] [--jsonl] [--text] [--raw]
+canarchy encode --dbc <path|provider-ref> <message> <signal=value>... [--json] [--jsonl] [--text] [--raw]
+canarchy dbc inspect <path|provider-ref> [--message <name>] [--signals-only] [--json] [--jsonl] [--text] [--raw]
 ```
 
 ## Responsibilities And Boundaries

--- a/docs/design/dbc-runtime-schema-split.md
+++ b/docs/design/dbc-runtime-schema-split.md
@@ -15,7 +15,7 @@ Define an internal DBC architecture that preserves CANarchy's stable CLI and eve
 
 ## User-Facing Motivation
 
-Operators and agents need richer database-aware workflows than the current thin DBC layer provides, but they also need stable outputs. A split architecture lets CANarchy adopt `cantools` where runtime metadata and validation matter, while retaining `canmatrix` for schema ingestion and future conversion-oriented workflows.
+Operators and agents need richer database-aware workflows than the current thin DBC layer provides, but they also need stext outputs. A split architecture lets CANarchy adopt `cantools` where runtime metadata and validation matter, while retaining `canmatrix` for schema ingestion and future conversion-oriented workflows.
 
 ## Requirements
 
@@ -32,10 +32,10 @@ Operators and agents need richer database-aware workflows than the current thin 
 ## Command Surface
 
 ```text
-canarchy decode --file <file> --dbc <file> [--json] [--jsonl] [--table] [--raw]
-canarchy decode --stdin --dbc <file> [--json] [--jsonl] [--table] [--raw]
-canarchy encode --dbc <file> <message> <signal=value>... [--json] [--jsonl] [--table] [--raw]
-canarchy dbc inspect <dbc> [--message <name>] [--signals-only] [--json] [--jsonl] [--table] [--raw]
+canarchy decode --file <file> --dbc <file> [--json] [--jsonl] [--text] [--raw]
+canarchy decode --stdin --dbc <file> [--json] [--jsonl] [--text] [--raw]
+canarchy encode --dbc <file> <message> <signal=value>... [--json] [--jsonl] [--text] [--raw]
+canarchy dbc inspect <dbc> [--message <name>] [--signals-only] [--json] [--jsonl] [--text] [--raw]
 ```
 
 Future schema-management commands are expected to live under a separate `canarchy db ...` namespace.
@@ -110,7 +110,7 @@ All phases complete as of April 2026:
 | Phase | Status | Description |
 |-------|--------|-------------|
 | Phase 1 | Done | Internal metadata types in `dbc_types.py`, facade at `dbc.py`, `DBC_SIGNAL_INVALID` aligned, fixtures expanded |
-| Phase 2 | Done | `canarchy dbc inspect` implemented, JSON/JSONL/table/raw outputs, MCP exposed |
+| Phase 2 | Done | `canarchy dbc inspect` implemented, JSON/JSONL/text/raw outputs, MCP exposed |
 | Phase 3 | Done | cantools runtime adapter at `dbc_runtime.py`, decode/encode switched, fixture parity verified |
 | Phase 4 | Deferred | canmatrix retained for future schema workflows |
 | Phase 5 | Deferred | Evaluate long-term dependency strategy later |

--- a/docs/design/export-command.md
+++ b/docs/design/export-command.md
@@ -10,7 +10,7 @@
 
 ## Goal
 
-Preserve structured CANarchy artifacts on disk so operators and coding agents can save event streams and session state for later analysis without scraping table output.
+Preserve structured CANarchy artifacts on disk so operators and coding agents can save event streams and session state for later analysis without scraping text output.
 
 ## User-Facing Motivation
 
@@ -33,7 +33,7 @@ Operators need a deterministic way to persist machine-readable results from curr
 ## Command Surface
 
 ```text
-canarchy export <source> <destination> [--json] [--jsonl] [--table] [--raw]
+canarchy export <source> <destination> [--json] [--jsonl] [--text] [--raw]
 ```
 
 ### Supported source forms

--- a/docs/design/gateway-command.md
+++ b/docs/design/gateway-command.md
@@ -36,7 +36,7 @@ canarchy gateway <src> <dst>
                  [--src-backend TYPE] [--dst-backend TYPE]
                  [--bidirectional]
                  [--count N]
-                 [--json] [--jsonl] [--table] [--raw]
+                 [--json] [--jsonl] [--text] [--raw]
 ```
 
 ### Arguments

--- a/docs/design/generate-command.md
+++ b/docs/design/generate-command.md
@@ -37,7 +37,7 @@ Operators need a quick active-traffic workflow for lab validation, replay suppor
 ```text
 canarchy generate <interface> [--id <hex|R>] [--dlc <0-8|R>] [--data <hex|R|I>]
                                [--count <n>] [--gap <ms>] [--extended] [--ack-active]
-                               [--json] [--jsonl] [--table] [--raw]
+                               [--json] [--jsonl] [--text] [--raw]
 ```
 
 ### Arguments

--- a/docs/design/j1939-bounded-analysis.md
+++ b/docs/design/j1939-bounded-analysis.md
@@ -32,12 +32,12 @@ Large heavy-vehicle captures often contain millions of frames. Analysts need to 
 ## Command Surface
 
 ```text
-canarchy j1939 decode --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--table] [--raw]
-canarchy j1939 decode --stdin [--dbc <path|provider-ref>] [--json] [--jsonl] [--table] [--raw]
-canarchy j1939 pgn <pgn> --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--table] [--raw]
-canarchy j1939 spn <spn> --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--table] [--raw]
-canarchy j1939 tp sessions --file <capture> [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--table] [--raw]
-canarchy j1939 dm1 --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--table] [--raw]
+canarchy j1939 decode --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--text] [--raw]
+canarchy j1939 decode --stdin [--dbc <path|provider-ref>] [--json] [--jsonl] [--text] [--raw]
+canarchy j1939 pgn <pgn> --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--text] [--raw]
+canarchy j1939 spn <spn> --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--text] [--raw]
+canarchy j1939 tp sessions --file <capture> [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--text] [--raw]
+canarchy j1939 dm1 --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--text] [--raw]
 ```
 
 ## Responsibilities And Boundaries

--- a/docs/design/j1939-expanded-workflows.md
+++ b/docs/design/j1939-expanded-workflows.md
@@ -211,7 +211,7 @@ The compare view is intended to answer high-value investigation questions quickl
 
 ## Output Contracts
 
-For `j1939 spn`, `j1939 tp sessions`, `j1939 dm1`, `j1939 inventory`, and `j1939 compare`, both `--json` and `--jsonl` emit a single CANarchy result object because these commands return structured observations under `data` rather than event streams. Table output remains protocol-first and summarises SPN observations, TP sessions, DM1 fault content, source-address inventory rows, and multi-capture J1939 differences without dropping to raw-ID-only views. For `j1939 tp sessions`, raw `reassembled_data` remains authoritative even when heuristic text or payload labels are present.
+For `j1939 spn`, `j1939 tp sessions`, `j1939 dm1`, `j1939 inventory`, and `j1939 compare`, both `--json` and `--jsonl` emit a single CANarchy result object because these commands return structured observations under `data` rather than event streams. Text output remains protocol-first and summarises SPN observations, TP sessions, DM1 fault content, source-address inventory rows, and multi-capture J1939 differences without dropping to raw-ID-only views. For `j1939 tp sessions`, raw `reassembled_data` remains authoritative even when heuristic text or payload labels are present.
 
 ## Error Contracts
 

--- a/docs/design/j1939-first-class-decoder.md
+++ b/docs/design/j1939-first-class-decoder.md
@@ -30,19 +30,19 @@ Operators need J1939 commands that scale beyond a demo-only SPN map. They should
 | `REQ-J1939F-05` | Optional feature | Where `--dbc <path|provider-ref>` is specified for a J1939 decode workflow, the system shall enrich protocol-aware results with DBC-backed signal metadata and values when the supplied DBC contains a matching J1939 definition. |
 | `REQ-J1939F-10` | Optional feature | Where no `--dbc` flag is supplied and a default J1939 DBC is configured through `CANARCHY_J1939_DBC` or `[j1939].dbc`, the system shall use that configured DBC for J1939 DBC enrichment workflows. |
 | `REQ-J1939F-06` | Event-driven | When `j1939 spn <spn>` is invoked, the system shall resolve the requested SPN through the library-backed metadata path and optional DBC input rather than limiting decode to the current curated starter map. |
-| `REQ-J1939F-07` | Ubiquitous | The system shall preserve the existing command names and standard output modes (`--json`, `--jsonl`, `--table`, `--raw`) while upgrading the decoder implementation. |
+| `REQ-J1939F-07` | Ubiquitous | The system shall preserve the existing command names and standard output modes (`--json`, `--jsonl`, `--text`, `--raw`) while upgrading the decoder implementation. |
 | `REQ-J1939F-08` | Unwanted behaviour | If the configured J1939 decoder backend cannot be initialized, the system shall return a structured error with code `J1939_DECODER_UNAVAILABLE` and exit code `3`. |
 | `REQ-J1939F-09` | Unwanted behaviour | If `j1939 spn <spn>` is requested and neither the library metadata nor an optional DBC can resolve that SPN, the system shall return a structured error with code `J1939_SPN_NOT_FOUND` and exit code `1`. |
 
 ## Command Surface
 
 ```text
-canarchy j1939 decode --file <capture> [--dbc <path|provider-ref>] [--json] [--jsonl] [--table] [--raw]
-canarchy j1939 decode --stdin [--dbc <path|provider-ref>] [--json] [--jsonl] [--table] [--raw]
-canarchy j1939 pgn <pgn> --file <capture> [--dbc <path|provider-ref>] [--json] [--jsonl] [--table] [--raw]
-canarchy j1939 spn <spn> --file <capture> [--dbc <path|provider-ref>] [--json] [--jsonl] [--table] [--raw]
-canarchy j1939 tp sessions --file <capture> [--json] [--jsonl] [--table] [--raw]
-canarchy j1939 dm1 --file <capture> [--dbc <path|provider-ref>] [--json] [--jsonl] [--table] [--raw]
+canarchy j1939 decode --file <capture> [--dbc <path|provider-ref>] [--json] [--jsonl] [--text] [--raw]
+canarchy j1939 decode --stdin [--dbc <path|provider-ref>] [--json] [--jsonl] [--text] [--raw]
+canarchy j1939 pgn <pgn> --file <capture> [--dbc <path|provider-ref>] [--json] [--jsonl] [--text] [--raw]
+canarchy j1939 spn <spn> --file <capture> [--dbc <path|provider-ref>] [--json] [--jsonl] [--text] [--raw]
+canarchy j1939 tp sessions --file <capture> [--json] [--jsonl] [--text] [--raw]
+canarchy j1939 dm1 --file <capture> [--dbc <path|provider-ref>] [--json] [--jsonl] [--text] [--raw]
 
 # optional defaults
 # ~/.canarchy/config.toml

--- a/docs/design/j1939-monitor-command.md
+++ b/docs/design/j1939-monitor-command.md
@@ -26,12 +26,12 @@ Operators need a fast way to inspect live or sample J1939 traffic as PGN-oriente
 | `REQ-J1939MON-03` | Event-driven | When `j1939 monitor <interface>` is invoked, the system shall use the transport-backed monitor path and include the selected interface in the structured result. |
 | `REQ-J1939MON-04` | Optional feature | Where `--pgn <id>` is specified, the system shall restrict emitted observations to the selected PGN and echo the filter value in the structured result. |
 | `REQ-J1939MON-05` | Ubiquitous | The `j1939 monitor` result envelope shall expose passive-mode metadata plus J1939 observation events rather than raw-frame-only output. |
-| `REQ-J1939MON-06` | Ubiquitous | `j1939 monitor` shall preserve the standard output modes (`--json`, `--jsonl`, `--table`, `--raw`) with command-specific formatting over the same observation stream. |
+| `REQ-J1939MON-06` | Ubiquitous | `j1939 monitor` shall preserve the standard output modes (`--json`, `--jsonl`, `--text`, `--raw`) with command-specific formatting over the same observation stream. |
 
 ## Command Surface
 
 ```text
-canarchy j1939 monitor [<interface>] [--pgn <id>] [--json] [--jsonl] [--table] [--raw]
+canarchy j1939 monitor [<interface>] [--pgn <id>] [--json] [--jsonl] [--text] [--raw]
 ```
 
 ## Responsibilities And Boundaries
@@ -78,7 +78,7 @@ Each event is a J1939 PGN observation whose payload includes protocol-first fiel
 
 ### Table
 
-`--table` renders protocol-first observation lines, including PGN, source address, destination address, priority, and frame data, and shows the active `pgn_filter` when one is applied.
+`--text` renders protocol-first observation lines, including PGN, source address, destination address, priority, and frame data, and shows the active `pgn_filter` when one is applied.
 
 ### Raw
 

--- a/docs/design/j1939-summary-command.md
+++ b/docs/design/j1939-summary-command.md
@@ -32,7 +32,7 @@ Operators often start with the question "what is in this capture and what looks 
 ## Command Surface
 
 ```text
-canarchy j1939 summary --file <capture> [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--table] [--raw]
+canarchy j1939 summary --file <capture> [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--text] [--raw]
 ```
 
 ## Responsibilities And Boundaries
@@ -85,7 +85,7 @@ The command returns the standard CANarchy result envelope. `data` for `j1939 sum
 
 ## Output Contracts
 
-`--json` returns a single stable result object. `--table` presents the reconnaissance summary as compact operator-facing lines without dropping the structured field naming in the JSON contract.
+`--json` returns a single stable result object. `--text` presents the reconnaissance summary as compact operator-facing lines without dropping the structured field naming in the JSON contract.
 
 ## Deferred Decisions
 

--- a/docs/design/replay-command.md
+++ b/docs/design/replay-command.md
@@ -30,7 +30,7 @@ Replay is a core lab workflow for reproducing traffic patterns, validating tooli
 ## Command Surface
 
 ```text
-canarchy replay --file <file> [--rate <factor>] [--json] [--jsonl] [--table] [--raw]
+canarchy replay --file <file> [--rate <factor>] [--json] [--jsonl] [--text] [--raw]
 ```
 
 ## Responsibilities And Boundaries

--- a/docs/design/reverse-engineering-helpers.md
+++ b/docs/design/reverse-engineering-helpers.md
@@ -27,7 +27,7 @@ Operators analysing unknown traffic need repeatable helpers that summarise likel
 | `REQ-RE-05` | Event-driven | When `re entropy <file>` is invoked, the system shall rank arbitration IDs and candidate fields by Shannon entropy derived from observed value distributions. |
 | `REQ-RE-06` | Event-driven | When `re correlate <file> --reference <ref>` is invoked, the system shall correlate candidate bit fields against the reference series and return ranked correlation results. |
 | `REQ-RE-07` | Ubiquitous | Reverse-engineering output shall include confidence, score, or rationale fields that distinguish heuristic inferences from established facts. |
-| `REQ-RE-08` | Ubiquitous | The commands shall support `--json`, `--jsonl`, and `--table` output modes. |
+| `REQ-RE-08` | Ubiquitous | The commands shall support `--json`, `--jsonl`, and `--text` output modes. |
 | `REQ-RE-09` | Unwanted behaviour | If `re correlate` is invoked without `--reference`, the system shall return a structured error with code `RE_REFERENCE_REQUIRED` and exit code 1. |
 | `REQ-RE-10` | Unwanted behaviour | If the reference file is missing, malformed, or does not match the required timestamped numeric sample schema, the system shall return a structured error with code `INVALID_REFERENCE_FILE` and exit code 1. |
 | `REQ-RE-11` | Event-driven | When `re match-dbc <capture>` is invoked, the system shall rank candidate DBCs by comparing provider-catalog message IDs against the capture's observed arbitration IDs. |
@@ -36,12 +36,12 @@ Operators analysing unknown traffic need repeatable helpers that summarise likel
 ## Command Surface
 
 ```text
-canarchy re signals <file> [--json] [--jsonl] [--table] [--raw]
-canarchy re counters <file> [--json] [--jsonl] [--table] [--raw]
-canarchy re entropy <file> [--json] [--jsonl] [--table] [--raw]
-canarchy re correlate <file> --reference <file> [--json] [--jsonl] [--table] [--raw]
-canarchy re match-dbc <capture> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--table] [--raw]
-canarchy re shortlist-dbc <capture> --make <brand> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--table] [--raw]
+canarchy re signals <file> [--json] [--jsonl] [--text] [--raw]
+canarchy re counters <file> [--json] [--jsonl] [--text] [--raw]
+canarchy re entropy <file> [--json] [--jsonl] [--text] [--raw]
+canarchy re correlate <file> --reference <file> [--json] [--jsonl] [--text] [--raw]
+canarchy re match-dbc <capture> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--text] [--raw]
+canarchy re shortlist-dbc <capture> --make <brand> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--text] [--raw]
 ```
 
 ### Scope assumptions
@@ -222,7 +222,7 @@ The initial implementation may either emit a single result object line or one ca
 
 ### Table
 
-Table output shall present compact ranked candidate summaries with confidence/score and rationale visible.
+Text output shall present compact ranked candidate summaries with confidence/score and rationale visible.
 
 ## Error Contracts
 

--- a/docs/design/scapy-diagnostic-integration.md
+++ b/docs/design/scapy-diagnostic-integration.md
@@ -30,8 +30,8 @@ Operators already have structured UDS scan and trace workflows, but deeper diagn
 ## Command Surface
 
 ```text
-canarchy uds scan <interface> [--ack-active] [--json] [--jsonl] [--table] [--raw]
-canarchy uds trace <interface> [--json] [--jsonl] [--table] [--raw]
+canarchy uds scan <interface> [--ack-active] [--json] [--jsonl] [--text] [--raw]
+canarchy uds trace <interface> [--json] [--jsonl] [--text] [--raw]
 ```
 
 ## Responsibilities And Boundaries
@@ -69,7 +69,7 @@ The standard CANarchy result envelope and event schema remain unchanged except f
 
 ### Table
 
-Table output remains transaction-first and may show negative response naming and Scapy-backed response summaries when available.
+Text output remains transaction-first and may show negative response naming and Scapy-backed response summaries when available.
 
 ## Error Contracts
 

--- a/docs/design/session-workflows.md
+++ b/docs/design/session-workflows.md
@@ -30,9 +30,9 @@ Operators often reuse the same interface, DBC, and capture context across comman
 ## Command Surface
 
 ```text
-canarchy session save <name> [--interface <name>] [--dbc <file>] [--capture <file>] [--json] [--jsonl] [--table] [--raw]
-canarchy session load <name> [--json] [--jsonl] [--table] [--raw]
-canarchy session show [--json] [--jsonl] [--table] [--raw]
+canarchy session save <name> [--interface <name>] [--dbc <file>] [--capture <file>] [--json] [--jsonl] [--text] [--raw]
+canarchy session load <name> [--json] [--jsonl] [--text] [--raw]
+canarchy session show [--json] [--jsonl] [--text] [--raw]
 ```
 
 ## Responsibilities And Boundaries

--- a/docs/design/shell-command.md
+++ b/docs/design/shell-command.md
@@ -28,7 +28,7 @@ Operators sometimes want to run several CANarchy commands from a persistent prom
 ## Command Surface
 
 ```text
-canarchy shell [--command "<existing canarchy command>"] [--json] [--jsonl] [--table] [--raw]
+canarchy shell [--command "<existing canarchy command>"] [--json] [--jsonl] [--text] [--raw]
 ```
 
 ## Responsibilities And Boundaries

--- a/docs/design/skills-agent-mcp-integration.md
+++ b/docs/design/skills-agent-mcp-integration.md
@@ -35,11 +35,11 @@ Operators and agents need a repeatable way to select the right CANarchy skill fo
 ## Command Surface
 
 ```text
-canarchy skills provider list [--json] [--jsonl] [--table] [--raw]
-canarchy skills search <query> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--table] [--raw]
-canarchy skills fetch <provider>:<skill> [--json] [--jsonl] [--table] [--raw]
-canarchy skills cache list [--json] [--jsonl] [--table] [--raw]
-canarchy skills cache refresh [--provider <name>] [--json] [--jsonl] [--table] [--raw]
+canarchy skills provider list [--json] [--jsonl] [--text] [--raw]
+canarchy skills search <query> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--text] [--raw]
+canarchy skills fetch <provider>:<skill> [--json] [--jsonl] [--text] [--raw]
+canarchy skills cache list [--json] [--jsonl] [--text] [--raw]
+canarchy skills cache refresh [--provider <name>] [--json] [--jsonl] [--text] [--raw]
 canarchy mcp serve
 ```
 

--- a/docs/design/skills-provider-workflows.md
+++ b/docs/design/skills-provider-workflows.md
@@ -39,11 +39,11 @@ Operators and future agents need a local, inspectable skill catalog with reprodu
 ## Command Surface
 
 ```text
-canarchy skills provider list [--json] [--jsonl] [--table] [--raw]
-canarchy skills search <query> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--table] [--raw]
-canarchy skills fetch <ref> [--json] [--jsonl] [--table] [--raw]
-canarchy skills cache list [--json] [--jsonl] [--table] [--raw]
-canarchy skills cache refresh [--provider <name>] [--json] [--jsonl] [--table] [--raw]
+canarchy skills provider list [--json] [--jsonl] [--text] [--raw]
+canarchy skills search <query> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--text] [--raw]
+canarchy skills fetch <ref> [--json] [--jsonl] [--text] [--raw]
+canarchy skills cache list [--json] [--jsonl] [--text] [--raw]
+canarchy skills cache refresh [--provider <name>] [--json] [--jsonl] [--text] [--raw]
 ```
 
 ## Responsibilities And Boundaries

--- a/docs/design/transport-core-commands.md
+++ b/docs/design/transport-core-commands.md
@@ -38,11 +38,11 @@ Operators need a stable base command set that supports passive live observation,
 ## Command Surface
 
 ```text
-canarchy capture <interface> [--candump] [--json] [--jsonl] [--table] [--raw]
-canarchy send <interface> <frame-id> <hex-data> [--ack-active] [--json] [--jsonl] [--table] [--raw]
-canarchy filter <expression> (--file <path>|--file -|--stdin) [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json] [--jsonl] [--table] [--raw]
-canarchy stats --file <path|-> [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json] [--jsonl] [--table] [--raw]
-canarchy capture-info --file <path|-> [--json] [--jsonl] [--table] [--raw]
+canarchy capture <interface> [--candump] [--json] [--jsonl] [--text] [--raw]
+canarchy send <interface> <frame-id> <hex-data> [--ack-active] [--json] [--jsonl] [--text] [--raw]
+canarchy filter <expression> (--file <path>|--file -|--stdin) [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json] [--jsonl] [--text] [--raw]
+canarchy stats --file <path|-> [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json] [--jsonl] [--text] [--raw]
+canarchy capture-info --file <path|-> [--json] [--jsonl] [--text] [--raw]
 ```
 
 ## Responsibilities And Boundaries
@@ -105,7 +105,7 @@ Event-producing commands emit one event per line. Event-less success and error p
 
 ### Table and raw
 
-`capture` uses candump-style rendering for table, raw, and `--candump`. Other commands use the standard table or raw command-result paths, while active-command preflight warnings are emitted on `stderr`.
+`capture` uses candump-style rendering for text, raw, and `--candump`. Other commands use the standard text or raw command-result paths, while active-command preflight warnings are emitted on `stderr`.
 
 ## Error Contracts
 

--- a/docs/design/uds-services-command.md
+++ b/docs/design/uds-services-command.md
@@ -23,12 +23,12 @@ UDS workflows are easier to script and reason about when the command surface inc
 | `REQ-UDS-SVC-01` | Ubiquitous | The system shall provide a `canarchy uds services` command. |
 | `REQ-UDS-SVC-02` | Event-driven | When `uds services` is invoked, the system shall return a stable catalogue of UDS services including service identifier, name, positive-response service identifier, category, and subfunction requirements. |
 | `REQ-UDS-SVC-03` | Ubiquitous | The `uds services` command shall require no transport interface or live bus connection. |
-| `REQ-UDS-SVC-04` | Ubiquitous | The command shall support standard CANarchy output modes with protocol-aware table output. |
+| `REQ-UDS-SVC-04` | Ubiquitous | The command shall support standard CANarchy output modes with protocol-aware text output. |
 
 ## Command Surface
 
 ```text
-canarchy uds services [--json] [--jsonl] [--table] [--raw]
+canarchy uds services [--json] [--jsonl] [--text] [--raw]
 ```
 
 ## Responsibilities And Boundaries
@@ -63,7 +63,7 @@ Because `uds services` is reference-only and does not emit an event stream, both
 
 ### Table
 
-Table output presents a compact service catalogue with service identifier, positive-response identifier, category, and subfunction requirement.
+Text output presents a compact service catalogue with service identifier, positive-response identifier, category, and subfunction requirement.
 
 ### Raw
 

--- a/docs/design/uds-transaction-workflows.md
+++ b/docs/design/uds-transaction-workflows.md
@@ -27,7 +27,7 @@ Operators need a protocol-aware UDS surface for discovery and transaction inspec
 | `REQ-UDS-TX-07` | Optional feature | Where `--ack-active` is supplied for `uds scan`, the system shall require a confirmation response of `YES` before a diagnostic request is sent. |
 | `REQ-UDS-TX-08` | Optional feature | Where active acknowledgement is required, the system shall require `--ack-active` before `uds scan` sends a diagnostic request. |
 | `REQ-UDS-TX-04` | Event-driven | When `uds trace <interface>` is invoked, the system shall emit structured `uds_transaction` events for traced request/response exchanges. |
-| `REQ-UDS-TX-05` | Ubiquitous | UDS table output shall present service identifier, ECU address, request ID, and response ID for each transaction. |
+| `REQ-UDS-TX-05` | Ubiquitous | UDS text output shall present service identifier, ECU address, request ID, and response ID for each transaction. |
 | `REQ-UDS-TX-06` | Unwanted behaviour | If the transport interface is unavailable, the system shall return a structured error with code `TRANSPORT_UNAVAILABLE` and exit code 2. |
 | `REQ-UDS-TX-09` | Event-driven | When `uds scan` or `uds trace` receives ISO 15765-2 first-frame and consecutive-frame responses, the system shall reassemble them into a single `uds_transaction` response payload before service decoding. |
 | `REQ-UDS-TX-10` | Unwanted behaviour | If a segmented UDS response is truncated or arrives out of order, the system shall emit a `uds_transaction` event with `complete` equal to `false` and the partial reassembled response payload. |
@@ -37,8 +37,8 @@ Operators need a protocol-aware UDS surface for discovery and transaction inspec
 ## Command Surface
 
 ```text
-canarchy uds scan <interface> [--ack-active] [--json] [--jsonl] [--table] [--raw]
-canarchy uds trace <interface> [--json] [--jsonl] [--table] [--raw]
+canarchy uds scan <interface> [--ack-active] [--json] [--jsonl] [--text] [--raw]
+canarchy uds trace <interface> [--json] [--jsonl] [--text] [--raw]
 ```
 
 ## Responsibilities And Boundaries
@@ -47,7 +47,7 @@ In scope:
 
 * structured scan responder transactions
 * structured trace transactions
-* protocol-aware table rendering
+* protocol-aware text rendering
 * transport-backed UDS response reassembly through the shared transport layer when `python-can` is selected
 
 Out of scope:

--- a/docs/event-schema.md
+++ b/docs/event-schema.md
@@ -2,7 +2,7 @@
 
 Every CANarchy command that produces structured output emits events using a canonical envelope. This document defines that envelope and every typed event subclass.
 
-The event schema is the stable interface between CANarchy and downstream consumers: scripts, pipelines, analysis tools, and coding agents. If you are parsing CANarchy output programmatically, parse the event stream rather than the human-readable table output.
+The event schema is the stable interface between CANarchy and downstream consumers: scripts, pipelines, analysis tools, and coding agents. If you are parsing CANarchy output programmatically, parse the event stream rather than the human-readable text output.
 
 ## Canonical Envelope
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -30,7 +30,7 @@ Implemented and exercised in the current codebase:
 * shell command reuse through `canarchy shell --command ...`
 * initial text-mode `tui` shell over the shared command layer
 * `config show` for effective transport configuration inspection
-* structured `--json`, `--jsonl`, `--table`, and `--raw` output modes
+* structured `--json`, `--jsonl`, `--text`, and `--raw` output modes
 
 Some protocol-oriented commands still use explicit sample/reference providers rather than true transport-backed execution. See [Architecture](architecture.md) and [Command Spec](command_spec.md) for the current boundary.
 

--- a/docs/spec-template.md
+++ b/docs/spec-template.md
@@ -117,7 +117,7 @@ Why an analyst or agent needs this capability.
 ## Command Surface
 
 \```text
-canarchy <command> <args> [--json] [--jsonl] [--table] [--raw]
+canarchy <command> <args> [--json] [--jsonl] [--text] [--raw]
 \```
 
 ## Responsibilities And Boundaries
@@ -131,7 +131,7 @@ Key fields and structures returned by this command.
 
 ## Output Contracts
 
-How each output mode (`--json`, `--jsonl`, `--table`, `--raw`) behaves.
+How each output mode (`--json`, `--jsonl`, `--text`, `--raw`) behaves.
 
 ## Error Contracts
 

--- a/docs/tests/config-show-command.md
+++ b/docs/tests/config-show-command.md
@@ -114,11 +114,11 @@ And    the source entry shall be marked as `file`
 
 ---
 
-### TEST-CONFIG-08 — Table output includes source annotations
+### TEST-CONFIG-08 — Text output includes source annotations
 
 ```gherkin
 Given  the configuration snapshot is available
-When   the operator runs `canarchy config show --table`
+When   the operator runs `canarchy config show --text`
 Then   the system shall render a human-readable configuration summary
 And    the output shall include source annotations and config-file status text
 ```

--- a/docs/tests/gateway-command.md
+++ b/docs/tests/gateway-command.md
@@ -22,7 +22,7 @@ Validate that `gateway` forwards frames correctly, preserves structured directio
 * unreachable channel raises `TRANSPORT_UNAVAILABLE`
 * `--count 0` returns a structured user error
 * JSON output includes the correct direction label
-* table output includes the gateway header and candump-style frame lines
+* text output includes the gateway header and candump-style frame lines
 
 ## Requirement Traceability
 
@@ -130,11 +130,11 @@ And    the event `source` field shall equal `"gateway.src->dst"`
 
 ---
 
-### `TEST-GATEWAY-08` — Table output
+### `TEST-GATEWAY-08` — Text output
 
 ```gherkin
 Given  a valid gateway source and destination with one frame available
-When   the operator runs `canarchy gateway src dst --count 1 --table`
+When   the operator runs `canarchy gateway src dst --count 1 --text`
 Then   the output shall contain a `gateway:` header line
 And    the output shall contain at least one candump-style frame line
 ```

--- a/docs/tests/j1939-expanded-workflows.md
+++ b/docs/tests/j1939-expanded-workflows.md
@@ -20,7 +20,7 @@ Validate that the expanded J1939 workflows preserve protocol-first behavior and 
 * `j1939 dm1` parsing for both direct and TP-reassembled messages
 * `j1939 inventory` source-address inventory assembly from identification and DM1 context
 * `j1939 compare` multi-capture PGN/source/dm1/identifier differences
-* table output for DM1 remains human-readable
+* text output for DM1 remains human-readable
 
 ## Requirement Traceability
 
@@ -101,11 +101,11 @@ And    the direct message shall preserve its source address and FMI
 
 ---
 
-### `TEST-J1939-05` — DM1 table output
+### `TEST-J1939-05` — DM1 text output
 
 ```gherkin
 Given  the fixture `j1939_dm1_tp.candump` is available
-When   the operator runs `canarchy j1939 dm1 --file j1939_dm1_tp.candump --table`
+When   the operator runs `canarchy j1939 dm1 --file j1939_dm1_tp.candump --text`
 Then   the output shall include the command header
 And    the output shall include a message section with a transport label
 And    the output shall include DTC summaries for each message
@@ -129,11 +129,11 @@ And    the session shall include a stable payload label when the transferred PGN
 
 ---
 
-### `TEST-J1939-07` — TP table output surfaces printable identification text
+### `TEST-J1939-07` — TP text output surfaces printable identification text
 
 ```gherkin
 Given  the fixture `j1939_tp_printable_id.candump` contains a printable TP identification payload
-When   the operator runs `canarchy j1939 tp sessions --file j1939_tp_printable_id.candump --table`
+When   the operator runs `canarchy j1939 tp sessions --file j1939_tp_printable_id.candump --text`
 Then   the operator-facing output shall include the payload label when available
 And    the operator-facing output shall include the decoded printable text without hiding the TP session summary context
 ```
@@ -157,11 +157,11 @@ And    the reporting source address shall include DM1 presence metadata
 
 ---
 
-### `TEST-J1939-09` — Inventory table output remains operator-friendly
+### `TEST-J1939-09` — Inventory text output remains operator-friendly
 
 ```gherkin
 Given  the fixture `j1939_inventory.candump` is available
-When   the operator runs `canarchy j1939 inventory --file j1939_inventory.candump --table`
+When   the operator runs `canarchy j1939 inventory --file j1939_inventory.candump --text`
 Then   the output shall include the command header
 And    the output shall include the decoded vehicle identification text when available
 And    the output shall include per-source rows with component-identification and DM1 presence summaries
@@ -186,11 +186,11 @@ And    the result shall include source-address identification differences when p
 
 ---
 
-### `TEST-J1939-11` — Compare table output remains operator-friendly
+### `TEST-J1939-11` — Compare text output remains operator-friendly
 
 ```gherkin
 Given  two J1939 capture fixtures with identification differences are available
-When   the operator runs `canarchy j1939 compare compare_a.candump compare_b.candump --table`
+When   the operator runs `canarchy j1939 compare compare_a.candump compare_b.candump --text`
 Then   the output shall include the command header
 And    the output shall include common-PGN and unique-source sections
 And    the output shall include the differing printable identification values

--- a/docs/tests/j1939-monitor-command.md
+++ b/docs/tests/j1939-monitor-command.md
@@ -62,13 +62,13 @@ And    the returned observations shall only report PGN `65262`
 
 ---
 
-### TEST-J1939MON-04 — Table output remains protocol-first
+### TEST-J1939MON-04 — Text output remains protocol-first
 
 ```gherkin
 Given  a PGN filter is supplied
-When   the operator runs `canarchy j1939 monitor --pgn 65262 --table`
+When   the operator runs `canarchy j1939 monitor --pgn 65262 --text`
 Then   the system shall print the command header
-And    the table output shall include the active PGN filter and protocol-first observation fields
+And    the text output shall include the active PGN filter and protocol-first observation fields
 ```
 
 **Fixture:** built-in sample/reference provider.

--- a/docs/tests/j1939-summary-command.md
+++ b/docs/tests/j1939-summary-command.md
@@ -48,11 +48,11 @@ And    the candidate shall retain the related PGN and addressing metadata
 
 ---
 
-### TEST-J1939SUM-03 — Table output remains operator-friendly
+### TEST-J1939SUM-03 — Text output remains operator-friendly
 
 ```gherkin
 Given  a J1939 TP capture fixture contains a printable candidate identifier
-When   the operator runs `canarchy j1939 summary --file <capture> --table`
+When   the operator runs `canarchy j1939 summary --file <capture> --text`
 Then   the output shall show the summary sections for top PGNs and printable identifiers
 And    the printable text shall remain visible in the operator-facing output
 ```

--- a/docs/tests/reverse-engineering-helpers.md
+++ b/docs/tests/reverse-engineering-helpers.md
@@ -20,7 +20,7 @@ Define the expected coverage for the reverse-engineering helper family so shippe
 * representative edge cases for sparse captures, low-sample captures, and mixed arbitration IDs
 * warning and limit behavior for provider-backed DBC matching workflows
 * structured error handling for missing captures, missing or malformed reference files, and insufficient overlap
-* human-readable ranked table output for each shipped helper
+* human-readable ranked text output for each shipped helper
 
 ## Requirement Traceability
 
@@ -106,11 +106,11 @@ And    the response data shall record the selected `make`
 
 ---
 
-### `TEST-RE-06` — Table output summaries for shipped helpers
+### `TEST-RE-06` — Text output summaries for shipped helpers
 
 ```gherkin
 Given  a valid capture fixture is available
-When   the operator runs a shipped `re` helper with `--table`
+When   the operator runs a shipped `re` helper with `--text`
 Then   the output shall present a compact ranked summary
 And    score or confidence data shall be visible in the table
 ```
@@ -222,11 +222,11 @@ Then   the result data shall include a 'reference_name' field matching the name 
 
 ---
 
-### `TEST-CORR-04` — Table output for re correlate
+### `TEST-CORR-04` — Text output for re correlate
 
 ```gherkin
 Given  a valid capture fixture and reference series are available
-When   the operator runs `canarchy re correlate <fixture> --reference <ref> --table`
+When   the operator runs `canarchy re correlate <fixture> --reference <ref> --text`
 Then   the output shall present ranked candidates
 And    each candidate line shall include pearson_r, spearman_r, and lag_ms
 ```

--- a/docs/tests/uds-services-command.md
+++ b/docs/tests/uds-services-command.md
@@ -10,13 +10,13 @@
 
 ## Test Objectives
 
-Validate that `uds services` returns a stable protocol-reference catalog and renders it consistently across structured and table output modes.
+Validate that `uds services` returns a stable protocol-reference catalog and renders it consistently across structured and text output modes.
 
 ## Coverage Requirements
 
 * command succeeds without a transport interface
 * JSON output contains stable service catalog metadata
-* table output presents protocol-aware service summaries
+* text output presents protocol-aware service summaries
 * raw output follows standard command-success behavior
 
 ## Requirement Traceability
@@ -48,7 +48,7 @@ And    the result shall include a `services` list containing known entries such 
 
 ```gherkin
 Given  no transport interface or live bus connection is required
-When   the operator runs `canarchy uds services --table`
+When   the operator runs `canarchy uds services --text`
 Then   the output shall include the command header and service count
 And    the output shall include catalog rows with service and positive-response identifiers
 ```

--- a/docs/tests/uds-transaction-workflows.md
+++ b/docs/tests/uds-transaction-workflows.md
@@ -10,7 +10,7 @@
 
 ## Test Objectives
 
-Validate the structured UDS scan/trace transaction paths, protocol-aware table output, ISO-TP multi-frame response handling, and transport failure handling.
+Validate the structured UDS scan/trace transaction paths, protocol-aware text output, ISO-TP multi-frame response handling, and transport failure handling.
 
 The current implementation covers transport-backed multi-frame response reassembly on `python-can` and explicit sample/reference behavior on the scaffold backend.
 
@@ -18,7 +18,7 @@ The current implementation covers transport-backed multi-frame response reassemb
 
 * scan JSON output with transaction events and preflight warning behavior
 * trace JSON output with transaction events
-* protocol-aware table rendering for scan and trace
+* protocol-aware text rendering for scan and trace
 * ISO-TP reassembly for first-frame and consecutive-frame responses
 * incomplete transaction reporting for truncated or out-of-order responses
 * flow-control frame filtering
@@ -72,11 +72,11 @@ And    the result shall report the active protocol decoder path
 
 ---
 
-### `TEST-UDS-TX-03` — Scan table output
+### `TEST-UDS-TX-03` — Scan text output
 
 ```gherkin
 Given  the scaffold transport backend is active
-When   the operator runs `canarchy uds scan can0 --table`
+When   the operator runs `canarchy uds scan can0 --text`
 Then   the output shall include responder and transaction sections
 And    the output shall include protocol-aware service metadata
 ```
@@ -85,11 +85,11 @@ And    the output shall include protocol-aware service metadata
 
 ---
 
-### `TEST-UDS-TX-04` — Trace table output
+### `TEST-UDS-TX-04` — Trace text output
 
 ```gherkin
 Given  the scaffold transport backend is active
-When   the operator runs `canarchy uds trace can0 --table`
+When   the operator runs `canarchy uds trace can0 --text`
 Then   the output shall include traced transaction summaries
 And    the output shall include service and identifier information for each transaction
 ```

--- a/docs/tutorials/dbc_provider_workflow.md
+++ b/docs/tutorials/dbc_provider_workflow.md
@@ -36,7 +36,7 @@ This updates the cached provider manifest under `~/.canarchy/cache/dbc`.
 Search by make, model family, or another keyword:
 
 ```bash
-canarchy dbc search toyota --provider opendbc --limit 5 --table
+canarchy dbc search toyota --provider opendbc --limit 5 --text
 ```
 
 This returns provider-catalog matches without downloading every DBC file.
@@ -66,7 +66,7 @@ canarchy dbc inspect opendbc:toyota_tnga_k_pt --json
 Restrict the result to a single message when needed:
 
 ```bash
-canarchy dbc inspect opendbc:toyota_tnga_k_pt --message STEER_TORQUE_SENSOR --table
+canarchy dbc inspect opendbc:toyota_tnga_k_pt --message STEER_TORQUE_SENSOR --text
 ```
 
 Structured output includes `data.dbc_source`, which records the provider, logical DBC name, pinned version, and resolved local cache path.
@@ -86,13 +86,13 @@ This avoids copying or hard-coding a separate local path.
 If you are not sure which catalog entry fits the capture best, score multiple candidates against the observed arbitration IDs:
 
 ```bash
-canarchy re match-dbc tests/fixtures/sample.candump --provider opendbc --limit 5 --table
+canarchy re match-dbc tests/fixtures/sample.candump --provider opendbc --limit 5 --text
 ```
 
 To narrow the catalog first by vehicle make:
 
 ```bash
-canarchy re shortlist-dbc tests/fixtures/sample.candump --make toyota --provider opendbc --limit 5 --table
+canarchy re shortlist-dbc tests/fixtures/sample.candump --make toyota --provider opendbc --limit 5 --text
 ```
 
 These commands are passive and file-backed. They do not decode payload semantics; they rank candidate DBCs by frequency-weighted arbitration-ID coverage.

--- a/docs/tutorials/j1939_heavy_vehicle.md
+++ b/docs/tutorials/j1939_heavy_vehicle.md
@@ -30,7 +30,7 @@ The fixture used in this demo is at `tests/fixtures/j1939_heavy_vehicle.candump`
 Get an overview of what's on the bus:
 
 ```bash
-canarchy j1939 decode --file tests/fixtures/j1939_heavy_vehicle.candump --table
+canarchy j1939 decode --file tests/fixtures/j1939_heavy_vehicle.candump --text
 ```
 
 ```text
@@ -60,7 +60,7 @@ You can see three PGN classes from SA=0x31:
 SPN 110 (Engine Coolant Temperature) lives in PGN 65262. Decode it directly:
 
 ```bash
-canarchy j1939 spn 110 --file tests/fixtures/j1939_heavy_vehicle.candump --table
+canarchy j1939 spn 110 --file tests/fixtures/j1939_heavy_vehicle.candump --text
 ```
 
 ```text
@@ -82,7 +82,7 @@ The coolant temperature is climbing: 85°C → 86°C → 87°C across the 550ms 
 Those TP frames in Step 1 are carrying a DM1 message. Let CANarchy reassemble and decode them:
 
 ```bash
-canarchy j1939 dm1 --file tests/fixtures/j1939_heavy_vehicle.candump --table
+canarchy j1939 dm1 --file tests/fixtures/j1939_heavy_vehicle.candump --text
 ```
 
 ```text
@@ -135,7 +135,7 @@ export CANARCHY_TRANSPORT_BACKEND=python-can
 export CANARCHY_PYTHON_CAN_INTERFACE=socketcan   # or kvaser, pcan, etc.
 
 canarchy capture can0 --candump                   # live candump view
-canarchy j1939 dm1 --file today.candump --table   # decode DM1 from saved capture
+canarchy j1939 dm1 --file today.candump --text   # decode DM1 from saved capture
 ```
 
 For cross-process demos without physical hardware, see the [Generate and Capture Demo](generate_and_capture.md) using the `udp_multicast` backend.

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -155,7 +155,8 @@ def add_output_arguments(parser: argparse.ArgumentParser) -> None:
     group.add_argument("--json", action="store_true", help="emit JSON output")
     group.add_argument("--jsonl", action="store_true", help="emit JSONL output")
     group.add_argument("--compact", action="store_true", help="emit compact JSON with frame data only")
-    group.add_argument("--table", action="store_true", help="emit table output")
+    group.add_argument("--text", action="store_true", help="emit human-readable text output")
+    group.add_argument("--table", action="store_true", help=argparse.SUPPRESS)
     group.add_argument("--raw", action="store_true", help="emit raw output")
 
 
@@ -690,20 +691,24 @@ def build_parser() -> CanarchyArgumentParser:
 
 
 def format_name(args: argparse.Namespace) -> str:
-    for name in ("json", "jsonl", "compact", "table", "raw"):
+    for name in ("json", "jsonl", "compact", "text", "raw"):
         if getattr(args, name, False):
             return name
-    return "table"
+    if getattr(args, "table", False):
+        return "text"
+    return "text"
 
 
 def requested_output_format(argv: Sequence[str] | None) -> str:
     if argv is None:
-        return "table"
+        return "text"
 
-    for name in ("json", "jsonl", "compact", "table", "raw"):
+    for name in ("json", "jsonl", "compact", "text", "raw"):
         if f"--{name}" in argv:
             return name
-    return "table"
+    if "--table" in argv:
+        return "text"
+    return "text"
 
 
 def active_transmit_preflight_warning(args: argparse.Namespace) -> str:
@@ -3554,7 +3559,18 @@ def build_result(args: argparse.Namespace) -> CommandResult:
         key: value
         for key, value in vars(args).items()
         if not key.endswith("_action")
-        and key not in {"command", "command_name", "json", "jsonl", "compact", "table", "raw", "ack_active"}
+        and key
+        not in {
+            "command",
+            "command_name",
+            "json",
+            "jsonl",
+            "compact",
+            "text",
+            "table",
+            "raw",
+            "ack_active",
+        }
         and value is not None
     }
     if args.command in TRANSPORT_COMMANDS:
@@ -4543,11 +4559,11 @@ def emit_live_capture(args: argparse.Namespace, output_format: str) -> int:
 
     All formats stream continuously rather than returning a fixed batch:
 
-    * ``table`` / ``raw`` / ``candump`` — candump-style text line per frame
+    * ``text`` / ``table`` / ``raw`` / ``candump`` — candump-style text line per frame
     * ``json`` / ``jsonl`` — one ``json.dumps(event)`` line per frame
     """
     transport = LocalTransport()
-    text_mode = output_format in {"table", "raw"}
+    text_mode = output_format in {"text", "raw"}
     try:
         for event in transport.capture_stream_events(args.interface):
             if event.get("event_type") != "frame":
@@ -4580,7 +4596,7 @@ def emit_live_capture(args: argparse.Namespace, output_format: str) -> int:
 
 def emit_live_candump(args: argparse.Namespace) -> int:
     """Backwards-compatible wrapper — delegates to emit_live_capture."""
-    return emit_live_capture(args, "table")
+    return emit_live_capture(args, "text")
 
 
 def emit_live_gateway(args: argparse.Namespace) -> int:
@@ -4778,7 +4794,7 @@ def emit_result(result: CommandResult, output_format: str) -> None:
         return
 
     if (
-        output_format == "table"
+        output_format == "text"
         and result.ok
         and result.command == "capture"
         and result.data.get("display") == "candump"
@@ -4789,84 +4805,84 @@ def emit_result(result: CommandResult, output_format: str) -> None:
             print(f"warning: {warning}")
         return
 
-    if output_format == "table" and result.ok and result.command == "gateway":
+    if output_format == "text" and result.ok and result.command == "gateway":
         for line in format_gateway_lines(result):
             print(line)
         for warning in payload["warnings"]:
             print(f"warning: {warning}")
         return
 
-    if output_format == "table" and result.ok and result.command in J1939_COMMANDS:
+    if output_format == "text" and result.ok and result.command in J1939_COMMANDS:
         for line in format_j1939_table(result):
             print(line)
         for warning in payload["warnings"]:
             print(f"warning: {warning}")
         return
 
-    if output_format == "table" and result.ok and result.command == "dbc inspect":
+    if output_format == "text" and result.ok and result.command == "dbc inspect":
         for line in format_dbc_table(result):
             print(line)
         for warning in payload["warnings"]:
             print(f"warning: {warning}")
         return
 
-    if output_format == "table" and result.ok and result.command in DBC_PROVIDER_COMMANDS:
+    if output_format == "text" and result.ok and result.command in DBC_PROVIDER_COMMANDS:
         for line in format_dbc_provider_table(result):
             print(line)
         for warning in payload["warnings"]:
             print(f"warning: {warning}")
         return
 
-    if output_format == "table" and result.ok and result.command in SKILLS_COMMANDS:
+    if output_format == "text" and result.ok and result.command in SKILLS_COMMANDS:
         for line in format_skills_table(result):
             print(line)
         for warning in payload["warnings"]:
             print(f"warning: {warning}")
         return
 
-    if output_format == "table" and result.ok and result.command in {"datasets provider list", "datasets search"}:
+    if output_format == "text" and result.ok and result.command in {"datasets provider list", "datasets search"}:
         for line in format_datasets_table(result):
             print(line)
         for warning in payload["warnings"]:
             print(f"warning: {warning}")
         return
 
-    if output_format == "table" and result.ok and result.command == "datasets inspect":
+    if output_format == "text" and result.ok and result.command == "datasets inspect":
         for line in format_dataset_inspect(result):
             print(line)
         for warning in payload["warnings"]:
             print(f"warning: {warning}")
         return
 
-    if output_format == "table" and result.ok and result.command == "datasets fetch":
+    if output_format == "text" and result.ok and result.command == "datasets fetch":
         for line in format_datasets_fetch(result):
             print(line)
         for warning in payload["warnings"]:
             print(f"warning: {warning}")
         return
 
-    if output_format == "table" and result.ok and result.command == "datasets replay" and result.data.get("dry_run"):
+    if output_format == "text" and result.ok and result.command == "datasets replay" and result.data.get("dry_run"):
         for line in format_datasets_replay_dry_run(result):
             print(line)
         for warning in payload["warnings"]:
             print(f"warning: {warning}")
         return
 
-    if output_format == "table" and result.ok and result.command in UDS_COMMANDS:
+    if output_format == "text" and result.ok and result.command in UDS_COMMANDS:
         for line in format_uds_table(result):
             print(line)
         for warning in payload["warnings"]:
             print(f"warning: {warning}")
         return
 
-    if output_format == "table" and result.ok and result.command in RE_COMMANDS:
+    if output_format == "text" and result.ok and result.command in RE_COMMANDS:
         for line in format_re_table(result):
             print(line)
         for warning in payload["warnings"]:
             print(f"warning: {warning}")
         return
 
-    if output_format == "table" and result.ok and result.command == "generate":
+    if output_format == "text" and result.ok and result.command == "generate":
         print(f"command: {result.command}")
         print(f"interface: {result.data.get('interface', 'unknown')}")
         print(f"frames: {result.data.get('frame_count', 0)}")
@@ -4876,7 +4892,7 @@ def emit_result(result: CommandResult, output_format: str) -> None:
             print(f"warning: {warning}")
         return
 
-    if output_format == "table" and result.ok and result.command == "config show":
+    if output_format == "text" and result.ok and result.command == "config show":
         sources = result.data.get("sources", {})
         print("Effective transport configuration:")
         for field in ("backend", "interface", "capture_limit", "capture_timeout"):
@@ -5058,7 +5074,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return run_tui(execute_command, command=args.tui_command)
     if args.command == "capture":
         return emit_live_capture(args, output_format)
-    if args.command == "gateway" and output_format in {"table", "raw"}:
+    if args.command == "gateway" and output_format in {"text", "raw"}:
         return emit_live_gateway(args)
     if args.command == "datasets stream" and not args.json:
         return emit_dataset_stream(args)

--- a/src/canarchy/completion.py
+++ b/src/canarchy/completion.py
@@ -60,7 +60,7 @@ SUBCOMMANDS: dict[str, list[str]] = {
 }
 
 # Output format flags shared by every command.
-_OUTPUT = ["--json", "--jsonl", "--raw", "--table"]
+_OUTPUT = ["--json", "--jsonl", "--raw", "--text"]
 _J1939_FILE_BOUNDS = ["--offset", "--max-frames", "--seconds"]
 
 # Per-command (or per-subcommand) flag lists.

--- a/src/canarchy/pretty_j1939_support.py
+++ b/src/canarchy/pretty_j1939_support.py
@@ -1,6 +1,6 @@
 """pretty_j1939 integration for richer J1939 human-readable output.
 
-Provides SA names, PGN labels, and decoded SPN field values in table-mode
+Provides SA names, PGN labels, and decoded SPN field values in text-mode
 output for j1939 decode / monitor / pgn / dm1 / summary commands.
 Structured output (--json / --jsonl) is never affected.
 """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -417,7 +417,7 @@ class CliTests(unittest.TestCase):
         payload = json.loads(stdout)
         self.assertEqual(payload["errors"][0]["code"], "TRANSPORT_UNAVAILABLE")
 
-    def test_gateway_table_output_prints_header_and_direction(self) -> None:
+    def test_gateway_text_output_prints_header_and_direction(self) -> None:
         src_bus = FakeBus([self.fake_message(0x18FEEE31, bytes.fromhex("11223344"), is_extended_id=True)])
         dst_bus = FakeBus()
 
@@ -428,7 +428,7 @@ class CliTests(unittest.TestCase):
             with patch.object(PythonCanBackend, "_open_bus", new=fake_open_bus):
                 with patch.object(PythonCanBackend, "_encode_message", return_value=object()):
                     exit_code, stdout, stderr = run_cli(
-                        "gateway", "src0", "dst0", "--count", "1", "--table"
+                        "gateway", "src0", "dst0", "--count", "1", "--text"
                     )
 
         self.assertEqual(exit_code, EXIT_OK)
@@ -688,13 +688,13 @@ class CliTests(unittest.TestCase):
             ],
         )
 
-    def test_j1939_summary_table_output_is_pretty_printed(self) -> None:
+    def test_j1939_summary_text_output_is_pretty_printed(self) -> None:
         exit_code, stdout, stderr = run_cli(
             "j1939",
             "summary",
             "--file",
             str(FIXTURES / "j1939_tp_printable_id.candump"),
-            "--table",
+            "--text",
         )
         self.assertEqual(exit_code, EXIT_OK)
         self.assertEqual(stderr, "")
@@ -775,13 +775,13 @@ class CliTests(unittest.TestCase):
         self.assertEqual(nodes[3]["component_identifications"][0]["text"], "TRANS01")
         self.assertFalse(nodes[3]["dm1"]["present"])
 
-    def test_j1939_inventory_table_output_is_pretty_printed(self) -> None:
+    def test_j1939_inventory_text_output_is_pretty_printed(self) -> None:
         exit_code, stdout, stderr = run_cli(
             "j1939",
             "inventory",
             "--file",
             str(FIXTURES / "j1939_inventory.candump"),
-            "--table",
+            "--text",
         )
         self.assertEqual(exit_code, EXIT_OK)
         self.assertEqual(stderr, "")
@@ -865,13 +865,13 @@ class CliTests(unittest.TestCase):
         payload = json.loads(stdout)
         self.assertTrue(any("Large file" in w for w in payload["warnings"]))
 
-    def test_j1939_compare_table_output_is_pretty_printed(self) -> None:
+    def test_j1939_compare_text_output_is_pretty_printed(self) -> None:
         exit_code, stdout, stderr = run_cli(
             "j1939",
             "compare",
             str(FIXTURES / "j1939_inventory.candump"),
             str(FIXTURES / "j1939_compare_shifted.candump"),
-            "--table",
+            "--text",
         )
         self.assertEqual(exit_code, EXIT_OK)
         self.assertEqual(stderr, "")
@@ -893,8 +893,8 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["data"]["file"], str(FIXTURES / "sample.candump"))
         self.assertEqual(payload["data"]["events"][1]["payload"]["pgn"], 61444)
 
-    def test_j1939_monitor_table_output_is_pretty_printed(self) -> None:
-        exit_code, stdout, stderr = run_cli("j1939", "monitor", "--pgn", "65262", "--table")
+    def test_j1939_monitor_text_output_is_pretty_printed(self) -> None:
+        exit_code, stdout, stderr = run_cli("j1939", "monitor", "--pgn", "65262", "--text")
         self.assertEqual(exit_code, EXIT_OK)
         self.assertEqual(stderr, "")
         self.assertIn("command: j1939 monitor", stdout)
@@ -906,9 +906,9 @@ class CliTests(unittest.TestCase):
         self.assertIn("prio=6", stdout)
         self.assertIn("data=11223344", stdout)
 
-    def test_j1939_decode_table_output_is_pretty_printed(self) -> None:
+    def test_j1939_decode_text_output_is_pretty_printed(self) -> None:
         exit_code, stdout, stderr = run_cli(
-            "j1939", "decode", "--file", str(FIXTURES / "sample.candump"), "--table"
+            "j1939", "decode", "--file", str(FIXTURES / "sample.candump"), "--text"
         )
         self.assertEqual(exit_code, EXIT_OK)
         self.assertEqual(stderr, "")
@@ -917,18 +917,18 @@ class CliTests(unittest.TestCase):
         self.assertIn("pgn=61444", stdout)
         self.assertIn("sa=0x31", stdout)
 
-    def test_j1939_decode_table_includes_pgn_label_and_sa_name(self) -> None:
+    def test_j1939_decode_text_includes_pgn_label_and_sa_name(self) -> None:
         exit_code, stdout, _ = run_cli(
-            "j1939", "decode", "--file", str(FIXTURES / "j1939_heavy_vehicle.candump"), "--table"
+            "j1939", "decode", "--file", str(FIXTURES / "j1939_heavy_vehicle.candump"), "--text"
         )
         self.assertEqual(exit_code, EXIT_OK)
         self.assertIn("pgn=65262 [ET1]", stdout)
         self.assertIn("pgn=61444 [EEC1]", stdout)
         self.assertIn("sa=0x31 [Cab Controller - Primary]", stdout)
 
-    def test_j1939_decode_table_includes_pretty_j1939_spn_values(self) -> None:
+    def test_j1939_decode_text_includes_pretty_j1939_spn_values(self) -> None:
         exit_code, stdout, _ = run_cli(
-            "j1939", "decode", "--file", str(FIXTURES / "j1939_heavy_vehicle.candump"), "--table"
+            "j1939", "decode", "--file", str(FIXTURES / "j1939_heavy_vehicle.candump"), "--text"
         )
         self.assertEqual(exit_code, EXIT_OK)
         self.assertIn("Engine Coolant Temperature:", stdout)
@@ -945,16 +945,16 @@ class CliTests(unittest.TestCase):
         self.assertEqual(first_event["pgn"], 65262)
         self.assertNotIn("Engine Coolant Temperature", str(payload))
 
-    def test_j1939_dm1_table_includes_sa_name(self) -> None:
+    def test_j1939_dm1_text_includes_sa_name(self) -> None:
         exit_code, stdout, _ = run_cli(
-            "j1939", "dm1", "--file", str(FIXTURES / "j1939_dm1_tp.candump"), "--table"
+            "j1939", "dm1", "--file", str(FIXTURES / "j1939_dm1_tp.candump"), "--text"
         )
         self.assertEqual(exit_code, EXIT_OK)
         self.assertIn("sa=0x31 [Cab Controller - Primary]", stdout)
 
-    def test_j1939_summary_table_includes_pgn_labels_and_sa_names(self) -> None:
+    def test_j1939_summary_text_includes_pgn_labels_and_sa_names(self) -> None:
         exit_code, stdout, _ = run_cli(
-            "j1939", "summary", "--file", str(FIXTURES / "j1939_heavy_vehicle.candump"), "--table"
+            "j1939", "summary", "--file", str(FIXTURES / "j1939_heavy_vehicle.candump"), "--text"
         )
         self.assertEqual(exit_code, EXIT_OK)
         self.assertIn("pgn=65262 [ET1]", stdout)
@@ -1243,14 +1243,14 @@ class CliTests(unittest.TestCase):
         self.assertEqual(session["decoded_text_encoding"], "ascii")
         self.assertTrue(session["decoded_text_heuristic"])
 
-    def test_j1939_tp_table_output_shows_printable_text_when_present(self) -> None:
+    def test_j1939_tp_text_output_shows_printable_text_when_present(self) -> None:
         exit_code, stdout, stderr = run_cli(
             "j1939",
             "tp",
             "sessions",
             "--file",
             str(FIXTURES / "j1939_tp_printable_id.candump"),
-            "--table",
+            "--text",
         )
         self.assertEqual(exit_code, EXIT_OK)
         self.assertEqual(stderr, "")
@@ -1351,7 +1351,7 @@ class CliTests(unittest.TestCase):
         self.assertEqual(group["unique_payload_count"], 1)
         self.assertEqual(group["repeated_sources"], [0x80])
 
-    def test_j1939_tp_compare_table_output_is_pretty_printed(self) -> None:
+    def test_j1939_tp_compare_text_output_is_pretty_printed(self) -> None:
         exit_code, stdout, stderr = run_cli(
             "j1939",
             "tp",
@@ -1360,7 +1360,7 @@ class CliTests(unittest.TestCase):
             str(FIXTURES / "j1939_tp_compare.candump"),
             "--sa",
             "0x80,0x83",
-            "--table",
+            "--text",
         )
         self.assertEqual(exit_code, EXIT_OK)
         self.assertEqual(stderr, "")
@@ -1439,14 +1439,14 @@ class CliTests(unittest.TestCase):
         self.assertEqual(session["decoded_text_encoding"], "ascii")
         self.assertTrue(session["decoded_text_heuristic"])
 
-    def test_j1939_tp_table_output_shows_printable_text_when_present(self) -> None:
+    def test_j1939_tp_text_output_shows_printable_text_when_present(self) -> None:
         exit_code, stdout, stderr = run_cli(
             "j1939",
             "tp",
             "sessions",
             "--file",
             str(FIXTURES / "j1939_tp_printable_id.candump"),
-            "--table",
+            "--text",
         )
         self.assertEqual(exit_code, EXIT_OK)
         self.assertEqual(stderr, "")
@@ -1561,13 +1561,13 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["data"]["dbc_spn_matches"], 1)
         self.assertEqual(dtc["name"], "EngineOilTemp")
 
-    def test_j1939_dm1_table_output_is_pretty_printed(self) -> None:
+    def test_j1939_dm1_text_output_is_pretty_printed(self) -> None:
         exit_code, stdout, stderr = run_cli(
             "j1939",
             "dm1",
             "--file",
             str(FIXTURES / "j1939_dm1_tp.candump"),
-            "--table",
+            "--text",
         )
         self.assertEqual(exit_code, EXIT_OK)
         self.assertEqual(stderr, "")
@@ -1821,13 +1821,13 @@ class CliTests(unittest.TestCase):
             self.assertIn("amber_warning", lamp)
             self.assertIn("protect", lamp)
 
-    def test_j1939_faults_table_output_is_pretty_printed(self) -> None:
+    def test_j1939_faults_text_output_is_pretty_printed(self) -> None:
         exit_code, stdout, stderr = run_cli(
             "j1939",
             "faults",
             "--file",
             str(FIXTURES / "j1939_dm1_tp.candump"),
-            "--table",
+            "--text",
         )
         self.assertEqual(exit_code, EXIT_OK)
         self.assertEqual(stderr, "")
@@ -1970,9 +1970,9 @@ class CliTests(unittest.TestCase):
         self.assertEqual(first["decoder"], "scapy")
         self.assertEqual(first["response_summary"], "UDS / PositiveResponse DiagnosticSessionControl")
 
-    def test_uds_scan_table_output_is_pretty_printed(self) -> None:
+    def test_uds_scan_text_output_is_pretty_printed(self) -> None:
         with patch("canarchy.transport._load_user_config", return_value={"CANARCHY_TRANSPORT_BACKEND": "scaffold"}):
-            exit_code, stdout, stderr = run_cli("uds", "scan", "can0", "--table")
+            exit_code, stdout, stderr = run_cli("uds", "scan", "can0", "--text")
         self.assertEqual(exit_code, EXIT_OK)
         self.assertIn("warning: `uds scan` will transmit diagnostic requests", stderr)
         self.assertIn("command: uds scan", stdout)
@@ -1984,9 +1984,9 @@ class CliTests(unittest.TestCase):
         self.assertIn("req_id=0x7DF", stdout)
         self.assertIn("resp_id=0x7E8", stdout)
 
-    def test_uds_trace_table_output_is_pretty_printed(self) -> None:
+    def test_uds_trace_text_output_is_pretty_printed(self) -> None:
         with patch("canarchy.transport._load_user_config", return_value={"CANARCHY_TRANSPORT_BACKEND": "scaffold"}):
-            exit_code, stdout, stderr = run_cli("uds", "trace", "can0", "--table")
+            exit_code, stdout, stderr = run_cli("uds", "trace", "can0", "--text")
         self.assertEqual(exit_code, EXIT_OK)
         self.assertIn("command: uds trace", stdout)
         self.assertIn("interface: can0", stdout)
@@ -2010,8 +2010,8 @@ class CliTests(unittest.TestCase):
         self.assertTrue(services[0]["requires_subfunction"])
         self.assertEqual(services[6]["name"], "SecurityAccess")
 
-    def test_uds_services_table_output_is_pretty_printed(self) -> None:
-        exit_code, stdout, stderr = run_cli("uds", "services", "--table")
+    def test_uds_services_text_output_is_pretty_printed(self) -> None:
+        exit_code, stdout, stderr = run_cli("uds", "services", "--text")
         self.assertEqual(exit_code, EXIT_OK)
         self.assertEqual(stderr, "")
         self.assertIn("command: uds services", stdout)
@@ -2104,12 +2104,12 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["data"]["candidate_count"], 0)
         self.assertEqual(payload["data"]["candidates"], [])
 
-    def test_re_counters_table_output_is_ranked(self) -> None:
+    def test_re_counters_text_output_is_ranked(self) -> None:
         exit_code, stdout, stderr = run_cli(
             "re",
             "counters",
             str(FIXTURES / "re_counter_nibble.candump"),
-            "--table",
+            "--text",
         )
         self.assertEqual(exit_code, EXIT_OK)
         self.assertEqual(stderr, "")
@@ -2156,12 +2156,12 @@ class CliTests(unittest.TestCase):
         self.assertEqual(analysed["frame_count"], 10)
         self.assertFalse(analysed["low_sample"])
 
-    def test_re_signals_table_output_is_ranked(self) -> None:
+    def test_re_signals_text_output_is_ranked(self) -> None:
         exit_code, stdout, stderr = run_cli(
             "re",
             "signals",
             str(FIXTURES / "re_signals_mixed.candump"),
-            "--table",
+            "--text",
         )
         self.assertEqual(exit_code, EXIT_OK)
         self.assertEqual(stderr, "")
@@ -2218,12 +2218,12 @@ class CliTests(unittest.TestCase):
         self.assertTrue(low_sample["low_sample"])
         self.assertEqual(low_sample["frame_count"], 5)
 
-    def test_re_entropy_table_output_is_ranked(self) -> None:
+    def test_re_entropy_text_output_is_ranked(self) -> None:
         exit_code, stdout, stderr = run_cli(
             "re",
             "entropy",
             str(FIXTURES / "re_entropy_mixed.candump"),
-            "--table",
+            "--text",
         )
         self.assertEqual(exit_code, EXIT_OK)
         self.assertEqual(stderr, "")
@@ -2276,14 +2276,14 @@ class CliTests(unittest.TestCase):
         for key in ("pearson_r", "spearman_r", "sample_count", "lag_ms"):
             self.assertIn(key, byte1)
 
-    def test_re_correlate_table_output_includes_ranked_candidates(self) -> None:
+    def test_re_correlate_text_output_includes_ranked_candidates(self) -> None:
         exit_code, stdout, stderr = run_cli(
             "re",
             "correlate",
             str(FIXTURES / "re_correlate_linear.candump"),
             "--reference",
             str(FIXTURES / "re_correlate_reference.json"),
-            "--table",
+            "--text",
         )
         self.assertEqual(exit_code, EXIT_OK)
         self.assertEqual(stderr, "")
@@ -3112,9 +3112,9 @@ class CliTests(unittest.TestCase):
 
     @patch("canarchy.transport.time.sleep")
     @patch("canarchy.transport._load_user_config", return_value={"CANARCHY_TRANSPORT_BACKEND": "scaffold"})
-    def test_generate_table_output_is_pretty_printed(self, _mock_cfg, _mock_sleep) -> None:
+    def test_generate_text_output_is_pretty_printed(self, _mock_cfg, _mock_sleep) -> None:
         exit_code, stdout, stderr = run_cli(
-            "generate", "can0", "--id", "0x123", "--dlc", "4", "--data", "AABBCCDD", "--count", "2", "--table"
+            "generate", "can0", "--id", "0x123", "--dlc", "4", "--data", "AABBCCDD", "--count", "2", "--text"
         )
         self.assertEqual(exit_code, EXIT_OK)
         self.assertIn("command: generate", stdout)
@@ -3952,8 +3952,9 @@ class CompletionTests(unittest.TestCase):
         self.assertIn("--candump", names)
         self.assertIn("--json", names)
         self.assertIn("--jsonl", names)
-        self.assertIn("--table", names)
+        self.assertIn("--text", names)
         self.assertIn("--raw", names)
+        self.assertNotIn("--table", names)
 
     def test_generate_flags_include_gap_and_count(self) -> None:
         results = self._completions("generate can0 ", "")
@@ -4038,7 +4039,7 @@ class CompletionTests(unittest.TestCase):
         names = [r.strip() for r in results]
         self.assertIn("--json", names)
         self.assertIn("--jsonl", names)
-        self.assertNotIn("--table", names)
+        self.assertNotIn("--text", names)
         self.assertNotIn("--candump", names)
 
     def test_flags_not_offered_for_unknown_command(self) -> None:
@@ -4179,19 +4180,29 @@ class ConfigShowTests(unittest.TestCase):
         # interface came from file
         self.assertEqual(sources["interface"], "file")
 
-    def test_config_show_table_output(self) -> None:
-        """Table output includes backend, interface, and config-file path."""
+    def test_config_show_text_output(self) -> None:
+        """Text output includes backend, interface, and config-file path."""
         with (
             patch("canarchy.transport._load_user_config", return_value={}),
             patch.dict(os.environ, {}, clear=True),
         ):
-            exit_code, stdout, _ = run_cli("config", "show", "--table")
+            exit_code, stdout, _ = run_cli("config", "show", "--text")
         self.assertEqual(exit_code, EXIT_OK)
         self.assertIn("backend: python-can", stdout)
         self.assertIn("interface: socketcan", stdout)
         self.assertIn("require_active_ack: False", stdout)
         self.assertIn("j1939_dbc: None", stdout)
         self.assertIn("config file:", stdout)
+
+    def test_table_output_flag_is_text_alias(self) -> None:
+        with (
+            patch("canarchy.transport._load_user_config", return_value={}),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            exit_code, stdout, _ = run_cli("config", "show", "--table")
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertIn("Effective transport configuration:", stdout)
+        self.assertIn("backend: python-can", stdout)
 
     def test_config_show_config_file_found_false_when_missing(self) -> None:
         """config_file_found is False when the config file does not exist."""

--- a/tests/test_dbc.py
+++ b/tests/test_dbc.py
@@ -204,12 +204,12 @@ class DbcTests(unittest.TestCase):
         payload = json.loads(stdout)
         self.assertEqual(payload["errors"][0]["code"], "DBC_MESSAGE_NOT_FOUND")
 
-    def test_dbc_inspect_table_output(self) -> None:
+    def test_dbc_inspect_text_output(self) -> None:
         exit_code, stdout, _ = run_cli(
             "dbc",
             "inspect",
             str(FIXTURES / "sample.dbc"),
-            "--table",
+            "--text",
         )
         self.assertEqual(exit_code, EXIT_OK)
         self.assertIn("messages: 2", stdout)


### PR DESCRIPTION
## Summary
- Make `--text` the canonical human-readable output mode and default output path.
- Keep `--table` accepted as a hidden compatibility alias for existing callers.
- Update completions, docs, specs, tutorials, tests, and changelog to use `--text`.

## Verification
- `uv run python -m pytest tests/ -q`
- `uv run mkdocs build --strict`
- `uv run canarchy config show --text`
- `uv run canarchy config show --table`
- `uv run canarchy config show`
- `uv run canarchy config show --help`

Closes #286