### PR TITLE
Remove generic raw output mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,7 +299,6 @@ Every command should support explicit output modes:
 * `--json`
 * `--jsonl`
 * `--text`
-* `--raw`
 
 Do not mix human decoration into JSON output.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Changed
 
 * Renamed the canonical human-readable output flag from `--table` to `--text`; `--table` remains accepted as a compatibility alias. Closes #286.
+* Removed the generic `--raw` output mode from the shared command surface; use `--text`, `--json`, `--jsonl`, or command-specific frame-line options such as `--candump` instead. Closes #288.
 
 ## [0.7.0] - 2026-05-09
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Today the repository delivers:
 
 * a stable CLI surface for analysts, scripts, and coding agents
 * J1939-first heavy vehicle workflows: PGN decoding, SPN extraction, TP session reassembly, DM1 fault parsing
-* structured output (`--json`, `--jsonl`, `--text`, `--raw`) on every command
+* structured output (`--json`, `--jsonl`, `--text`) on every command
 * live CAN transport via `python-can` with support for socketcan, virtual bus, and UDP multicast
 * UDS scan and trace, DBC decode/encode, capture/filter/replay, and an interactive shell
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,7 @@ flowchart TD
     REP --> EV
     REF --> EV
 
-    EV --> OUT[JSON / JSONL / text / raw output]
+    EV --> OUT[JSON / JSONL / text output]
     DBC --> PROV[dbc_source provenance]
     PROV --> OUT
 ```
@@ -150,7 +150,7 @@ Primary responsibilities:
 * argument parsing and validation
 * dispatch to transport, DBC provider resolution, protocol, replay, reverse-engineering, export, and session helpers
 * structured error handling and exit codes
-* shaping output for `--json`, `--jsonl`, `--text`, and `--raw`
+* shaping output for `--json`, `--jsonl`, `--text`,
 
 Relevant module:
 
@@ -319,7 +319,7 @@ sequenceDiagram
     Command->>Engine: decode / classify / replay / summarize
     Engine-->>Command: typed events and payloads
     Command->>Output: CommandResult
-    Output-->>User: json / jsonl / text / raw
+    Output-->>User: json / jsonl / text
 ```
 
 ## Current Strengths

--- a/docs/command_spec.md
+++ b/docs/command_spec.md
@@ -72,7 +72,7 @@ Examples:
 Capture traffic from a local interface. Structured capture uses the selected transport backend. `--candump` is a live-only mode.
 
 ```bash
-canarchy capture <interface> [--candump] [--json|--jsonl|--text|--raw]
+canarchy capture <interface> [--candump] [--json|--jsonl|--text]
 ```
 
 Example:
@@ -103,7 +103,7 @@ Supported file input today:
 Prepare an active transmit frame.
 
 ```bash
-canarchy send <interface> <frame-id> <hex-data> [--ack-active] [--json|--jsonl|--text|--raw]
+canarchy send <interface> <frame-id> <hex-data> [--ack-active] [--json|--jsonl|--text]
 ```
 
 Example:
@@ -122,7 +122,7 @@ Notes:
 Filter a capture source by a simple expression.
 
 ```bash
-canarchy filter <expression> (--file <path> | --file - | --stdin) [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json|--jsonl|--compact|--text|--raw]
+canarchy filter <expression> (--file <path> | --file - | --stdin) [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json|--jsonl|--compact|--text]
 ```
 ```
 
@@ -137,8 +137,8 @@ Notes:
 Inspect a candump capture quickly before running deeper analysis.
 
 ```bash
-canarchy capture-info --file <path> [--json|--jsonl|--text|--raw]
-canarchy capture-info --file - [--json|--jsonl|--text|--raw]
+canarchy capture-info --file <path> [--json|--jsonl|--text]
+canarchy capture-info --file - [--json|--jsonl|--text]
 ```
 
 Notes:
@@ -160,8 +160,8 @@ Notes:
 Summarize a capture source.
 
 ```bash
-canarchy stats --file <path> [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json|--jsonl|--text|--raw]
-canarchy stats --file - [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json|--jsonl|--text|--raw]
+canarchy stats --file <path> [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json|--jsonl|--text]
+canarchy stats --file - [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json|--jsonl|--text]
 ```
 
 Notes:
@@ -173,7 +173,7 @@ Notes:
 Generate CAN frames from explicit, random, or incrementing inputs.
 
 ```bash
-canarchy generate <interface> [--id <hex|R>] [--dlc <0-8|R>] [--data <hex|R|I>] [--count <n>] [--gap <ms>] [--extended] [--ack-active] [--json|--jsonl|--text|--raw]
+canarchy generate <interface> [--id <hex|R>] [--dlc <0-8|R>] [--data <hex|R|I>] [--count <n>] [--gap <ms>] [--extended] [--ack-active] [--json|--jsonl|--text]
 ```
 
 Examples:
@@ -195,7 +195,7 @@ Notes:
 Replay a capture source with deterministic timing derived from relative frame timestamps.
 
 ```bash
-canarchy replay --file <path> [--rate <factor>] [--json|--jsonl|--text|--raw]
+canarchy replay --file <path> [--rate <factor>] [--json|--jsonl|--text]
 ```
 
 Example:
@@ -209,7 +209,7 @@ canarchy replay --file tests/fixtures/sample.candump --rate 2.0 --json
 Bridge frames from one live CAN interface to another through the `python-can` backend.
 
 ```bash
-canarchy gateway <src> <dst> [--src-backend <type>] [--dst-backend <type>] [--bidirectional] [--count <n>] [--ack-active] [--json|--jsonl|--text|--raw]
+canarchy gateway <src> <dst> [--src-backend <type>] [--dst-backend <type>] [--bidirectional] [--count <n>] [--ack-active] [--json|--jsonl|--text]
 ```
 
 Examples:
@@ -224,7 +224,7 @@ Notes:
 * `gateway` requires the `python-can` backend (set in `~/.canarchy/config.toml` or via `CANARCHY_TRANSPORT_BACKEND=python-can`)
 * `--src-backend` and `--dst-backend` default to the configured `interface` value
 * `--ack-active` requests an interactive `YES` confirmation before forwarding begins
-* default text and raw output use candump-style forwarded frame lines with direction labels such as `[src->dst]`
+* default text output use candump-style forwarded frame lines with direction labels such as `[src->dst]`
 * `--json` returns a standard command envelope; `--jsonl` emits one forwarded event per line for `gateway`
 
 ### export
@@ -232,7 +232,7 @@ Notes:
 Export structured artifacts for later analysis.
 
 ```bash
-canarchy export <source> <destination> [--json|--jsonl|--text|--raw]
+canarchy export <source> <destination> [--json|--jsonl|--text]
 ```
 
 Examples:
@@ -255,8 +255,8 @@ Notes:
 Decode frames from a capture source using a DBC file.
 
 ```bash
-canarchy decode --file <file> --dbc <file> [--json|--jsonl|--text|--raw]
-canarchy decode --stdin --dbc <file> [--json|--jsonl|--text|--raw]
+canarchy decode --file <file> --dbc <file> [--json|--jsonl|--text]
+canarchy decode --stdin --dbc <file> [--json|--jsonl|--text]
 ```
 
 Example:
@@ -276,7 +276,7 @@ Notes:
 Encode a DBC message into a frame payload.
 
 ```bash
-canarchy encode --dbc <file> <message> <signal=value>... [--json|--jsonl|--text|--raw]
+canarchy encode --dbc <file> <message> <signal=value>... [--json|--jsonl|--text]
 ```
 
 Example:
@@ -295,7 +295,7 @@ Notes:
 Inspect database, message, and signal metadata for a DBC file or provider ref.
 
 ```bash
-canarchy dbc inspect <dbc> [--message <name>] [--signals-only] [--json|--jsonl|--text|--raw]
+canarchy dbc inspect <dbc> [--message <name>] [--signals-only] [--json|--jsonl|--text]
 ```
 
 Examples:
@@ -315,7 +315,7 @@ Notes:
 List registered DBC providers.
 
 ```bash
-canarchy dbc provider list [--json|--jsonl|--text|--raw]
+canarchy dbc provider list [--json|--jsonl|--text]
 ```
 
 ### dbc search
@@ -323,7 +323,7 @@ canarchy dbc provider list [--json|--jsonl|--text|--raw]
 Search DBC catalogs across enabled providers.
 
 ```bash
-canarchy dbc search <query> [--provider <name>] [--limit <n>] [--json|--jsonl|--text|--raw]
+canarchy dbc search <query> [--provider <name>] [--limit <n>] [--json|--jsonl|--text]
 ```
 
 Example:
@@ -337,7 +337,7 @@ canarchy dbc search toyota --provider opendbc --limit 5 --json
 Fetch and cache a DBC file from a provider.
 
 ```bash
-canarchy dbc fetch <ref> [--json|--jsonl|--text|--raw]
+canarchy dbc fetch <ref> [--json|--jsonl|--text]
 ```
 
 Example:
@@ -351,7 +351,7 @@ canarchy dbc fetch opendbc:toyota_tnga_k_pt_generated --json
 List cached provider manifests.
 
 ```bash
-canarchy dbc cache list [--json|--jsonl|--text|--raw]
+canarchy dbc cache list [--json|--jsonl|--text]
 ```
 
 ### dbc cache prune
@@ -359,7 +359,7 @@ canarchy dbc cache list [--json|--jsonl|--text|--raw]
 Remove stale cached provider snapshots while keeping the pinned commit.
 
 ```bash
-canarchy dbc cache prune [--provider <name>] [--json|--jsonl|--text|--raw]
+canarchy dbc cache prune [--provider <name>] [--json|--jsonl|--text]
 ```
 
 ### dbc cache refresh
@@ -367,7 +367,7 @@ canarchy dbc cache prune [--provider <name>] [--json|--jsonl|--text|--raw]
 Refresh a provider catalog from upstream.
 
 ```bash
-canarchy dbc cache refresh [--provider <name>] [--json|--jsonl|--text|--raw]
+canarchy dbc cache refresh [--provider <name>] [--json|--jsonl|--text]
 ```
 
 Notes:
@@ -381,7 +381,7 @@ Notes:
 List registered repository-backed skills providers.
 
 ```bash
-canarchy skills provider list [--json|--jsonl|--text|--raw]
+canarchy skills provider list [--json|--jsonl|--text]
 ```
 
 ### skills search
@@ -389,7 +389,7 @@ canarchy skills provider list [--json|--jsonl|--text|--raw]
 Search repository-backed skills catalogs by name, tag, or keyword.
 
 ```bash
-canarchy skills search <query> [--provider <name>] [--limit <n>] [--json|--jsonl|--text|--raw]
+canarchy skills search <query> [--provider <name>] [--limit <n>] [--json|--jsonl|--text]
 ```
 
 Example:
@@ -403,7 +403,7 @@ canarchy skills search j1939 --provider github --json
 Fetch and cache a repository-backed skill locally.
 
 ```bash
-canarchy skills fetch <provider>:<skill> [--json|--jsonl|--text|--raw]
+canarchy skills fetch <provider>:<skill> [--json|--jsonl|--text]
 ```
 
 Example:
@@ -417,7 +417,7 @@ canarchy skills fetch github:j1939_compare_triage --json
 List cached skills provider manifests.
 
 ```bash
-canarchy skills cache list [--json|--jsonl|--text|--raw]
+canarchy skills cache list [--json|--jsonl|--text]
 ```
 
 ### skills cache refresh
@@ -425,7 +425,7 @@ canarchy skills cache list [--json|--jsonl|--text|--raw]
 Refresh a skills provider catalog from upstream.
 
 ```bash
-canarchy skills cache refresh [--provider <name>] [--json|--jsonl|--text|--raw]
+canarchy skills cache refresh [--provider <name>] [--json|--jsonl|--text]
 ```
 
 Notes:
@@ -440,7 +440,7 @@ Notes:
 List registered public CAN dataset providers.
 
 ```bash
-canarchy datasets provider list [--json|--jsonl|--text|--raw]
+canarchy datasets provider list [--json|--jsonl|--text]
 ```
 
 ### datasets search
@@ -448,7 +448,7 @@ canarchy datasets provider list [--json|--jsonl|--text|--raw]
 Search public CAN dataset provider catalogs by name, protocol, or keyword.
 
 ```bash
-canarchy datasets search [query] [--provider <name>] [--limit <n>] [--verbose] [--json|--jsonl|--text|--raw]
+canarchy datasets search [query] [--provider <name>] [--limit <n>] [--verbose] [--json|--jsonl|--text]
 ```
 
 ### datasets inspect
@@ -456,7 +456,7 @@ canarchy datasets search [query] [--provider <name>] [--limit <n>] [--verbose] [
 Show full metadata for a dataset ref.
 
 ```bash
-canarchy datasets inspect <provider>:<dataset> [--json|--jsonl|--text|--raw]
+canarchy datasets inspect <provider>:<dataset> [--json|--jsonl|--text]
 ```
 
 Examples:
@@ -477,7 +477,7 @@ Notes:
 Record dataset provenance in the local cache. This does not download large dataset payloads.
 
 ```bash
-canarchy datasets fetch <provider>:<dataset> [--json|--jsonl|--text|--raw]
+canarchy datasets fetch <provider>:<dataset> [--json|--jsonl|--text]
 ```
 
 Notes:
@@ -490,7 +490,7 @@ Notes:
 List cached dataset provider manifests and provenance records.
 
 ```bash
-canarchy datasets cache list [--json|--jsonl|--text|--raw]
+canarchy datasets cache list [--json|--jsonl|--text]
 ```
 
 ### datasets cache refresh
@@ -498,7 +498,7 @@ canarchy datasets cache list [--json|--jsonl|--text|--raw]
 Refresh the built-in dataset catalog manifest.
 
 ```bash
-canarchy datasets cache refresh [--provider <name>] [--json|--jsonl|--text|--raw]
+canarchy datasets cache refresh [--provider <name>] [--json|--jsonl|--text]
 ```
 
 ### datasets convert
@@ -506,7 +506,7 @@ canarchy datasets cache refresh [--provider <name>] [--json|--jsonl|--text|--raw
 Convert a downloaded dataset file to a CANarchy-compatible capture format.
 
 ```bash
-canarchy datasets convert <file> --source-format hcrl-csv --format candump|jsonl [--output <path>] [--json|--jsonl|--text|--raw]
+canarchy datasets convert <file> --source-format hcrl-csv --format candump|jsonl [--output <path>] [--json|--jsonl|--text]
 ```
 
 ### datasets stream
@@ -578,7 +578,7 @@ Notes:
 Save a named session with useful CLI context.
 
 ```bash
-canarchy session save <name> [--interface <name>] [--dbc <file>] [--capture <file>] [--json|--jsonl|--text|--raw]
+canarchy session save <name> [--interface <name>] [--dbc <file>] [--capture <file>] [--json|--jsonl|--text]
 ```
 
 ### session load
@@ -586,7 +586,7 @@ canarchy session save <name> [--interface <name>] [--dbc <file>] [--capture <fil
 Load a previously saved session and mark it active.
 
 ```bash
-canarchy session load <name> [--json|--jsonl|--text|--raw]
+canarchy session load <name> [--json|--jsonl|--text]
 ```
 
 ### session show
@@ -594,7 +594,7 @@ canarchy session load <name> [--json|--jsonl|--text|--raw]
 Show saved sessions and the active session.
 
 ```bash
-canarchy session show [--json|--jsonl|--text|--raw]
+canarchy session show [--json|--jsonl|--text]
 ```
 
 ### shell
@@ -602,7 +602,7 @@ canarchy session show [--json|--jsonl|--text|--raw]
 Run a single shell command through the shared parser, or start a minimal interactive shell loop.
 
 ```bash
-canarchy shell [--command "capture can0 --raw"] [--json|--jsonl|--text|--raw]
+canarchy shell [--command "capture can0 --text"] [--json|--jsonl|--text]
 ```
 
 ### j1939 monitor
@@ -610,7 +610,7 @@ canarchy shell [--command "capture can0 --raw"] [--json|--jsonl|--text|--raw]
 Inspect J1939 traffic and emit PGN-oriented structured events.
 
 ```bash
-canarchy j1939 monitor [<interface>] [--pgn <id>] [--json|--jsonl|--text|--raw]
+canarchy j1939 monitor [<interface>] [--pgn <id>] [--json|--jsonl|--text]
 ```
 
 Example:
@@ -631,8 +631,8 @@ Notes:
 Decode a capture source into J1939 PGN observations.
 
 ```bash
-canarchy j1939 decode --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--text|--raw]
-canarchy j1939 decode --stdin [--dbc <path|provider-ref>] [--json|--jsonl|--text|--raw]
+canarchy j1939 decode --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--text]
+canarchy j1939 decode --stdin [--dbc <path|provider-ref>] [--json|--jsonl|--text]
 ```
 
 Notes:
@@ -645,7 +645,7 @@ Notes:
 Inspect events for a specific PGN from a capture file.
 
 ```bash
-canarchy j1939 pgn <pgn> --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--text|--raw]
+canarchy j1939 pgn <pgn> --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--text]
 ```
 
 Example:
@@ -659,7 +659,7 @@ canarchy j1939 pgn 65262 --file tests/fixtures/sample.candump --json
 Inspect a curated SPN decoder over recorded J1939 traffic.
 
 ```bash
-canarchy j1939 spn <spn> --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--text|--raw]
+canarchy j1939 spn <spn> --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--text]
 ```
 
 Example:
@@ -679,7 +679,7 @@ Notes:
 Summarize J1939 transport-protocol sessions from a capture file.
 
 ```bash
-canarchy j1939 tp sessions --file <file> [--json|--jsonl|--text|--raw]
+canarchy j1939 tp sessions --file <file> [--json|--jsonl|--text]
 ```
 
 Notes:
@@ -691,7 +691,7 @@ Notes:
 Inspect DM1 fault traffic from direct J1939 frames and TP-reassembled payloads.
 
 ```bash
-canarchy j1939 dm1 --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--text|--raw]
+canarchy j1939 dm1 --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--text]
 ```
 
 ### j1939 faults
@@ -699,7 +699,7 @@ canarchy j1939 dm1 --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--t
 Summarize active DM1 faults by ECU/source address, including lamp state and suspicious DTC markers.
 
 ```bash
-canarchy j1939 faults --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--text|--raw]
+canarchy j1939 faults --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|--text]
 ```
 
 ### j1939 inventory
@@ -707,7 +707,7 @@ canarchy j1939 faults --file <file> [--dbc <path|provider-ref>] [--json|--jsonl|
 Build a source-address inventory from a J1939 capture file, including top PGNs, component-identification strings, vehicle-identification strings, and DM1 presence.
 
 ```bash
-canarchy j1939 inventory --file <file> [--json|--jsonl|--text|--raw]
+canarchy j1939 inventory --file <file> [--json|--jsonl|--text]
 ```
 
 Example:
@@ -727,7 +727,7 @@ Notes:
 Compare two or more J1939 capture files and highlight common versus capture-unique PGNs, source-address changes, DM1 differences, and printable TP identification changes.
 
 ```bash
-canarchy j1939 compare <file> <file> [<file> ...] [--json|--jsonl|--text|--raw]
+canarchy j1939 compare <file> <file> [<file> ...] [--json|--jsonl|--text]
 ```
 
 Example:
@@ -763,7 +763,7 @@ Notes:
 Inspect representative UDS responder discovery transactions.
 
 ```bash
-canarchy uds scan <interface> [--ack-active] [--json|--jsonl|--text|--raw]
+canarchy uds scan <interface> [--ack-active] [--json|--jsonl|--text]
 ```
 
 Notes:
@@ -778,7 +778,7 @@ Notes:
 Inspect representative UDS request and response transactions.
 
 ```bash
-canarchy uds trace <interface> [--json|--jsonl|--text|--raw]
+canarchy uds trace <interface> [--json|--jsonl|--text]
 ```
 
 Notes:
@@ -793,7 +793,7 @@ Notes:
 Inspect the built-in UDS service catalog.
 
 ```bash
-canarchy uds services [--json|--jsonl|--text|--raw]
+canarchy uds services [--json|--jsonl|--text]
 ```
 
 Notes:
@@ -806,7 +806,7 @@ Notes:
 Rank likely counter fields from recorded CAN traffic.
 
 ```bash
-canarchy re counters <file> [--json|--jsonl|--text|--raw]
+canarchy re counters <file> [--json|--jsonl|--text]
 ```
 
 Notes:
@@ -820,7 +820,7 @@ Notes:
 Rank likely signal fields from recorded CAN traffic.
 
 ```bash
-canarchy re signals <file> [--json|--jsonl|--text|--raw]
+canarchy re signals <file> [--json|--jsonl|--text]
 ```
 
 Notes:
@@ -835,7 +835,7 @@ Notes:
 Correlate candidate bit fields against a timestamped reference series.
 
 ```bash
-canarchy re correlate <file> --reference <ref.json|ref.jsonl> [--json|--jsonl|--text|--raw]
+canarchy re correlate <file> --reference <ref.json|ref.jsonl> [--json|--jsonl|--text]
 ```
 
 Notes:
@@ -850,7 +850,7 @@ Notes:
 Rank arbitration IDs and byte positions by Shannon entropy over recorded CAN traffic.
 
 ```bash
-canarchy re entropy <file> [--json|--jsonl|--text|--raw]
+canarchy re entropy <file> [--json|--jsonl|--text]
 ```
 
 Notes:
@@ -864,7 +864,7 @@ Notes:
 Rank candidate DBC files against a capture using provider-backed catalog metadata.
 
 ```bash
-canarchy re match-dbc <capture> [--provider <name>] [--limit <n>] [--json|--jsonl|--text|--raw]
+canarchy re match-dbc <capture> [--provider <name>] [--limit <n>] [--json|--jsonl|--text]
 ```
 
 Notes:
@@ -878,7 +878,7 @@ Notes:
 Rank candidate DBC files against a capture after pre-filtering by vehicle make.
 
 ```bash
-canarchy re shortlist-dbc <capture> --make <brand> [--provider <name>] [--limit <n>] [--json|--jsonl|--text|--raw]
+canarchy re shortlist-dbc <capture> --make <brand> [--provider <name>] [--limit <n>] [--json|--jsonl|--text]
 ```
 
 Notes:
@@ -892,7 +892,7 @@ Notes:
 Inspect the effective transport configuration and the source of each setting.
 
 ```bash
-canarchy config show [--json|--jsonl|--text|--raw]
+canarchy config show [--json|--jsonl|--text]
 ```
 
 ### mcp serve
@@ -917,7 +917,6 @@ All commands support:
 * `--json`
 * `--jsonl`
 * `--text`
-* `--raw`
 
 `--text` is the default when no output mode is specified. `--table` remains accepted as a compatibility alias for `--text`, but new examples and automation should use `--text`.
 
@@ -929,7 +928,6 @@ Current behavior:
 * event-less successful commands emit a single result object line
 * failed commands emit a single error result object line
 * `--text` emits a human-readable summary view, with protocol-aware pretty-printing for J1939 monitor and decode workflows
-* `--raw` emits the command name on success or the primary error message on failure
 
 J1939 `--text` output includes:
 
@@ -1124,7 +1122,7 @@ canarchy session save lab-a --interface can0 --dbc tests/fixtures/sample.dbc --c
 ### Shell One-Shot Command
 
 ```bash
-canarchy shell --command "capture can0 --raw"
+canarchy shell --command "capture can0 --text"
 ```
 
 ---

--- a/docs/design/active-command-safety.md
+++ b/docs/design/active-command-safety.md
@@ -33,14 +33,14 @@ Operators and automation need active workflows to remain scriptable, but active 
 ## Command Surface
 
 ```text
-canarchy send <interface> <frame-id> <hex-data> [--ack-active] [--json] [--jsonl] [--text] [--raw]
+canarchy send <interface> <frame-id> <hex-data> [--ack-active] [--json] [--jsonl] [--text]
 canarchy generate <interface> [--id <hex|R>] [--dlc <0-8|R>] [--data <hex|R|I>]
                            [--count <n>] [--gap <ms>] [--extended] [--ack-active]
-                           [--json] [--jsonl] [--text] [--raw]
+                           [--json] [--jsonl] [--text]
 canarchy gateway <src> <dst> [--src-backend <name>] [--dst-backend <name>]
                             [--bidirectional] [--count <n>] [--ack-active]
-                            [--json] [--jsonl] [--text] [--raw]
-canarchy uds scan <interface> [--ack-active] [--json] [--jsonl] [--text] [--raw]
+                            [--json] [--jsonl] [--text]
+canarchy uds scan <interface> [--ack-active] [--json] [--jsonl] [--text]
 ```
 
 ## Responsibilities And Boundaries
@@ -83,7 +83,7 @@ When `--ack-active` is supplied, the command emits a confirmation prompt to `std
 
 Structured `stdout` output remains machine-readable and shall not rely on duplicated top-level warning strings for active-command safety prompts.
 
-### Table and raw
+### Text
 
 Human-readable `stdout` remains reserved for the requested output mode; the preflight warning still appears on `stderr`.
 

--- a/docs/design/composition.md
+++ b/docs/design/composition.md
@@ -31,9 +31,9 @@ Operators and coding agents should be able to connect commands with pipes instea
 ## Command Surface
 
 ```text
-canarchy decode --dbc <file> --stdin [--json|--jsonl|--text|--raw]
-canarchy filter <expression> --stdin [--json|--jsonl|--text|--raw]
-canarchy j1939 decode --stdin [--json|--jsonl|--text|--raw]
+canarchy decode --dbc <file> --stdin [--json|--jsonl|--text]
+canarchy filter <expression> --stdin [--json|--jsonl|--text]
+canarchy j1939 decode --stdin [--json|--jsonl|--text]
 ```
 
 Representative usage:

--- a/docs/design/config-show-command.md
+++ b/docs/design/config-show-command.md
@@ -28,12 +28,12 @@ Operators need an inspectable way to answer basic configuration questions such a
 | `REQ-CONFIG-05` | Optional feature | Where a value is set in the config file and not overridden by the environment, the system shall use the config-file value and mark its source as `file`. |
 | `REQ-CONFIG-06` | State-driven | While no environment or config-file override exists for a supported setting, the system shall use the built-in default and mark its source as `default`. |
 | `REQ-CONFIG-07` | Ubiquitous | The `config show` result shall report the resolved config-file path and whether that file currently exists. |
-| `REQ-CONFIG-08` | Ubiquitous | `config show` shall preserve the standard output modes (`--json`, `--jsonl`, `--text`, `--raw`) with command-specific formatting over the same configuration payload. |
+| `REQ-CONFIG-08` | Ubiquitous | `config show` shall preserve the standard output modes (`--json`, `--jsonl`, `--text`) with command-specific formatting over the same configuration payload. |
 
 ## Command Surface
 
 ```text
-canarchy config show [--json] [--jsonl] [--text] [--raw]
+canarchy config show [--json] [--jsonl] [--text]
 ```
 
 ## Responsibilities And Boundaries
@@ -79,10 +79,6 @@ The `sources` object includes one source entry for each effective configuration 
 ### Table
 
 `--text` renders a human-readable configuration summary that shows each effective value together with its source annotation and ends with the config-file path plus its found/not-found status.
-
-### Raw
-
-`--raw` prints `config show` on success.
 
 ## Error Contracts
 

--- a/docs/design/dataset-provider-workflow.md
+++ b/docs/design/dataset-provider-workflow.md
@@ -35,7 +35,7 @@ canarchy datasets stream <file> --source-format hcrl-csv|candump --format candum
 canarchy datasets replay <dataset-ref-or-url> [--file <id-or-name>] [--list-files] [--format candump|jsonl] [--rate N] [--max-frames N] [--max-seconds N] [--dry-run]
 ```
 
-All commands follow the standard `--json`, `--jsonl`, `--text`, `--raw` output modes.
+All commands follow the standard `--json`, `--jsonl`, `--text` output modes.
 
 ---
 

--- a/docs/design/dbc-command-workflows.md
+++ b/docs/design/dbc-command-workflows.md
@@ -31,9 +31,9 @@ DBC-backed workflows are central to protocol-aware CAN analysis. Operators shoul
 ## Command Surface
 
 ```text
-canarchy decode --file <file> --dbc <file> [--json] [--jsonl] [--text] [--raw]
-canarchy decode --stdin --dbc <file> [--json] [--jsonl] [--text] [--raw]
-canarchy encode --dbc <file> <message> <signal=value>... [--json] [--jsonl] [--text] [--raw]
+canarchy decode --file <file> --dbc <file> [--json] [--jsonl] [--text]
+canarchy decode --stdin --dbc <file> [--json] [--jsonl] [--text]
+canarchy encode --dbc <file> <message> <signal=value>... [--json] [--jsonl] [--text]
 ```
 
 ## Responsibilities And Boundaries
@@ -63,9 +63,9 @@ Returns the standard CANarchy command envelope.
 
 Event-producing commands emit one event per line; warnings without corresponding events are emitted as alert lines.
 
-### Table and raw
+### Table
 
-Use the shared text/raw result rendering path.
+Use the shared text result rendering path.
 
 ## Error Contracts
 

--- a/docs/design/dbc-inspect-command.md
+++ b/docs/design/dbc-inspect-command.md
@@ -33,7 +33,7 @@ Operators often need to answer questions such as which messages exist in a datab
 ## Command Surface
 
 ```text
-canarchy dbc inspect <dbc> [--message <name>] [--signals-only] [--json] [--jsonl] [--text] [--raw]
+canarchy dbc inspect <dbc> [--message <name>] [--signals-only] [--json] [--jsonl] [--text]
 ```
 
 ### Arguments
@@ -186,10 +186,6 @@ nodes: 1
 ```
 
 When `--message EngineStatus1` is specified, the table includes the message summary plus one line per signal.
-
-### Raw
-
-Emits the inspected file path on success or the first error message on failure.
 
 ## Error Contracts
 

--- a/docs/design/dbc-provider-workflows.md
+++ b/docs/design/dbc-provider-workflows.md
@@ -39,16 +39,16 @@ Operators often have a capture before they have the matching DBC on disk. CANarc
 ## Command Surface
 
 ```text
-canarchy dbc provider list [--json] [--jsonl] [--text] [--raw]
-canarchy dbc search <query> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--text] [--raw]
-canarchy dbc fetch <ref> [--json] [--jsonl] [--text] [--raw]
-canarchy dbc cache list [--json] [--jsonl] [--text] [--raw]
-canarchy dbc cache prune [--provider <name>] [--json] [--jsonl] [--text] [--raw]
-canarchy dbc cache refresh [--provider <name>] [--json] [--jsonl] [--text] [--raw]
-canarchy decode --file <file> --dbc <path|provider-ref> [--json] [--jsonl] [--text] [--raw]
-canarchy decode --stdin --dbc <path|provider-ref> [--json] [--jsonl] [--text] [--raw]
-canarchy encode --dbc <path|provider-ref> <message> <signal=value>... [--json] [--jsonl] [--text] [--raw]
-canarchy dbc inspect <path|provider-ref> [--message <name>] [--signals-only] [--json] [--jsonl] [--text] [--raw]
+canarchy dbc provider list [--json] [--jsonl] [--text]
+canarchy dbc search <query> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--text]
+canarchy dbc fetch <ref> [--json] [--jsonl] [--text]
+canarchy dbc cache list [--json] [--jsonl] [--text]
+canarchy dbc cache prune [--provider <name>] [--json] [--jsonl] [--text]
+canarchy dbc cache refresh [--provider <name>] [--json] [--jsonl] [--text]
+canarchy decode --file <file> --dbc <path|provider-ref> [--json] [--jsonl] [--text]
+canarchy decode --stdin --dbc <path|provider-ref> [--json] [--jsonl] [--text]
+canarchy encode --dbc <path|provider-ref> <message> <signal=value>... [--json] [--jsonl] [--text]
+canarchy dbc inspect <path|provider-ref> [--message <name>] [--signals-only] [--json] [--jsonl] [--text]
 ```
 
 ## Responsibilities And Boundaries
@@ -114,10 +114,6 @@ Provider and cache commands emit a single result object line because they do not
 ### Table
 
 `dbc provider list` and `dbc search` use DBC-specific table helpers. Cache and fetch workflows return compact key/value summaries.
-
-### Raw
-
-Provider and cache workflows emit the command name on success or the first error message on failure.
 
 ## Error Contracts
 

--- a/docs/design/dbc-runtime-schema-split.md
+++ b/docs/design/dbc-runtime-schema-split.md
@@ -32,10 +32,10 @@ Operators and agents need richer database-aware workflows than the current thin 
 ## Command Surface
 
 ```text
-canarchy decode --file <file> --dbc <file> [--json] [--jsonl] [--text] [--raw]
-canarchy decode --stdin --dbc <file> [--json] [--jsonl] [--text] [--raw]
-canarchy encode --dbc <file> <message> <signal=value>... [--json] [--jsonl] [--text] [--raw]
-canarchy dbc inspect <dbc> [--message <name>] [--signals-only] [--json] [--jsonl] [--text] [--raw]
+canarchy decode --file <file> --dbc <file> [--json] [--jsonl] [--text]
+canarchy decode --stdin --dbc <file> [--json] [--jsonl] [--text]
+canarchy encode --dbc <file> <message> <signal=value>... [--json] [--jsonl] [--text]
+canarchy dbc inspect <dbc> [--message <name>] [--signals-only] [--json] [--jsonl] [--text]
 ```
 
 Future schema-management commands are expected to live under a separate `canarchy db ...` namespace.
@@ -88,9 +88,9 @@ The command layer continues to own all human and machine-readable output contrac
 * `decode` and `encode` shall preserve their existing envelopes and event shapes unless a design spec explicitly expands them
 * `dbc inspect` shall emit the metadata structures defined in `docs/design/dbc-inspect-command.md`
 
-### Table and raw
+### Text
 
-Table and raw formatting remain command-layer concerns and shall not depend on third-party object representations.
+Text formatting remains a command-layer concern and shall not depend on third-party object representations.
 
 ## Error Contracts
 
@@ -110,7 +110,7 @@ All phases complete as of April 2026:
 | Phase | Status | Description |
 |-------|--------|-------------|
 | Phase 1 | Done | Internal metadata types in `dbc_types.py`, facade at `dbc.py`, `DBC_SIGNAL_INVALID` aligned, fixtures expanded |
-| Phase 2 | Done | `canarchy dbc inspect` implemented, JSON/JSONL/text/raw outputs, MCP exposed |
+| Phase 2 | Done | `canarchy dbc inspect` implemented, JSON/JSONL/text outputs, MCP exposed |
 | Phase 3 | Done | cantools runtime adapter at `dbc_runtime.py`, decode/encode switched, fixture parity verified |
 | Phase 4 | Deferred | canmatrix retained for future schema workflows |
 | Phase 5 | Deferred | Evaluate long-term dependency strategy later |

--- a/docs/design/export-command.md
+++ b/docs/design/export-command.md
@@ -33,7 +33,7 @@ Operators need a deterministic way to persist machine-readable results from curr
 ## Command Surface
 
 ```text
-canarchy export <source> <destination> [--json] [--jsonl] [--text] [--raw]
+canarchy export <source> <destination> [--json] [--jsonl] [--text]
 ```
 
 ### Supported source forms

--- a/docs/design/gateway-command.md
+++ b/docs/design/gateway-command.md
@@ -36,7 +36,7 @@ canarchy gateway <src> <dst>
                  [--src-backend TYPE] [--dst-backend TYPE]
                  [--bidirectional]
                  [--count N]
-                 [--json] [--jsonl] [--text] [--raw]
+                 [--json] [--jsonl] [--text]
 ```
 
 ### Arguments
@@ -98,7 +98,7 @@ Relevant event fields:
 
 ## Output Contracts
 
-### Table and raw
+### Text
 
 Default streaming output is candump-style with a gateway header and direction labels.
 

--- a/docs/design/generate-command.md
+++ b/docs/design/generate-command.md
@@ -37,7 +37,7 @@ Operators need a quick active-traffic workflow for lab validation, replay suppor
 ```text
 canarchy generate <interface> [--id <hex|R>] [--dlc <0-8|R>] [--data <hex|R|I>]
                                [--count <n>] [--gap <ms>] [--extended] [--ack-active]
-                               [--json] [--jsonl] [--text] [--raw]
+                               [--json] [--jsonl] [--text]
 ```
 
 ### Arguments
@@ -104,10 +104,6 @@ frames: 3
 (0.200000) can0 3B2#00112233
 (0.400000) can0 1FF#FF
 ```
-
-### Raw
-
-Emits the command name on success or the first error message on failure.
 
 ## Error Contracts
 

--- a/docs/design/j1939-bounded-analysis.md
+++ b/docs/design/j1939-bounded-analysis.md
@@ -32,12 +32,12 @@ Large heavy-vehicle captures often contain millions of frames. Analysts need to 
 ## Command Surface
 
 ```text
-canarchy j1939 decode --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--text] [--raw]
-canarchy j1939 decode --stdin [--dbc <path|provider-ref>] [--json] [--jsonl] [--text] [--raw]
-canarchy j1939 pgn <pgn> --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--text] [--raw]
-canarchy j1939 spn <spn> --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--text] [--raw]
-canarchy j1939 tp sessions --file <capture> [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--text] [--raw]
-canarchy j1939 dm1 --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--text] [--raw]
+canarchy j1939 decode --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--text]
+canarchy j1939 decode --stdin [--dbc <path|provider-ref>] [--json] [--jsonl] [--text]
+canarchy j1939 pgn <pgn> --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--text]
+canarchy j1939 spn <spn> --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--text]
+canarchy j1939 tp sessions --file <capture> [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--text]
+canarchy j1939 dm1 --file <capture> [--dbc <path|provider-ref>] [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--text]
 ```
 
 ## Responsibilities And Boundaries

--- a/docs/design/j1939-first-class-decoder.md
+++ b/docs/design/j1939-first-class-decoder.md
@@ -30,19 +30,19 @@ Operators need J1939 commands that scale beyond a demo-only SPN map. They should
 | `REQ-J1939F-05` | Optional feature | Where `--dbc <path|provider-ref>` is specified for a J1939 decode workflow, the system shall enrich protocol-aware results with DBC-backed signal metadata and values when the supplied DBC contains a matching J1939 definition. |
 | `REQ-J1939F-10` | Optional feature | Where no `--dbc` flag is supplied and a default J1939 DBC is configured through `CANARCHY_J1939_DBC` or `[j1939].dbc`, the system shall use that configured DBC for J1939 DBC enrichment workflows. |
 | `REQ-J1939F-06` | Event-driven | When `j1939 spn <spn>` is invoked, the system shall resolve the requested SPN through the library-backed metadata path and optional DBC input rather than limiting decode to the current curated starter map. |
-| `REQ-J1939F-07` | Ubiquitous | The system shall preserve the existing command names and standard output modes (`--json`, `--jsonl`, `--text`, `--raw`) while upgrading the decoder implementation. |
+| `REQ-J1939F-07` | Ubiquitous | The system shall preserve the existing command names and standard output modes (`--json`, `--jsonl`, `--text`) while upgrading the decoder implementation. |
 | `REQ-J1939F-08` | Unwanted behaviour | If the configured J1939 decoder backend cannot be initialized, the system shall return a structured error with code `J1939_DECODER_UNAVAILABLE` and exit code `3`. |
 | `REQ-J1939F-09` | Unwanted behaviour | If `j1939 spn <spn>` is requested and neither the library metadata nor an optional DBC can resolve that SPN, the system shall return a structured error with code `J1939_SPN_NOT_FOUND` and exit code `1`. |
 
 ## Command Surface
 
 ```text
-canarchy j1939 decode --file <capture> [--dbc <path|provider-ref>] [--json] [--jsonl] [--text] [--raw]
-canarchy j1939 decode --stdin [--dbc <path|provider-ref>] [--json] [--jsonl] [--text] [--raw]
-canarchy j1939 pgn <pgn> --file <capture> [--dbc <path|provider-ref>] [--json] [--jsonl] [--text] [--raw]
-canarchy j1939 spn <spn> --file <capture> [--dbc <path|provider-ref>] [--json] [--jsonl] [--text] [--raw]
-canarchy j1939 tp sessions --file <capture> [--json] [--jsonl] [--text] [--raw]
-canarchy j1939 dm1 --file <capture> [--dbc <path|provider-ref>] [--json] [--jsonl] [--text] [--raw]
+canarchy j1939 decode --file <capture> [--dbc <path|provider-ref>] [--json] [--jsonl] [--text]
+canarchy j1939 decode --stdin [--dbc <path|provider-ref>] [--json] [--jsonl] [--text]
+canarchy j1939 pgn <pgn> --file <capture> [--dbc <path|provider-ref>] [--json] [--jsonl] [--text]
+canarchy j1939 spn <spn> --file <capture> [--dbc <path|provider-ref>] [--json] [--jsonl] [--text]
+canarchy j1939 tp sessions --file <capture> [--json] [--jsonl] [--text]
+canarchy j1939 dm1 --file <capture> [--dbc <path|provider-ref>] [--json] [--jsonl] [--text]
 
 # optional defaults
 # ~/.canarchy/config.toml
@@ -107,10 +107,6 @@ J1939 commands shall continue returning the standard CANarchy result envelope. D
 ### Table
 
 Human-readable output shall remain protocol-first, showing PGNs, SPNs, source and destination addressing, TP session progress, and DM1 diagnostic content without forcing operators back to raw frame-only views.
-
-### Raw
-
-Raw mode shall preserve current command-name-on-success behavior unless a command already defines a more specific raw contract.
 
 ## Error Contracts
 

--- a/docs/design/j1939-monitor-command.md
+++ b/docs/design/j1939-monitor-command.md
@@ -26,12 +26,12 @@ Operators need a fast way to inspect live or sample J1939 traffic as PGN-oriente
 | `REQ-J1939MON-03` | Event-driven | When `j1939 monitor <interface>` is invoked, the system shall use the transport-backed monitor path and include the selected interface in the structured result. |
 | `REQ-J1939MON-04` | Optional feature | Where `--pgn <id>` is specified, the system shall restrict emitted observations to the selected PGN and echo the filter value in the structured result. |
 | `REQ-J1939MON-05` | Ubiquitous | The `j1939 monitor` result envelope shall expose passive-mode metadata plus J1939 observation events rather than raw-frame-only output. |
-| `REQ-J1939MON-06` | Ubiquitous | `j1939 monitor` shall preserve the standard output modes (`--json`, `--jsonl`, `--text`, `--raw`) with command-specific formatting over the same observation stream. |
+| `REQ-J1939MON-06` | Ubiquitous | `j1939 monitor` shall preserve the standard output modes (`--json`, `--jsonl`, `--text`) with command-specific formatting over the same observation stream. |
 
 ## Command Surface
 
 ```text
-canarchy j1939 monitor [<interface>] [--pgn <id>] [--json] [--jsonl] [--text] [--raw]
+canarchy j1939 monitor [<interface>] [--pgn <id>] [--json] [--jsonl] [--text]
 ```
 
 ## Responsibilities And Boundaries
@@ -79,10 +79,6 @@ Each event is a J1939 PGN observation whose payload includes protocol-first fiel
 ### Table
 
 `--text` renders protocol-first observation lines, including PGN, source address, destination address, priority, and frame data, and shows the active `pgn_filter` when one is applied.
-
-### Raw
-
-`--raw` prints `j1939 monitor` on success.
 
 ## Error Contracts
 

--- a/docs/design/j1939-summary-command.md
+++ b/docs/design/j1939-summary-command.md
@@ -32,7 +32,7 @@ Operators often start with the question "what is in this capture and what looks 
 ## Command Surface
 
 ```text
-canarchy j1939 summary --file <capture> [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--text] [--raw]
+canarchy j1939 summary --file <capture> [--max-frames <n>] [--seconds <n>] [--json] [--jsonl] [--text]
 ```
 
 ## Responsibilities And Boundaries

--- a/docs/design/replay-command.md
+++ b/docs/design/replay-command.md
@@ -30,7 +30,7 @@ Replay is a core lab workflow for reproducing traffic patterns, validating tooli
 ## Command Surface
 
 ```text
-canarchy replay --file <file> [--rate <factor>] [--json] [--jsonl] [--text] [--raw]
+canarchy replay --file <file> [--rate <factor>] [--json] [--jsonl] [--text]
 ```
 
 ## Responsibilities And Boundaries

--- a/docs/design/reverse-engineering-helpers.md
+++ b/docs/design/reverse-engineering-helpers.md
@@ -36,12 +36,12 @@ Operators analysing unknown traffic need repeatable helpers that summarise likel
 ## Command Surface
 
 ```text
-canarchy re signals <file> [--json] [--jsonl] [--text] [--raw]
-canarchy re counters <file> [--json] [--jsonl] [--text] [--raw]
-canarchy re entropy <file> [--json] [--jsonl] [--text] [--raw]
-canarchy re correlate <file> --reference <file> [--json] [--jsonl] [--text] [--raw]
-canarchy re match-dbc <capture> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--text] [--raw]
-canarchy re shortlist-dbc <capture> --make <brand> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--text] [--raw]
+canarchy re signals <file> [--json] [--jsonl] [--text]
+canarchy re counters <file> [--json] [--jsonl] [--text]
+canarchy re entropy <file> [--json] [--jsonl] [--text]
+canarchy re correlate <file> --reference <file> [--json] [--jsonl] [--text]
+canarchy re match-dbc <capture> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--text]
+canarchy re shortlist-dbc <capture> --make <brand> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--text]
 ```
 
 ### Scope assumptions

--- a/docs/design/scapy-diagnostic-integration.md
+++ b/docs/design/scapy-diagnostic-integration.md
@@ -30,8 +30,8 @@ Operators already have structured UDS scan and trace workflows, but deeper diagn
 ## Command Surface
 
 ```text
-canarchy uds scan <interface> [--ack-active] [--json] [--jsonl] [--text] [--raw]
-canarchy uds trace <interface> [--json] [--jsonl] [--text] [--raw]
+canarchy uds scan <interface> [--ack-active] [--json] [--jsonl] [--text]
+canarchy uds trace <interface> [--json] [--jsonl] [--text]
 ```
 
 ## Responsibilities And Boundaries

--- a/docs/design/session-workflows.md
+++ b/docs/design/session-workflows.md
@@ -30,9 +30,9 @@ Operators often reuse the same interface, DBC, and capture context across comman
 ## Command Surface
 
 ```text
-canarchy session save <name> [--interface <name>] [--dbc <file>] [--capture <file>] [--json] [--jsonl] [--text] [--raw]
-canarchy session load <name> [--json] [--jsonl] [--text] [--raw]
-canarchy session show [--json] [--jsonl] [--text] [--raw]
+canarchy session save <name> [--interface <name>] [--dbc <file>] [--capture <file>] [--json] [--jsonl] [--text]
+canarchy session load <name> [--json] [--jsonl] [--text]
+canarchy session show [--json] [--jsonl] [--text]
 ```
 
 ## Responsibilities And Boundaries

--- a/docs/design/shell-command.md
+++ b/docs/design/shell-command.md
@@ -28,7 +28,7 @@ Operators sometimes want to run several CANarchy commands from a persistent prom
 ## Command Surface
 
 ```text
-canarchy shell [--command "<existing canarchy command>"] [--json] [--jsonl] [--text] [--raw]
+canarchy shell [--command "<existing canarchy command>"] [--json] [--jsonl] [--text]
 ```
 
 ## Responsibilities And Boundaries

--- a/docs/design/skills-agent-mcp-integration.md
+++ b/docs/design/skills-agent-mcp-integration.md
@@ -35,11 +35,11 @@ Operators and agents need a repeatable way to select the right CANarchy skill fo
 ## Command Surface
 
 ```text
-canarchy skills provider list [--json] [--jsonl] [--text] [--raw]
-canarchy skills search <query> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--text] [--raw]
-canarchy skills fetch <provider>:<skill> [--json] [--jsonl] [--text] [--raw]
-canarchy skills cache list [--json] [--jsonl] [--text] [--raw]
-canarchy skills cache refresh [--provider <name>] [--json] [--jsonl] [--text] [--raw]
+canarchy skills provider list [--json] [--jsonl] [--text]
+canarchy skills search <query> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--text]
+canarchy skills fetch <provider>:<skill> [--json] [--jsonl] [--text]
+canarchy skills cache list [--json] [--jsonl] [--text]
+canarchy skills cache refresh [--provider <name>] [--json] [--jsonl] [--text]
 canarchy mcp serve
 ```
 

--- a/docs/design/skills-provider-workflows.md
+++ b/docs/design/skills-provider-workflows.md
@@ -39,11 +39,11 @@ Operators and future agents need a local, inspectable skill catalog with reprodu
 ## Command Surface
 
 ```text
-canarchy skills provider list [--json] [--jsonl] [--text] [--raw]
-canarchy skills search <query> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--text] [--raw]
-canarchy skills fetch <ref> [--json] [--jsonl] [--text] [--raw]
-canarchy skills cache list [--json] [--jsonl] [--text] [--raw]
-canarchy skills cache refresh [--provider <name>] [--json] [--jsonl] [--text] [--raw]
+canarchy skills provider list [--json] [--jsonl] [--text]
+canarchy skills search <query> [--provider <name>] [--limit <n>] [--json] [--jsonl] [--text]
+canarchy skills fetch <ref> [--json] [--jsonl] [--text]
+canarchy skills cache list [--json] [--jsonl] [--text]
+canarchy skills cache refresh [--provider <name>] [--json] [--jsonl] [--text]
 ```
 
 ## Responsibilities And Boundaries
@@ -113,10 +113,6 @@ Provider and cache commands emit a single result object line because they do not
 ### Table
 
 `skills provider list`, `skills search`, `skills fetch`, `skills cache list`, and `skills cache refresh` use compact provider-specific summaries.
-
-### Raw
-
-Skills provider and cache workflows emit the command name on success or the first error message on failure.
 
 ## Error Contracts
 

--- a/docs/design/transport-core-commands.md
+++ b/docs/design/transport-core-commands.md
@@ -38,11 +38,11 @@ Operators need a stable base command set that supports passive live observation,
 ## Command Surface
 
 ```text
-canarchy capture <interface> [--candump] [--json] [--jsonl] [--text] [--raw]
-canarchy send <interface> <frame-id> <hex-data> [--ack-active] [--json] [--jsonl] [--text] [--raw]
-canarchy filter <expression> (--file <path>|--file -|--stdin) [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json] [--jsonl] [--text] [--raw]
-canarchy stats --file <path|-> [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json] [--jsonl] [--text] [--raw]
-canarchy capture-info --file <path|-> [--json] [--jsonl] [--text] [--raw]
+canarchy capture <interface> [--candump] [--json] [--jsonl] [--text]
+canarchy send <interface> <frame-id> <hex-data> [--ack-active] [--json] [--jsonl] [--text]
+canarchy filter <expression> (--file <path>|--file -|--stdin) [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json] [--jsonl] [--text]
+canarchy stats --file <path|-> [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json] [--jsonl] [--text]
+canarchy capture-info --file <path|-> [--json] [--jsonl] [--text]
 ```
 
 ## Responsibilities And Boundaries
@@ -103,7 +103,7 @@ Live `capture` emits one serialised event per line, matching JSONL semantics. Ot
 
 Event-producing commands emit one event per line. Event-less success and error paths emit a single result object line.
 
-### Table and raw
+### Table
 
 `capture` uses candump-style rendering for text, raw, and `--candump`. Other commands use the standard text or raw command-result paths, while active-command preflight warnings are emitted on `stderr`.
 

--- a/docs/design/uds-services-command.md
+++ b/docs/design/uds-services-command.md
@@ -28,7 +28,7 @@ UDS workflows are easier to script and reason about when the command surface inc
 ## Command Surface
 
 ```text
-canarchy uds services [--json] [--jsonl] [--text] [--raw]
+canarchy uds services [--json] [--jsonl] [--text]
 ```
 
 ## Responsibilities And Boundaries
@@ -64,10 +64,6 @@ Because `uds services` is reference-only and does not emit an event stream, both
 ### Table
 
 Text output presents a compact service catalogue with service identifier, positive-response identifier, category, and subfunction requirement.
-
-### Raw
-
-Raw output emits the command name on success.
 
 ## Error Contracts
 

--- a/docs/design/uds-transaction-workflows.md
+++ b/docs/design/uds-transaction-workflows.md
@@ -37,8 +37,8 @@ Operators need a protocol-aware UDS surface for discovery and transaction inspec
 ## Command Surface
 
 ```text
-canarchy uds scan <interface> [--ack-active] [--json] [--jsonl] [--text] [--raw]
-canarchy uds trace <interface> [--json] [--jsonl] [--text] [--raw]
+canarchy uds scan <interface> [--ack-active] [--json] [--jsonl] [--text]
+canarchy uds trace <interface> [--json] [--jsonl] [--text]
 ```
 
 ## Responsibilities And Boundaries

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -30,7 +30,7 @@ Implemented and exercised in the current codebase:
 * shell command reuse through `canarchy shell --command ...`
 * initial text-mode `tui` shell over the shared command layer
 * `config show` for effective transport configuration inspection
-* structured `--json`, `--jsonl`, `--text`, and `--raw` output modes
+* structured `--json`, `--jsonl`, `--text`, output modes
 
 Some protocol-oriented commands still use explicit sample/reference providers rather than true transport-backed execution. See [Architecture](architecture.md) and [Command Spec](command_spec.md) for the current boundary.
 

--- a/docs/spec-template.md
+++ b/docs/spec-template.md
@@ -117,7 +117,7 @@ Why an analyst or agent needs this capability.
 ## Command Surface
 
 \```text
-canarchy <command> <args> [--json] [--jsonl] [--text] [--raw]
+canarchy <command> <args> [--json] [--jsonl] [--text]
 \```
 
 ## Responsibilities And Boundaries
@@ -131,7 +131,7 @@ Key fields and structures returned by this command.
 
 ## Output Contracts
 
-How each output mode (`--json`, `--jsonl`, `--text`, `--raw`) behaves.
+How each output mode (`--json`, `--jsonl`, `--text`) behaves.
 
 ## Error Contracts
 

--- a/docs/tests/j1939-monitor-command.md
+++ b/docs/tests/j1939-monitor-command.md
@@ -73,18 +73,6 @@ And    the text output shall include the active PGN filter and protocol-first ob
 
 **Fixture:** built-in sample/reference provider.
 
----
-
-### TEST-J1939MON-05 — Raw output preserves the command-name contract
-
-```gherkin
-Given  the monitor command succeeds
-When   the operator runs `canarchy j1939 monitor --pgn 65262 --raw`
-Then   the system shall print `j1939 monitor`
-```
-
-**Fixture:** built-in sample/reference provider.
-
 ## Fixtures And Environment
 
 * built-in sample/reference J1939 provider

--- a/docs/tests/shell-command.md
+++ b/docs/tests/shell-command.md
@@ -31,9 +31,9 @@ Validate the one-shot shared-parser behavior of `shell` and document the current
 
 ```gherkin
 Given  the scaffold transport backend is active
-When   the operator runs `canarchy shell --command "capture can0 --raw"`
+When   the operator runs `canarchy shell --command "capture can0 --text"`
 Then   the delegated command shall execute through the shared CLI path
-And    the output shall match the expected raw output for the delegated command
+And    the output shall match the expected text output for the delegated command
 ```
 
 **Fixture:** scaffold backend (no file required).

--- a/docs/tests/tui-shell.md
+++ b/docs/tests/tui-shell.md
@@ -73,7 +73,7 @@ Then   the output shall contain a structured `INVALID_PGN` error in the alerts p
 
 ```gherkin
 Given  the TUI is running
-When   the operator submits the command `shell --command 'capture can0 --raw'` from TUI input
+When   the operator submits the command `shell --command 'capture can0 --text'` from TUI input
 Then   the output shall contain `TUI_COMMAND_UNSUPPORTED`
 ```
 

--- a/docs/tests/uds-services-command.md
+++ b/docs/tests/uds-services-command.md
@@ -17,7 +17,6 @@ Validate that `uds services` returns a stable protocol-reference catalog and ren
 * command succeeds without a transport interface
 * JSON output contains stable service catalog metadata
 * text output presents protocol-aware service summaries
-* raw output follows standard command-success behavior
 
 ## Requirement Traceability
 
@@ -54,20 +53,6 @@ And    the output shall include catalog rows with service and positive-response 
 ```
 
 **Fixture:** none required (in-repo UDS service catalog).
-
----
-
-### `TEST-UDS-SVC-03` — Raw output behavior
-
-```gherkin
-Given  no transport interface or live bus connection is required
-When   the operator runs `canarchy uds services --raw`
-Then   the output shall emit the command name on success
-```
-
-**Fixture:** none required (in-repo UDS service catalog).
-
----
 
 ## Fixtures And Environment
 

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -157,7 +157,6 @@ def add_output_arguments(parser: argparse.ArgumentParser) -> None:
     group.add_argument("--compact", action="store_true", help="emit compact JSON with frame data only")
     group.add_argument("--text", action="store_true", help="emit human-readable text output")
     group.add_argument("--table", action="store_true", help=argparse.SUPPRESS)
-    group.add_argument("--raw", action="store_true", help="emit raw output")
 
 
 def add_active_ack_argument(parser: argparse.ArgumentParser) -> None:
@@ -691,7 +690,7 @@ def build_parser() -> CanarchyArgumentParser:
 
 
 def format_name(args: argparse.Namespace) -> str:
-    for name in ("json", "jsonl", "compact", "text", "raw"):
+    for name in ("json", "jsonl", "compact", "text"):
         if getattr(args, name, False):
             return name
     if getattr(args, "table", False):
@@ -703,7 +702,7 @@ def requested_output_format(argv: Sequence[str] | None) -> str:
     if argv is None:
         return "text"
 
-    for name in ("json", "jsonl", "compact", "text", "raw"):
+    for name in ("json", "jsonl", "compact", "text"):
         if f"--{name}" in argv:
             return name
     if "--table" in argv:
@@ -3568,7 +3567,6 @@ def build_result(args: argparse.Namespace) -> CommandResult:
             "compact",
             "text",
             "table",
-            "raw",
             "ack_active",
         }
         and value is not None
@@ -4559,11 +4557,11 @@ def emit_live_capture(args: argparse.Namespace, output_format: str) -> int:
 
     All formats stream continuously rather than returning a fixed batch:
 
-    * ``text`` / ``table`` / ``raw`` / ``candump`` — candump-style text line per frame
+    * ``text`` / ``table`` / ``candump`` — candump-style text line per frame
     * ``json`` / ``jsonl`` — one ``json.dumps(event)`` line per frame
     """
     transport = LocalTransport()
-    text_mode = output_format in {"text", "raw"}
+    text_mode = output_format == "text"
     try:
         for event in transport.capture_stream_events(args.interface):
             if event.get("event_type") != "frame":
@@ -4773,24 +4771,6 @@ def emit_result(result: CommandResult, output_format: str) -> None:
             _emit_warnings_jsonl(payload, result)
             return
         print(json.dumps(payload, sort_keys=True))
-        return
-
-    if output_format == "raw":
-        if result.ok and result.command == "dbc inspect":
-            print(result.data.get("database", {}).get("path", result.command))
-            return
-        if result.ok and result.command == "gateway":
-            for line in format_gateway_lines(result):
-                print(line)
-            return
-        if result.ok and result.command == "capture" and result.data.get("display") == "candump":
-            for line in format_candump_lines(result):
-                print(line)
-            return
-        if result.ok:
-            print(result.command)
-        elif payload["errors"]:
-            print(payload["errors"][0]["message"])
         return
 
     if (
@@ -5074,7 +5054,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return run_tui(execute_command, command=args.tui_command)
     if args.command == "capture":
         return emit_live_capture(args, output_format)
-    if args.command == "gateway" and output_format in {"text", "raw"}:
+    if args.command == "gateway" and output_format == "text":
         return emit_live_gateway(args)
     if args.command == "datasets stream" and not args.json:
         return emit_dataset_stream(args)

--- a/src/canarchy/completion.py
+++ b/src/canarchy/completion.py
@@ -60,7 +60,7 @@ SUBCOMMANDS: dict[str, list[str]] = {
 }
 
 # Output format flags shared by every command.
-_OUTPUT = ["--json", "--jsonl", "--raw", "--text"]
+_OUTPUT = ["--json", "--jsonl", "--text"]
 _J1939_FILE_BOUNDS = ["--offset", "--max-frames", "--seconds"]
 
 # Per-command (or per-subcommand) flag lists.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -585,9 +585,9 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["errors"][0]["code"], "CAPTURE_SOURCE_INVALID")
 
     def test_nested_j1939_command_works(self) -> None:
-        exit_code, stdout, _ = run_cli("j1939", "monitor", "--pgn", "65262", "--raw")
+        exit_code, stdout, _ = run_cli("j1939", "monitor", "--pgn", "65262", "--text")
         self.assertEqual(exit_code, EXIT_OK)
-        self.assertEqual(stdout.strip(), "j1939 monitor")
+        self.assertIn("command: j1939 monitor", stdout)
 
     def test_j1939_monitor_returns_observations(self) -> None:
         exit_code, stdout, _ = run_cli("j1939", "monitor", "--json")
@@ -2019,11 +2019,11 @@ class CliTests(unittest.TestCase):
         self.assertIn("sid=0x10 name=DiagnosticSessionControl positive=0x50", stdout)
         self.assertIn("sid=0x27 name=SecurityAccess positive=0x67", stdout)
 
-    def test_uds_services_raw_output_is_command_name(self) -> None:
+    def test_raw_output_mode_is_rejected(self) -> None:
         exit_code, stdout, stderr = run_cli("uds", "services", "--raw")
-        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(exit_code, EXIT_USER_ERROR)
         self.assertEqual(stderr, "")
-        self.assertEqual(stdout.strip(), "uds services")
+        self.assertIn("error: INVALID_ARGUMENTS: unrecognized arguments: --raw", stdout)
 
     def test_uds_transport_error_returns_backend_exit_code(self) -> None:
         with patch("canarchy.transport._load_user_config", return_value={"CANARCHY_TRANSPORT_BACKEND": "scaffold"}):
@@ -2555,7 +2555,7 @@ class CliTests(unittest.TestCase):
 
     @patch("canarchy.transport._load_user_config", return_value={"CANARCHY_TRANSPORT_BACKEND": "scaffold"})
     def test_shell_command_reuses_cli_parser(self, _mock_cfg) -> None:
-        exit_code, stdout, stderr = run_cli("shell", "--command", "capture can0 --raw")
+        exit_code, stdout, stderr = run_cli("shell", "--command", "capture can0 --text")
         self.assertEqual(exit_code, EXIT_OK)
         self.assertEqual(stderr, "")
         self.assertIn(" can0 ", stdout)
@@ -2590,7 +2590,7 @@ class CliTests(unittest.TestCase):
         self.assertIn("error: INVALID_PGN: J1939 PGN must be between 0 and 262143.", stdout)
 
     def test_tui_command_rejects_nested_frontends(self) -> None:
-        exit_code, stdout, stderr = run_cli("tui", "--command", "shell --command 'capture can0 --raw'")
+        exit_code, stdout, stderr = run_cli("tui", "--command", "shell --command 'capture can0 --text'")
 
         self.assertEqual(exit_code, EXIT_USER_ERROR)
         self.assertEqual(stderr, "")
@@ -2601,7 +2601,7 @@ class CliTests(unittest.TestCase):
         """--help inside the shell must not exit the session."""
         # After one command containing --help (which raises SystemExit) the shell
         # should stay alive and accept a second command.
-        inputs = iter(["capture --help", "capture can0 --raw", EOFError()])
+        inputs = iter(["capture --help", "capture can0 --text", EOFError()])
 
         def fake_input(_prompt):
             val = next(inputs)
@@ -2629,7 +2629,7 @@ class CliTests(unittest.TestCase):
             # second call succeeds normally
             return 0
 
-        inputs = iter(["stats tests/fixtures/sample.candump", "capture can0 --raw", EOFError()])
+        inputs = iter(["stats tests/fixtures/sample.candump", "capture can0 --text", EOFError()])
 
         def fake_input(_prompt):
             val = next(inputs)
@@ -2647,7 +2647,7 @@ class CliTests(unittest.TestCase):
     @patch("canarchy.transport._load_user_config", return_value={"CANARCHY_TRANSPORT_BACKEND": "scaffold"})
     def test_shell_survives_keyboard_interrupt_at_prompt(self, _mock_cfg) -> None:
         """Ctrl+C at the input prompt must not exit the shell."""
-        inputs = iter([KeyboardInterrupt(), "capture can0 --raw", EOFError()])
+        inputs = iter([KeyboardInterrupt(), "capture can0 --text", EOFError()])
 
         def fake_input(_prompt):
             val = next(inputs)
@@ -2687,7 +2687,7 @@ class CliTests(unittest.TestCase):
             call_count += 1
             raise KeyboardInterrupt
 
-        result = _run_tui_command("capture can0 --raw", state, raising_execute)
+        result = _run_tui_command("capture can0 --text", state, raising_execute)
         self.assertEqual(result, 0)
         self.assertEqual(call_count, 1)
 
@@ -2791,10 +2791,10 @@ class CliTests(unittest.TestCase):
         self.assertFalse(payload["ok"])
         self.assertEqual(payload["errors"][0]["code"], "INVALID_PGN")
 
-    def test_raw_error_output_is_message_only(self) -> None:
-        exit_code, stdout, _ = run_cli("j1939", "pgn", "300000", "--raw")
+    def test_text_error_output_includes_structured_error_line(self) -> None:
+        exit_code, stdout, _ = run_cli("j1939", "pgn", "300000", "--text")
         self.assertEqual(exit_code, EXIT_USER_ERROR)
-        self.assertEqual(stdout.strip(), "J1939 PGN must be between 0 and 262143.")
+        self.assertIn("error: INVALID_PGN: J1939 PGN must be between 0 and 262143.", stdout)
 
     def test_j1939_pgn_requires_capture_file(self) -> None:
         exit_code, stdout, stderr = run_cli("j1939", "pgn", "65262", "--json")
@@ -3539,12 +3539,12 @@ class CliTests(unittest.TestCase):
         self.assertEqual(event_types.count("frame"), 2)
 
     @patch("canarchy.transport._load_user_config", return_value={"CANARCHY_TRANSPORT_BACKEND": "scaffold"})
-    def test_generate_raw_output_emits_command_name(self, _mock_cfg) -> None:
+    def test_generate_rejects_raw_output_mode(self, _mock_cfg) -> None:
         exit_code, stdout, _ = run_cli(
             "generate", "can0", "--id", "0x1", "--dlc", "1", "--data", "AA", "--raw"
         )
-        self.assertEqual(exit_code, EXIT_OK)
-        self.assertIn("generate", stdout.strip())
+        self.assertEqual(exit_code, EXIT_USER_ERROR)
+        self.assertIn("error: INVALID_ARGUMENTS: unrecognized arguments: --raw", stdout)
 
     # --- Result data fields ---
 
@@ -3953,7 +3953,7 @@ class CompletionTests(unittest.TestCase):
         self.assertIn("--json", names)
         self.assertIn("--jsonl", names)
         self.assertIn("--text", names)
-        self.assertIn("--raw", names)
+        self.assertNotIn("--raw", names)
         self.assertNotIn("--table", names)
 
     def test_generate_flags_include_gap_and_count(self) -> None:


### PR DESCRIPTION
## Summary
- Remove the shared `--raw` output mode from CLI parsing, help, completions, and generic rendering.
- Keep command-specific frame-line workflows through explicit options such as `capture --candump`.
- Update docs, specs, tests, README, AGENTS, and changelog to document `--json`, `--jsonl`, and `--text` as standard output modes.

## Verification
- `uv run python -m pytest tests/ -q`
- `uv run mkdocs build --strict`
- `uv run canarchy config show --help`
- `uv run canarchy config show`
- `uv run canarchy config show --raw`
- `uv run canarchy capture can0 --help`

Closes #288