### PR TITLE
Clean up stale docs after output mode changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * Renamed the canonical human-readable output flag from `--table` to `--text`; `--table` remains accepted as a compatibility alias. Closes #286.
 * Removed the generic `--raw` output mode from the shared command surface; use `--text`, `--json`, `--jsonl`, or command-specific frame-line options such as `--candump` instead. Closes #288.
 
+### Documentation
+
+* Cleaned up stale homepage, overview, command spec, and design wording after the output-mode updates. Closes #290.
+
 ## [0.7.0] - 2026-05-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ CANarchy is a stream-first CAN analysis and manipulation runtime designed for au
 
 The project is implemented in Python and uses `uv` for environment, dependency, and packaging workflows.
 
-Every command emits a [canonical event stream](docs/event-schema.md) — structured, pipeable, and machine-readable. The CLI is the interface. JSONL is the wire format. J1939 is a first-class citizen, not an afterthought.
+Machine-readable output uses canonical JSON envelopes and JSONL event streams where commands produce typed events. The CLI is the interface. J1939 is a first-class citizen, not an afterthought.
 
 Today the repository delivers:
 

--- a/docs/command_spec.md
+++ b/docs/command_spec.md
@@ -1136,4 +1136,3 @@ These commands are present in the CLI tree but not yet implemented end to end:
 These deeper capabilities are also not implemented yet even where the command surface exists:
 
 * deeper live transport integration beyond the current `python-can` transport path
-* pretty-print output tailored for UDS commands

--- a/docs/design/dbc-runtime-schema-split.md
+++ b/docs/design/dbc-runtime-schema-split.md
@@ -15,7 +15,7 @@ Define an internal DBC architecture that preserves CANarchy's stable CLI and eve
 
 ## User-Facing Motivation
 
-Operators and agents need richer database-aware workflows than the current thin DBC layer provides, but they also need stext outputs. A split architecture lets CANarchy adopt `cantools` where runtime metadata and validation matter, while retaining `canmatrix` for schema ingestion and future conversion-oriented workflows.
+Operators and agents need richer database-aware workflows than the current thin DBC layer provides, but they also need stable outputs. A split architecture lets CANarchy adopt `cantools` where runtime metadata and validation matter, while retaining `canmatrix` for schema ingestion and future conversion-oriented workflows.
 
 ## Requirements
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 CANarchy is a stream-first CAN analysis and manipulation runtime designed for automation, security research, and agent-driven workflows.
 
-Every command emits a [canonical event stream](event-schema.md) — structured, pipeable, and machine-readable. The CLI is the interface. JSONL is the wire format. J1939 is treated as a first-class workflow, not a plugin.
+Machine-readable output uses canonical JSON envelopes and JSONL event streams where commands produce typed events. The CLI is the interface. J1939 is treated as a first-class workflow, not a plugin.
 
 This docs site is the project documentation portal hosted from the same repository as the code.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -30,7 +30,7 @@ Implemented and exercised in the current codebase:
 * shell command reuse through `canarchy shell --command ...`
 * initial text-mode `tui` shell over the shared command layer
 * `config show` for effective transport configuration inspection
-* structured `--json`, `--jsonl`, `--text`, output modes
+* structured `--json`, `--jsonl`, and `--text` output modes
 
 Some protocol-oriented commands still use explicit sample/reference providers rather than true transport-backed execution. See [Architecture](architecture.md) and [Command Spec](command_spec.md) for the current boundary.
 
@@ -38,7 +38,6 @@ Some protocol-oriented commands still use explicit sample/reference providers ra
 
 Present in the CLI tree but not yet implemented end to end:
 
-* `re correlate`
 * `fuzz replay`, `fuzz mutate`, and `fuzz id`
 
 ## Recommended Reading


### PR DESCRIPTION
## Summary
- Clarify homepage and README structured-output wording so it does not imply every command always emits an event stream.
- Remove stale `re correlate` and UDS pretty-print gap references.
- Fix overview output-mode wording and a DBC design typo.

## Verification
- `uv run mkdocs build --strict`

Closes #290