### PR TITLE
Remove compact output and fuzz placeholders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -472,15 +472,12 @@ canarchy
     counters
     entropy
     correlate
-  fuzz
-    replay
-    mutate
-    id
   shell
   tui
 ```
 
 This tree is a starting point, not a lock.
+Fuzzing workflows are planned but intentionally not exposed until active-transmit safety design is complete.
 
 For dataset automation, agents should prefer MCP dataset tools when available, or explicit CLI JSON output otherwise. `datasets_search` / `datasets search --json` and `datasets_inspect` / `datasets inspect --json` include stable machine fields: `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`. `datasets_fetch` distinguishes curated indexes from normal dataset entries with `is_index`, `index_instructions`, and `download_instructions`. Use MCP `datasets_replay_plan` or CLI `datasets replay --dry-run --json` for safe replay preflight; use `datasets replay --list-files --json` to choose a replay file and `--file <id-or-name>` to select it. Use `--max-frames` or `--max-seconds` to bound replay. Use `datasets stream --max-frames <n>` to bound local downloaded dataset-file streaming; `--chunk-size` controls JSONL provenance chunk metadata and is not a frame limit. Actual dataset frame streaming remains CLI-only. Curated index entries that cannot be replayed return `DATASET_INDEX_NOT_REPLAYABLE`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * Renamed the canonical human-readable output flag from `--table` to `--text`; `--table` remains accepted as a compatibility alias. Closes #286.
 * Removed the generic `--raw` output mode from the shared command surface; use `--text`, `--json`, `--jsonl`, or command-specific frame-line options such as `--candump` instead. Closes #288.
 
+### Removed
+
+* Removed the `--compact` output mode and the placeholder `fuzz` command tree; fuzzing remains planned but is no longer exposed before active-transmit safety design is complete. Closes #292.
+
 ### Documentation
 
 * Cleaned up stale homepage, overview, command spec, and design wording after the output-mode updates. Closes #290.

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Fully implemented and tested:
 * `shell` — interactive REPL and `--command` scripting mode
 * `tui` — terminal UI front end
 
-Present in the CLI surface but not yet fully implemented:
+Planned but not yet exposed in the CLI:
 
-* `fuzz replay`, `fuzz mutate`, `fuzz id` — active fuzzing (planned)
+* active fuzzing workflows for replay mutation, payload mutation, and arbitration-ID probing
 
 Default transport backend is `python-can`; set `CANARCHY_TRANSPORT_BACKEND=scaffold` for deterministic offline behavior.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -112,7 +112,7 @@ Current exclusions:
 
 * dataset streaming commands that emit frame records, such as `datasets stream` and non-dry-run `datasets replay`
 * interactive or service commands such as `shell`, `tui`, and `mcp serve`
-* `fuzz` placeholder commands (deferred until active fuzzing safety design is complete)
+* fuzzing workflows (deferred until active fuzzing safety design is complete)
 
 For dataset workflows, agents should prefer MCP dataset tools when available. `datasets_search` and `datasets_inspect` include stable machine fields: `ref`, `is_replayable`, `is_index`, `default_replay_file`, `download_url_available`, and `source_type`. `datasets_fetch` distinguishes curated indexes from normal dataset entries with `is_index`, `index_instructions`, and `download_instructions`. Use `datasets_replay_plan` for safe replay preflight; use CLI `datasets replay --list-files --json` to choose a replay file and `--file <id-or-name>` to select it. Use `max_frames` or `max_seconds` to bound replay. Use CLI `datasets stream --max-frames <n>` to bound local downloaded dataset-file streaming. `--chunk-size` controls JSONL provenance chunk metadata only; it is not a frame limit. Actual frame streaming remains CLI-only. Curated index entries that cannot be replayed return `DATASET_INDEX_NOT_REPLAYABLE`.
 

--- a/docs/command_spec.md
+++ b/docs/command_spec.md
@@ -26,8 +26,6 @@ Implemented and verified in the current codebase:
 * structured JSON and JSONL output
 * explicit error schema and exit codes
 
-Some other commands are already present in the CLI tree but still return placeholder results until their implementation issues are completed.
-
 Important current behavior:
 
 * live transport-facing commands default to the `python-can` backend; set `backend = "scaffold"` in `~/.canarchy/config.toml` or export `CANARCHY_TRANSPORT_BACKEND=scaffold` for deterministic offline behavior
@@ -35,7 +33,6 @@ Important current behavior:
 * the default `python-can` interface is `socketcan`; set `interface` in the config file or `CANARCHY_PYTHON_CAN_INTERFACE` to change it
 * DBC-backed commands accept local paths and provider refs such as `opendbc:<name>` or `comma:<name>`
 * `decode`, `encode`, and `dbc inspect` include `data.dbc_source` in structured output so callers can see the provider, logical DBC name, pinned version, and resolved local path
-* placeholder-only commands, currently limited to the `fuzz` family, still return `status: planned` and `implementation: command surface scaffold`
 * some protocol-oriented commands currently use explicit sample/reference providers rather than true transport-backed execution paths
 * specialized text formatting exists for J1939 monitor and decode style output; other `--text` output is generic key/value rendering
 * file-backed analysis commands support standard timestamped candump log files with `.candump` and `.log` suffixes; selected commands also support `--file -` for candump text from stdin
@@ -122,7 +119,7 @@ Notes:
 Filter a capture source by a simple expression.
 
 ```bash
-canarchy filter <expression> (--file <path> | --file - | --stdin) [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json|--jsonl|--compact|--text]
+canarchy filter <expression> (--file <path> | --file - | --stdin) [--offset <n>] [--max-frames <n>] [--seconds <seconds>] [--json|--jsonl|--text]
 ```
 ```
 
@@ -1129,9 +1126,9 @@ canarchy shell --command "capture can0 --text"
 
 ## Current Gaps
 
-These commands are present in the CLI tree but not yet implemented end to end:
+Planned capabilities that are intentionally not exposed in the CLI yet:
 
-* `fuzz replay|mutate|id`
+* active fuzzing workflows for replay mutation, payload mutation, and arbitration-ID probing
 
 These deeper capabilities are also not implemented yet even where the command surface exists:
 

--- a/docs/design/mcp-server.md
+++ b/docs/design/mcp-server.md
@@ -119,7 +119,7 @@ The current MCP tool surface is a curated non-interactive subset of the CLI. It 
 | J1939 analysis including `j1939 compare`, `j1939 faults`, and TP compare | Exposed | File-backed analysis commands are safe, bounded, and deterministic. |
 | Reverse-engineering helpers including `re signals` | Exposed | File-backed analysis commands are safe and deterministic. |
 | `shell`, `tui`, `mcp serve` | Excluded | Interactive or service commands have no direct one-shot MCP tool equivalent. |
-| `fuzz` placeholder commands | Deferred | Active fuzzing workflows are command-surface scaffolds and need separate safety design before MCP exposure. |
+| Fuzzing workflows | Deferred | Active fuzzing needs separate safety design before CLI or MCP exposure. |
 
 ## Response Envelope
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -36,9 +36,9 @@ Some protocol-oriented commands still use explicit sample/reference providers ra
 
 ## Current Gaps
 
-Present in the CLI tree but not yet implemented end to end:
+Planned but not yet exposed in the CLI:
 
-* `fuzz replay`, `fuzz mutate`, and `fuzz id`
+* active fuzzing workflows for replay mutation, payload mutation, and arbitration-ID probing
 
 ## Recommended Reading
 

--- a/src/canarchy/cli.py
+++ b/src/canarchy/cli.py
@@ -154,7 +154,6 @@ def add_output_arguments(parser: argparse.ArgumentParser) -> None:
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--json", action="store_true", help="emit JSON output")
     group.add_argument("--jsonl", action="store_true", help="emit JSONL output")
-    group.add_argument("--compact", action="store_true", help="emit compact JSON with frame data only")
     group.add_argument("--text", action="store_true", help="emit human-readable text output")
     group.add_argument("--table", action="store_true", help=argparse.SUPPRESS)
 
@@ -647,24 +646,6 @@ def build_parser() -> CanarchyArgumentParser:
     add_output_arguments(re_shortlist_dbc)
     re_shortlist_dbc.set_defaults(command="re shortlist-dbc")
 
-    fuzz = subparsers.add_parser("fuzz", help="active fuzzing workflows")
-    fuzz_subparsers = fuzz.add_subparsers(dest="fuzz_action", required=True)
-
-    fuzz_replay = fuzz_subparsers.add_parser("replay", help="fuzz replay traffic")
-    fuzz_replay.add_argument("file")
-    add_output_arguments(fuzz_replay)
-    fuzz_replay.set_defaults(command="fuzz replay")
-
-    fuzz_mutate = fuzz_subparsers.add_parser("mutate", help="mutate captured traffic")
-    fuzz_mutate.add_argument("file")
-    add_output_arguments(fuzz_mutate)
-    fuzz_mutate.set_defaults(command="fuzz mutate")
-
-    fuzz_id = fuzz_subparsers.add_parser("id", help="fuzz arbitration IDs")
-    fuzz_id.add_argument("interface")
-    add_output_arguments(fuzz_id)
-    fuzz_id.set_defaults(command="fuzz id")
-
     config = subparsers.add_parser("config", help="inspect CANarchy configuration")
     config_subparsers = config.add_subparsers(dest="config_action", required=True)
     config_show = config_subparsers.add_parser("show", help="show effective transport configuration")
@@ -690,7 +671,7 @@ def build_parser() -> CanarchyArgumentParser:
 
 
 def format_name(args: argparse.Namespace) -> str:
-    for name in ("json", "jsonl", "compact", "text"):
+    for name in ("json", "jsonl", "text"):
         if getattr(args, name, False):
             return name
     if getattr(args, "table", False):
@@ -702,7 +683,7 @@ def requested_output_format(argv: Sequence[str] | None) -> str:
     if argv is None:
         return "text"
 
-    for name in ("json", "jsonl", "compact", "text"):
+    for name in ("json", "jsonl", "text"):
         if f"--{name}" in argv:
             return name
     if "--table" in argv:
@@ -3564,7 +3545,6 @@ def build_result(args: argparse.Namespace) -> CommandResult:
             "command_name",
             "json",
             "jsonl",
-            "compact",
             "text",
             "table",
             "ack_active",
@@ -4717,30 +4697,6 @@ def emit_result(result: CommandResult, output_format: str) -> None:
             data["frames"] = flat
         elif result.command in _J1939_SESSION_COMMANDS and "events" in data and not data["events"]:
             del data["events"]
-        print(json.dumps(payload, sort_keys=True))
-        return
-
-    if output_format == "compact":
-        if result.command == "filter":
-            if not result.ok:
-                print(json.dumps(payload, sort_keys=True))
-                return
-            events = payload.get("data", {}).get("events", [])
-            flat = [_flatten_frame_event(e) for e in events if e.get("event_type") == "frame"]
-            for frame in flat:
-                print(json.dumps(frame, sort_keys=True))
-            for warning in payload["warnings"]:
-                print(
-                    json.dumps(
-                        AlertEvent(
-                            level="warning",
-                            message=warning,
-                            source=f"cli.{result.command}",
-                        ).to_event().to_payload(),
-                        sort_keys=True,
-                    )
-                )
-            return
         print(json.dumps(payload, sort_keys=True))
         return
 

--- a/src/canarchy/completion.py
+++ b/src/canarchy/completion.py
@@ -28,7 +28,6 @@ TOP_LEVEL_COMMANDS: list[str] = [
     "encode",
     "export",
     "filter",
-    "fuzz",
     "gateway",
     "generate",
     "j1939",
@@ -56,7 +55,6 @@ SUBCOMMANDS: dict[str, list[str]] = {
     "skills cache": ["list", "refresh"],
     "uds": ["scan", "services", "trace"],
     "re": ["correlate", "counters", "entropy", "signals"],
-    "fuzz": ["id", "mutate", "replay"],
 }
 
 # Output format flags shared by every command.
@@ -73,7 +71,7 @@ FLAGS: dict[str, list[str]] = {
     "decode": ["--dbc", "--file"] + _OUTPUT,
     "encode": ["--dbc"] + _OUTPUT,
     "export": _OUTPUT,
-    "filter": ["--file", "--compact"] + _OUTPUT,
+    "filter": ["--file"] + _OUTPUT,
     "gateway": [
         "--ack-active",
         "--bidirectional",
@@ -103,9 +101,6 @@ FLAGS: dict[str, list[str]] = {
     "re counters": _OUTPUT,
     "re entropy": _OUTPUT,
     "re signals": _OUTPUT,
-    "fuzz id": _OUTPUT,
-    "fuzz mutate": _OUTPUT,
-    "fuzz replay": _OUTPUT,
     "replay": ["--file", "--rate"] + _OUTPUT,
     "send": ["--ack-active"] + _OUTPUT,
     "session load": _OUTPUT,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -455,18 +455,17 @@ class CliTests(unittest.TestCase):
         self.assertIn("dlc", frame)
         self.assertIn("is_extended_id", frame)
 
-    def test_filter_compact_output_returns_one_frame_per_line(self) -> None:
+    def test_filter_rejects_removed_compact_output_mode(self) -> None:
         exit_code, stdout, _ = run_cli(
             "filter", "extended", "--file", str(FIXTURES / "sample.candump"), "--compact"
         )
-        self.assertEqual(exit_code, EXIT_OK)
-        lines = stdout.strip().split("\n")
-        self.assertEqual(len(lines), 3)
-        for line in lines:
-            frame = json.loads(line)
-            self.assertIn("timestamp", frame)
-            self.assertIn("interface", frame)
-            self.assertIn("data", frame)
+        self.assertEqual(exit_code, EXIT_USER_ERROR)
+        self.assertIn("error: INVALID_ARGUMENTS: unrecognized arguments: --compact", stdout)
+
+    def test_fuzz_placeholder_command_is_not_registered(self) -> None:
+        exit_code, stdout, _ = run_cli("fuzz", "id", "can0")
+        self.assertEqual(exit_code, EXIT_USER_ERROR)
+        self.assertIn("error: INVALID_ARGUMENTS", stdout)
         exit_code, stdout, _ = run_cli(
             "filter", "dlc>4", "--file", str(FIXTURES / "sample.candump"), "--json"
         )
@@ -3730,10 +3729,10 @@ class CliTests(unittest.TestCase):
         payload = json.loads(stdout)
         self.assertEqual(payload["errors"][0]["code"], "INVALID_FILTER_EXPRESSION")
 
-    def test_compact_flag_not_leaked_into_stats_json_payload(self) -> None:
+    def test_output_flags_not_leaked_into_stats_json_payload(self) -> None:
         _, stdout, _ = run_cli("stats", "--file", str(FIXTURES / "sample.candump"), "--json")
         payload = json.loads(stdout)
-        self.assertNotIn("compact", payload["data"])
+        self.assertNotIn("text", payload["data"])
 
     def _mock_dbc_registry(self):
         from canarchy.dbc_provider import DbcDescriptor
@@ -3954,6 +3953,7 @@ class CompletionTests(unittest.TestCase):
         self.assertIn("--jsonl", names)
         self.assertIn("--text", names)
         self.assertNotIn("--raw", names)
+        self.assertNotIn("--compact", names)
         self.assertNotIn("--table", names)
 
     def test_generate_flags_include_gap_and_count(self) -> None:

--- a/tests/test_dbc.py
+++ b/tests/test_dbc.py
@@ -177,9 +177,9 @@ class DbcTests(unittest.TestCase):
         self.assertEqual(payload["command"], "dbc inspect")
         self.assertEqual(payload["data"]["database"]["message_count"], 2)
         self.assertEqual(payload["data"]["messages"][0]["name"], "EngineSpeed1")
-        self.assertNotIn("compact", payload["data"])
+        self.assertNotIn("text", payload["data"])
 
-    def test_compact_flag_not_leaked_into_json_payload(self) -> None:
+    def test_output_flags_not_leaked_into_json_payload(self) -> None:
         for argv in [
             ("dbc", "inspect", str(FIXTURES / "sample.dbc"), "--json"),
             ("encode", "--dbc", str(FIXTURES / "sample.dbc"), "EngineStatus1", "CoolantTemp=55", "--json"),
@@ -187,7 +187,7 @@ class DbcTests(unittest.TestCase):
             with self.subTest(argv=argv):
                 _, stdout, _ = run_cli(*argv)
                 payload = json.loads(stdout)
-                self.assertNotIn("compact", payload["data"])
+                self.assertNotIn("text", payload["data"])
 
     def test_dbc_inspect_unknown_message_returns_error(self) -> None:
         exit_code, stdout, stderr = run_cli(


### PR DESCRIPTION
## Summary
- Remove the `--compact` output mode and its filter-specific renderer.
- Remove the placeholder `fuzz` command tree from the CLI and completions.
- Document fuzzing as planned but intentionally not exposed until active-transmit safety design is complete.

## Verification
- `uv run python -m pytest tests/ -q`
- `uv run mkdocs build --strict`
- `uv run canarchy --help`
- `uv run canarchy filter --help`
- `uv run canarchy filter extended --file tests/fixtures/sample.candump --compact`
- `uv run canarchy fuzz id can0`

Closes #292