### PR TITLE
docs: governance, troubleshooting, cookbook, and config sample

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: Bug report
+description: Report unexpected behaviour in a CANarchy command, output, or workflow.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report.
+        Please complete the fields below so the issue can be triaged quickly.
+        For security-sensitive reports, follow SECURITY.md instead.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences describing what went wrong.
+      placeholder: "`canarchy filter` returned an empty result against a fixture that should match."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: The exact commands that show the problem. Use code fences.
+      placeholder: |
+        ```bash
+        canarchy filter 'id==0x123' --file tests/fixtures/sample.candump --json
+        ```
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      placeholder: "Expected at least one matching frame in the response payload."
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: Include the canonical envelope or text output you observed.
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: CANarchy version
+      description: Output of `canarchy --version`.
+      placeholder: "0.7.1.dev0"
+    validations:
+      required: true
+
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      placeholder: "3.12.4"
+
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Transport backend
+      options:
+        - python-can (socketcan)
+        - python-can (virtual)
+        - python-can (udp_multicast)
+        - python-can (other)
+        - scaffold
+        - not applicable
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Logs, captures (with sensitive data removed), or links.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://hexsecs.github.io/canarchy/docs/
+    about: User guide, command spec, event schema, and tutorials.
+  - name: Security report
+    url: https://github.com/hexsecs/canarchy/security/advisories/new
+    about: Private security advisory for sensitive reports. See SECURITY.md.
+  - name: Discussion or question
+    url: https://github.com/hexsecs/canarchy/discussions
+    about: Open-ended questions, ideas, or usage help.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Feature request
+description: Propose a new command, workflow, or capability.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for proposals that change or extend the CLI,
+        MCP, or library surface. Doc-only improvements can also use this
+        template — pick the closest fit.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences describing the proposed change.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Who benefits and why. What workflow is awkward today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed acceptance criteria
+      description: A bullet list of what must be true to close this issue.
+      placeholder: |
+        - `canarchy <command>` accepts `--new-flag`.
+        - Output JSON includes a new `field` documented in `docs/event-schema.md`.
+        - Tests cover the happy path and one structured-error case.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and non-goals
+      description: What is intentionally out of scope for this issue?
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed, and why this one fits.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,46 @@
+<!--
+Thanks for contributing to CANarchy. Please fill in the sections below.
+The PR acceptance gates live in AGENTS.md and CONTRIBUTING.md.
+-->
+
+## Summary
+
+<!-- Short description of the change. Reference the linked issue. -->
+
+Closes #
+
+## Changes
+
+<!-- Bullet list of the user-visible changes. Describe what changed, not
+which files were edited. -->
+
+-
+
+## Test plan
+
+<!-- How was this verified? Include the commands you ran and any manual
+checks against fixtures. -->
+
+- [ ] `uv run python -m unittest discover -s tests -v`
+- [ ] `uv run ruff check`
+- [ ] Manual run against a representative fixture or live interface
+
+## Documentation
+
+<!-- Tick every box that applies. PRs that change behaviour must update
+the matching docs in the same PR, not as a follow-up. -->
+
+- [ ] `CHANGELOG.md` updated under `[Unreleased]`
+- [ ] `docs/command_spec.md` updated (if the command surface changed)
+- [ ] `docs/event-schema.md` updated (if the structured-output shape changed)
+- [ ] Touched `docs/design/` spec updated (EARS syntax)
+- [ ] Touched `docs/tests/` spec updated (Gherkin Given/When/Then)
+- [ ] `AGENTS.md` / `docs/agents.md` updated (if agent workflows changed)
+- [ ] `mkdocs.yml` nav updated (if any new docs pages were added)
+
+## Safety
+
+<!-- Only if this PR introduces or changes active-bus behaviour. -->
+
+- [ ] Active-transmit commands require `--ack-active`
+- [ ] `SECURITY.md` reviewed against the new behaviour

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Documentation
 
 * Cleaned up stale homepage, overview, command spec, and design wording after the output-mode updates. Closes #290.
+* Added `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `SECURITY.md` at the repository root and linked them from the README under a Community section. Closes #296.
+* Added GitHub issue templates (bug report, feature request, contact-link config) and a pull request template under `.github/` so submissions follow the project's existing `## Summary` / `## Acceptance Criteria` shape. Closes #297.
+* Added `docs/troubleshooting.md` with a structured catalog of CLI error codes (`DBC_LOAD_FAILED`, `DBC_CACHE_MISS`, `DATASET_INDEX_NOT_REPLAYABLE`, `INVALID_MAX_FRAMES`, `ANALYSIS_WINDOW_REQUIRES_FILE`, and many more) including remediation snippets, and wired it into the User Guide nav. Closes #298.
+* Added a `docs/cookbook/` section with task-oriented recipes covering filtering by ID/PGN, decoding SPN 110, finding counter signals, matching captures against opendbc, streaming CANdid into stats, MCP integration with Claude Desktop and Claude Code, building a virtual CAN loop, and comparing DM1 faults across captures; new top-level Cookbook nav entry. Closes #299.
+* Added `docs/examples/config.toml` as a fully commented sample for `~/.canarchy/config.toml` and referenced it from the Getting Started guide. Closes #301.
 
 ## [0.7.0] - 2026-05-09
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,19 @@
+# Code of Conduct
+
+This project adopts the Contributor Covenant version 2.1 as its code of
+conduct.
+
+The full text is available at:
+https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+
+## Scope
+
+The Code of Conduct applies within all project spaces, and also when an
+individual is officially representing the project in public spaces.
+
+## Reporting
+
+Concerns about behaviour in project spaces should be reported to the
+project maintainers at the contact listed in [`SECURITY.md`](SECURITY.md).
+
+All reports will be reviewed and investigated promptly and fairly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,116 @@
+# Contributing to CANarchy
+
+Thanks for your interest in improving CANarchy. This guide is the short
+human-facing version of the contributor flow. Day-to-day project rules,
+agent-specific workflow, and deeper architectural guidance live in
+[`AGENTS.md`](AGENTS.md); please read that file before contributing
+non-trivial changes.
+
+## Project shape
+
+* CANarchy is implemented in Python and targets Python 3.12 or newer.
+* `uv` is the dependency / environment / build tool.
+* The CLI is the project contract; the REPL and TUI are views over the
+  same engine. New behaviour goes through the command layer.
+* Structured JSON / JSONL output is part of the public surface. Treat the
+  output envelope as stable unless the change is intentional and
+  documented in `CHANGELOG.md`.
+
+## Local development
+
+```bash
+# Sync dependencies and create the project virtualenv.
+uv sync
+
+# Install canarchy on your PATH so source edits take effect immediately.
+uv tool install --editable .
+
+# Confirm the CLI is wired up.
+canarchy --version
+canarchy --help
+
+# Run the full test suite.
+uv run python -m unittest discover -s tests -v
+```
+
+`uv.lock` is checked in for reproducible resolution. Do not modify it by
+hand — let `uv` do that.
+
+## Issues come first
+
+CANarchy uses GitHub Issues as the source of truth for planned work.
+
+* Before starting any non-trivial feature, bug fix, or refactor, check the
+  issue tracker for an existing item or open one with clear acceptance
+  criteria.
+* Comment on the issue to claim it before you start work. This prevents
+  duplicate effort.
+* Every commit should reference the relevant issue via
+  `closes #N`, `fixes #N`, or `refs #N`.
+
+The full rule is in [`AGENTS.md`](AGENTS.md#every-change-must-be-associated-with-an-issue).
+
+## Branches and pull requests
+
+* Work on a dedicated branch named after the issue where practical
+  (`issue-NNN-short-slug`).
+* Open a pull request when the work is ready — direct pushes to `main`
+  are not the default flow.
+* Update [`CHANGELOG.md`](CHANGELOG.md) under `[Unreleased]` in the same
+  PR that introduces the change.
+
+## What a "ready to merge" PR looks like
+
+Every PR must clear the following gates before it is ready for review:
+
+1. Linked issue referenced in the commit / PR body.
+2. Tests pass locally and in CI. New behaviour ships with new tests.
+3. `CHANGELOG.md` updated under `[Unreleased]`.
+4. Touched design spec under `docs/design/` reflects the implemented
+   behaviour (using EARS syntax per [`docs/spec-template.md`](docs/spec-template.md)).
+5. Touched test spec under `docs/tests/` reflects the actual coverage
+   (using Gherkin Given/When/Then per the same template).
+6. If the change affects the command surface, the MCP tool surface, or
+   the structured-output schema, `AGENTS.md` and `docs/agents.md` are
+   updated.
+7. Other docs (architecture, tutorials, `docs/command_spec.md`) do not
+   reference behaviour that this PR changes.
+
+See [`AGENTS.md`](AGENTS.md#pr-acceptance-criteria) for the canonical
+checklist.
+
+## Style and design
+
+* Favour readability and explicitness over cleverness. Keep modules
+  small and focused.
+* Prefer pure functions in the engine layer; keep transport adapters
+  separate from semantic layers.
+* Structured errors carry `code`, `message`, and an actionable `hint`.
+  Use `DBC_CACHE_MISS` as the reference for how to write a good hint.
+* Don't mix human-readable decoration into JSON or JSONL output. Log to
+  stderr; reserve stdout for structured payloads.
+* Active-transmit features (anything that writes frames to a real bus)
+  must respect the safety controls described in
+  [`SECURITY.md`](SECURITY.md) and the relevant design specs.
+
+## Documentation
+
+CANarchy treats documentation as part of the deliverable, not a follow-up.
+
+* Update `docs/command_spec.md` when adding or changing commands.
+* Update `docs/event-schema.md` when changing structured-output shapes.
+* Tutorials live under `docs/tutorials/`; short task recipes live under
+  `docs/cookbook/`.
+* The docs site is built with MkDocs in strict mode (`mkdocs.yml`). Any
+  new page must be added to the nav.
+
+## Reporting security issues
+
+Please follow [`SECURITY.md`](SECURITY.md) rather than filing a public
+issue for security-sensitive reports, particularly anything involving
+active transmission on a real vehicle bus.
+
+## Code of conduct
+
+By participating in this project, you agree to abide by the
+[Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -56,9 +56,17 @@ Default transport backend is `python-can`; set `CANARCHY_TRANSPORT_BACKEND=scaff
 * [Command spec](docs/command_spec.md)
 * [CAN Tool Feature Matrix](docs/feature-matrix.md) — high-level comparison to other OSS CAN tools
 * [Architecture](docs/architecture.md)
+* [Cookbook](docs/cookbook/index.md) — short task-oriented recipes
+* [Troubleshooting](docs/troubleshooting.md) — structured error-code catalog
 * [Changelog](CHANGELOG.md)
 * [Release Workflow](docs/release.md)
 * [J1939 Heavy Vehicle Demo](docs/tutorials/j1939_heavy_vehicle.md)
+
+### Community
+
+* [Contributing](CONTRIBUTING.md) — local development, branch flow, PR gates
+* [Code of Conduct](CODE_OF_CONDUCT.md)
+* [Security Policy](SECURITY.md) — reporting security concerns and active-bus operation guidance
 
 ### Installation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,56 @@
+# Security Policy
+
+CANarchy is a research toolkit for defensive analysis of CAN traffic. This
+document covers how to report security concerns and how the project
+treats active-bus operations.
+
+## Reporting a security concern
+
+Please do not file a public issue for reports that involve:
+
+* an undisclosed flaw in CANarchy itself
+* sensitive findings about a specific vehicle or fleet
+* anything that may affect a system in production use
+
+Open a private security advisory through the GitHub interface for this
+repository, or contact the maintainers via the address listed on the
+project page. Please include:
+
+* a clear description of the concern
+* steps to reproduce in a lab environment
+* the affected CANarchy version (`canarchy --version`)
+* any logs or captures that help triage (with personal data removed)
+
+A maintainer will acknowledge receipt and follow up with a planned
+response timeline.
+
+## Supported versions
+
+Only the most recent minor release receives fixes by default. Older
+versions may be patched at the maintainers' discretion when the fix is
+straightforward.
+
+## Active-bus operations
+
+CANarchy can transmit on a connected CAN interface. Commands that do so
+are documented as "active" and are gated by the `--ack-active` flag and
+an interactive confirmation prompt by default.
+
+When using active commands:
+
+* Run them on a lab bus, a bench harness, or a virtual interface first.
+* Confirm the target before transmitting.
+* Keep capture logs of every active session for later review.
+
+Do not run active commands against a vehicle that is in motion, that
+carries passengers, or that you are not authorised to test.
+
+Fuzzing workflows are intentionally not exposed in the current CLI while
+the active-transmit safety design is being completed. See
+`CHANGELOG.md` and the project roadmap for status.
+
+## Scope
+
+This policy covers the CANarchy CLI, library, MCP server, and the
+project documentation. Upstream dependencies (for example `python-can`
+and `cantools`) should be reported to their own maintainers.

--- a/docs/cookbook/compare-dm1-faults.md
+++ b/docs/cookbook/compare-dm1-faults.md
@@ -1,0 +1,57 @@
+# Compare two captures for DM1 fault diffs
+
+## Goal
+
+Given two J1939 captures from the same vehicle taken at different times,
+surface which active fault codes (DM1) changed between them.
+
+## Prerequisites
+
+* CANarchy installed.
+* Two J1939 captures. The example uses the in-tree fixtures:
+  * `tests/fixtures/j1939_heavy_vehicle.candump`
+  * `tests/fixtures/j1939_compare_shifted.candump`
+
+## Show active faults in each capture
+
+```bash
+canarchy j1939 dm1 \
+  --file tests/fixtures/j1939_heavy_vehicle.candump \
+  --text
+```
+
+```bash
+canarchy j1939 dm1 \
+  --file tests/fixtures/j1939_compare_shifted.candump \
+  --text
+```
+
+Each line lists the source address, transport mode, count of active
+DTCs, lamp state, and the decoded `spn`/`fmi` pairs.
+
+## Diff the two captures
+
+```bash
+canarchy j1939 compare \
+  tests/fixtures/j1939_heavy_vehicle.candump \
+  tests/fixtures/j1939_compare_shifted.candump \
+  --text
+```
+
+The compare output surfaces PGN deltas, source address changes, DM1
+fault changes, and printable TP identification differences.
+
+## JSON for further analysis
+
+```bash
+canarchy j1939 compare \
+  tests/fixtures/j1939_heavy_vehicle.candump \
+  tests/fixtures/j1939_compare_shifted.candump \
+  --json \
+  | jq '.data.dm1_changes'
+```
+
+## Where to go next
+
+* [Decode SPN 110](decode-spn-110.md)
+* [J1939 Heavy Vehicle Analysis tutorial](../tutorials/j1939_heavy_vehicle.md)

--- a/docs/cookbook/decode-spn-110.md
+++ b/docs/cookbook/decode-spn-110.md
@@ -1,0 +1,56 @@
+# Decode SPN 110 (engine coolant temperature)
+
+## Goal
+
+Extract engine coolant temperature samples from a J1939 capture using the
+SPN-aware decoder, with no DBC file required.
+
+## Prerequisites
+
+* CANarchy installed.
+* Any J1939 capture. The examples use
+  `tests/fixtures/j1939_heavy_vehicle.candump`.
+
+## Run
+
+```bash
+canarchy j1939 spn 110 \
+  --file tests/fixtures/j1939_heavy_vehicle.candump \
+  --text
+```
+
+Expected output (abridged):
+
+```text
+spn: 110
+file: tests/fixtures/j1939_heavy_vehicle.candump
+observations:
+- spn=110 name=Engine Coolant Temperature value=85.0 units=degC pgn=65262 sa=0x31 da=broadcast
+- spn=110 name=Engine Coolant Temperature value=86.0 units=degC pgn=65262 sa=0x31 da=broadcast
+- spn=110 name=Engine Coolant Temperature value=87.0 units=degC pgn=65262 sa=0x31 da=broadcast
+```
+
+## JSONL for downstream tools
+
+```bash
+canarchy j1939 spn 110 \
+  --file tests/fixtures/j1939_heavy_vehicle.candump \
+  --jsonl \
+  | jq '[.spn, .value, .units, .timestamp]'
+```
+
+## Other useful SPNs
+
+SPN | Description
+--- | ---
+190 | Engine speed
+84  | Wheel-based vehicle speed
+96  | Fuel level
+100 | Engine oil pressure
+
+Pass any of them to `canarchy j1939 spn <id> --file …`.
+
+## Where to go next
+
+* [J1939 Heavy Vehicle Analysis tutorial](../tutorials/j1939_heavy_vehicle.md)
+* [Compare DM1 faults across captures](compare-dm1-faults.md)

--- a/docs/cookbook/filter-pgn.md
+++ b/docs/cookbook/filter-pgn.md
@@ -1,0 +1,54 @@
+# Filter for a single arbitration ID or PGN
+
+## Goal
+
+Pull every frame matching a specific arbitration ID (or J1939 PGN) out
+of a capture, in a form you can pipe into other commands.
+
+## Prerequisites
+
+* CANarchy installed (`canarchy --version` works).
+* Any candump capture. The examples use the in-tree fixture
+  `tests/fixtures/j1939_heavy_vehicle.candump`.
+
+## Filter on a raw arbitration ID
+
+```bash
+canarchy filter 'id==0x18FEEE31' \
+  --file tests/fixtures/j1939_heavy_vehicle.candump \
+  --jsonl
+```
+
+Each output line is a `frame` event from the canonical
+[Event Schema](../event-schema.md). Pipe it into `jq` for further
+shaping.
+
+## Filter on a J1939 PGN
+
+PGNs map to ranges of arbitration IDs. The cleanest way is to use the
+J1939-aware commands instead of writing a regex:
+
+```bash
+canarchy j1939 pgn 65262 \
+  --file tests/fixtures/j1939_heavy_vehicle.candump \
+  --text
+```
+
+That prints every observation of PGN 65262 (Engine Coolant Temperature)
+with decoded signal context where available.
+
+## Compose with other commands
+
+`filter` supports `&&` and `||`, plus payload substring matching:
+
+```bash
+canarchy filter 'id==0x18FEEE31 && data~=7f' \
+  --file tests/fixtures/j1939_heavy_vehicle.candump \
+  --jsonl \
+  | canarchy stats --file - --json
+```
+
+## Where to go next
+
+* [Command Spec — filter](../command_spec.md)
+* [J1939 Heavy Vehicle Analysis tutorial](../tutorials/j1939_heavy_vehicle.md)

--- a/docs/cookbook/find-counter-signals.md
+++ b/docs/cookbook/find-counter-signals.md
@@ -1,0 +1,50 @@
+# Find counter signals in a capture
+
+## Goal
+
+Identify likely counter fields inside a capture — small monotonically
+incrementing fields that often live in the upper or lower nibble of a
+byte.
+
+## Prerequisites
+
+* CANarchy installed.
+* A capture with at least a few hundred frames per ID. The examples use
+  the in-tree fixture `tests/fixtures/re_counter_nibble.candump`.
+
+## Run
+
+```bash
+canarchy re counters tests/fixtures/re_counter_nibble.candump --text
+```
+
+The text output lists candidate counters with their ID, byte position,
+bit width, and stability score. JSON / JSONL output includes the same
+fields machine-readably:
+
+```bash
+canarchy re counters tests/fixtures/re_counter_nibble.candump --json
+```
+
+## What "counter" means here
+
+* The candidate field changes on most frames of the same ID.
+* The change is usually +1, modulo the field width.
+* Periodic rollover (for example a 4-bit counter wrapping from `0xF` to
+  `0x0`) is recognised.
+
+## Validate with `re entropy`
+
+Counters typically have high entropy. Cross-check with:
+
+```bash
+canarchy re entropy tests/fixtures/re_counter_nibble.candump --json
+```
+
+The combination is a good first pass before you start drafting signal
+definitions.
+
+## Where to go next
+
+* [Match an unknown capture against opendbc](match-dbc-against-capture.md)
+* [Command Spec — re](../command_spec.md)

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -1,0 +1,30 @@
+# Cookbook
+
+Short, task-oriented recipes for common CANarchy workflows. Each recipe
+is one page, runs against a fixture checked into the repository, and
+links back to the full tutorial or command spec where it applies.
+
+For longer walkthroughs, see the [Tutorials](../tutorials/index.md) page.
+
+## Capture and triage
+
+* [Filter for a single arbitration ID or PGN](filter-pgn.md)
+* [Compare two captures for DM1 fault diffs](compare-dm1-faults.md)
+* [Build a virtual CAN loop for offline testing](virtual-can-loop.md)
+
+## Decoding
+
+* [Decode SPN 110 (engine coolant temperature)](decode-spn-110.md)
+* [Match an unknown capture against opendbc](match-dbc-against-capture.md)
+
+## Reverse engineering
+
+* [Find counter signals in a capture](find-counter-signals.md)
+
+## Datasets and external sources
+
+* [Stream the CANdid dataset into stats](stream-candid-into-stats.md)
+
+## Agents and MCP
+
+* [Wire CANarchy into Claude Desktop or Claude Code](mcp-claude-integration.md)

--- a/docs/cookbook/match-dbc-against-capture.md
+++ b/docs/cookbook/match-dbc-against-capture.md
@@ -1,0 +1,59 @@
+# Match an unknown capture against opendbc
+
+## Goal
+
+Given a capture from an unknown vehicle, find the top DBC candidates
+from the opendbc catalogue.
+
+## Prerequisites
+
+* CANarchy installed.
+* The opendbc provider cache populated:
+
+  ```bash
+  canarchy dbc cache refresh --provider opendbc
+  ```
+
+* A capture file. The example uses `tests/fixtures/sample.candump`.
+
+## Run
+
+```bash
+canarchy re match-dbc tests/fixtures/sample.candump \
+  --provider opendbc \
+  --limit 10 \
+  --text
+```
+
+The output ranks DBC files by a frequency-weighted ID coverage score.
+A high score means a large fraction of the capture's frames are
+described by that DBC.
+
+## Narrow by vehicle brand
+
+If you already know the brand, use `re shortlist-dbc` to filter before
+scoring:
+
+```bash
+canarchy re shortlist-dbc tests/fixtures/sample.candump \
+  --make toyota \
+  --provider opendbc \
+  --limit 5 \
+  --text
+```
+
+## Use the chosen ref directly
+
+Once a candidate looks plausible, decode against it:
+
+```bash
+canarchy decode \
+  --file tests/fixtures/sample.candump \
+  --dbc opendbc:toyota_tnga_k_pt_generated \
+  --json
+```
+
+## Where to go next
+
+* [Discover and Use Provider-Backed DBC Files tutorial](../tutorials/dbc_provider_workflow.md)
+* [Find counter signals](find-counter-signals.md)

--- a/docs/cookbook/mcp-claude-integration.md
+++ b/docs/cookbook/mcp-claude-integration.md
@@ -1,0 +1,73 @@
+# Wire CANarchy into Claude Desktop or Claude Code
+
+## Goal
+
+Run `canarchy` as an MCP server so an agent can call CANarchy commands
+directly.
+
+## Prerequisites
+
+* CANarchy installed and on your `PATH` (`canarchy --version` works).
+* Claude Desktop or Claude Code installed.
+
+## Verify the MCP server runs
+
+```bash
+canarchy mcp serve --help
+```
+
+You should see the standard CLI envelope describing the MCP stdio
+server. The server speaks Model Context Protocol over stdin and stdout;
+do not run it interactively unless you are piping JSON-RPC into it.
+
+## Claude Desktop
+
+Add the following block to your `claude_desktop_config.json`. On macOS
+this is `~/Library/Application Support/Claude/claude_desktop_config.json`;
+on Windows it is `%AppData%/Claude/claude_desktop_config.json`.
+
+```json
+{
+  "mcpServers": {
+    "canarchy": {
+      "command": "canarchy",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The CANarchy tools should appear in the tool
+picker.
+
+## Claude Code
+
+Add CANarchy as an MCP server via the project or user-scoped MCP
+configuration. The exact location depends on the Claude Code version;
+the config block has the same shape as above:
+
+```json
+{
+  "mcpServers": {
+    "canarchy": {
+      "command": "canarchy",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+## Verify from an agent
+
+Ask the agent to call `canarchy capture-info` against an in-tree
+fixture:
+
+> Run `canarchy capture-info` on `tests/fixtures/j1939_heavy_vehicle.candump`
+> and summarise the result.
+
+The agent should invoke the MCP tool and return the canonical envelope.
+
+## Where to go next
+
+* [Agent Guide](../agents.md)
+* [Command Spec — mcp serve](../command_spec.md)

--- a/docs/cookbook/stream-candid-into-stats.md
+++ b/docs/cookbook/stream-candid-into-stats.md
@@ -1,0 +1,58 @@
+# Stream the CANdid dataset into stats
+
+## Goal
+
+Pipe a remote CANdid replay stream directly into the local analysis
+commands, with no temporary file on disk.
+
+## Prerequisites
+
+* CANarchy installed and network access to the CANdid dataset.
+* The CANdid catalogue is built in; no provider cache refresh is
+  required.
+
+## Quick preflight
+
+Resolve the replay metadata without opening the stream:
+
+```bash
+canarchy datasets replay catalog:candid --dry-run --json
+```
+
+List the replayable files in the dataset:
+
+```bash
+canarchy datasets replay catalog:candid --list-files --json
+```
+
+## Bounded replay piped into stats
+
+```bash
+canarchy datasets replay catalog:candid --rate 1000 --max-frames 1000 \
+  | canarchy stats --file - --json
+```
+
+`stats --file -` reads candump text from stdin. Combine with
+`--max-frames` to bound the work upfront.
+
+## Bounded replay piped into capture-info
+
+```bash
+canarchy datasets replay catalog:candid --rate 1000 --max-frames 1000 \
+  | canarchy capture-info --file - --json
+```
+
+## Select a specific file in the dataset
+
+```bash
+canarchy datasets replay catalog:candid \
+  --file 2_steering_CAN.log \
+  --rate 100 \
+  --max-frames 200 \
+  --format jsonl
+```
+
+## Where to go next
+
+* [Stream CAN Data from CANdid tutorial](../tutorials/stream_candid_dataset.md)
+* [Command Spec — datasets](../command_spec.md)

--- a/docs/cookbook/virtual-can-loop.md
+++ b/docs/cookbook/virtual-can-loop.md
@@ -1,0 +1,88 @@
+# Build a virtual CAN loop for offline testing
+
+## Goal
+
+Run CANarchy end-to-end with no hardware: one terminal sends frames, the
+other terminal captures them. Useful for testing scripts, demos, and CI
+fixtures.
+
+## Option A — Linux `vcan` (recommended on Linux)
+
+Create a virtual SocketCAN interface (one-time setup, requires root):
+
+```bash
+sudo modprobe vcan
+sudo ip link add dev vcan0 type vcan
+sudo ip link set up vcan0
+```
+
+Confirm:
+
+```bash
+ip link show vcan0
+```
+
+In one terminal, start a capture:
+
+```bash
+canarchy capture vcan0 --candump
+```
+
+In another terminal, send a frame:
+
+```bash
+canarchy send vcan0 0x123 11223344 --ack-active --json
+```
+
+The capture terminal prints the frame in candump form.
+
+## Option B — `udp_multicast` (cross-platform, no kernel modules)
+
+Set the python-can interface to `udp_multicast`. Persist it in
+`~/.canarchy/config.toml`:
+
+```toml
+[transport]
+backend = "python-can"
+interface = "udp_multicast"
+```
+
+Or export it for the current shell only:
+
+```bash
+export CANARCHY_PYTHON_CAN_INTERFACE=udp_multicast
+```
+
+On macOS you may need to add a multicast route first:
+
+```bash
+sudo route add -net 239.0.0.0/8 -interface lo0
+```
+
+In one terminal:
+
+```bash
+canarchy capture 239.0.0.1 --candump
+```
+
+In another:
+
+```bash
+canarchy send 239.0.0.1 0x123 11223344 --ack-active --json
+```
+
+## Option C — Scaffold backend (deterministic offline only)
+
+The `scaffold` backend returns pre-recorded fixture frames and does not
+deliver anything between processes. Use it for unit-test-like behaviour
+where you want a deterministic stream:
+
+```bash
+export CANARCHY_TRANSPORT_BACKEND=scaffold
+canarchy capture can0 --json
+```
+
+## Where to go next
+
+* [Backends and Interfaces](../backends.md)
+* [Generate and Capture tutorial](../tutorials/generate_and_capture.md)

--- a/docs/examples/config.toml
+++ b/docs/examples/config.toml
@@ -1,0 +1,74 @@
+# Example CANarchy configuration file.
+#
+# Copy this file to ~/.canarchy/config.toml and uncomment the keys you
+# want to set. Every value below is the documented default; CANarchy
+# behaves identically with this file present or absent.
+#
+# Verify the effective configuration at any time with:
+#
+#   canarchy config show
+#
+# Configuration sources are merged in the following order (later wins):
+#   1. Built-in defaults
+#   2. ~/.canarchy/config.toml
+#   3. Environment variables (CANARCHY_*)
+#   4. CLI flags
+
+# ---------------------------------------------------------------------------
+# Transport backend
+# ---------------------------------------------------------------------------
+#
+# `python-can` is the default. Set `scaffold` for deterministic offline
+# behaviour during development, CI, or demos without hardware.
+#
+# Environment override: CANARCHY_TRANSPORT_BACKEND
+
+[transport]
+# backend = "python-can"
+# backend = "scaffold"
+
+# Default python-can interface type. Common values: socketcan, virtual,
+# udp_multicast, pcan, vector, kvaser, ixxat. Each backend may need its
+# own additional configuration; see docs/backends.md.
+#
+# Environment override: CANARCHY_PYTHON_CAN_INTERFACE
+
+# interface = "socketcan"
+
+# ---------------------------------------------------------------------------
+# DBC providers
+# ---------------------------------------------------------------------------
+#
+# The opendbc provider exposes the community catalogue at
+# https://github.com/commaai/opendbc through `dbc search`, `dbc fetch`,
+# and provider refs such as `opendbc:toyota_tnga_k_pt_generated`.
+
+[dbc.providers.opendbc]
+# When true, a cold cache triggers an automatic `dbc cache refresh` the
+# first time a provider ref is resolved. Defaults to false so offline
+# environments remain offline.
+# auto_refresh = false
+
+# ---------------------------------------------------------------------------
+# J1939 defaults
+# ---------------------------------------------------------------------------
+#
+# A default J1939 DBC is used by `j1939 decode`, `j1939 pgn`,
+# `j1939 spn`, and `j1939 dm1` when no `--dbc` flag is supplied. Provider
+# refs (`opendbc:<name>`) and absolute paths are both accepted.
+#
+# Environment override: CANARCHY_J1939_DBC
+
+[j1939]
+# dbc = "opendbc:j1939"
+
+# ---------------------------------------------------------------------------
+# Plugins (planned)
+# ---------------------------------------------------------------------------
+#
+# Plugin discovery and toggle live under the [plugins] table once the
+# CLI surface lands. Plugins are Python entry points and remain disabled
+# until explicitly enabled here.
+
+# [plugins]
+# enabled = ["sqlite_sink"]

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -70,6 +70,8 @@ canarchy config show
 
 This prints each setting along with whether it came from a config file, an environment variable, or the built-in default.
 
+A fully commented sample configuration file is available at [`docs/examples/config.toml`](examples/config.toml). Copy it to `~/.canarchy/config.toml` and uncomment the keys you want to set.
+
 ---
 
 ## Software Loopback (No Hardware)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,527 @@
+# Troubleshooting
+
+CANarchy emits structured errors with a stable `code`, a human-readable
+`message`, and an actionable `hint`. This page catalogues the codes you
+are most likely to see, along with the typical cause and a copy-pasteable
+recovery path.
+
+Every code below also appears in the canonical envelope under
+`errors[]`. The exact format is described in the
+[Event Schema](event-schema.md).
+
+If you hit a code that is not listed here, please open a
+[bug report](https://github.com/hexsecs/canarchy/issues/new/choose).
+
+---
+
+## Common pitfalls
+
+A few situations cause the majority of structured errors. Check these
+first.
+
+* **No live CAN interface available.** Switch to the deterministic
+  scaffold backend for offline work:
+
+  ```bash
+  export CANARCHY_TRANSPORT_BACKEND=scaffold
+  canarchy capture can0 --json
+  ```
+
+* **Capture file is empty or malformed.** Confirm the file with
+  `capture-info`:
+
+  ```bash
+  canarchy capture-info --file path/to/capture.candump --json
+  ```
+
+* **Large captures need bounds.** File-backed J1939 analysis caps at
+  500,000 frames on captures larger than 50 MB and emits a warning.
+  Override with `--max-frames` or `--seconds` for full-file analysis.
+
+* **Stdin and `--file` cannot both be specified.** Use one or the other:
+
+  ```bash
+  canarchy stats --file - < capture.candump
+  ```
+
+---
+
+## DBC workflow errors
+
+### `DBC_LOAD_FAILED`
+
+Symptom — a DBC file was provided but the parser rejected it.
+
+Causes — malformed DBC syntax, mixed line endings, or a non-DBC file
+passed via `--dbc`.
+
+Recovery —
+
+```bash
+canarchy dbc inspect path/to/file.dbc --json
+```
+
+Use the inspect output to spot the failing line. Re-export the DBC from
+the source tool if the structure is corrupted.
+
+### `DBC_NOT_FOUND`
+
+Symptom — `--dbc <ref>` does not resolve to a local file or a cached
+provider entry.
+
+Recovery — confirm the path or refresh the provider cache:
+
+```bash
+canarchy dbc cache refresh --provider opendbc
+```
+
+### `DBC_DECODE_FAILED`
+
+Symptom — a frame matched a DBC message but signal decode failed.
+
+Causes — DLC mismatch, signal definitions outside the frame, or a wrong
+byte order for the source.
+
+Recovery — verify the message with `dbc inspect --message <name>` and
+check the signal start bits and lengths against the captured DLC.
+
+### `DBC_CACHE_MISS`
+
+Symptom — a provider ref (for example `opendbc:toyota_tnga_k_pt_generated`)
+was used but no cached entry exists.
+
+Recovery — the hint is copy-pasteable:
+
+```bash
+canarchy dbc cache refresh --provider opendbc
+```
+
+Enable `auto_refresh = true` under `[dbc.providers.opendbc]` in
+`~/.canarchy/config.toml` if you want this to happen on first use.
+
+### `DBC_CACHE_STALE`
+
+Symptom — the cached provider catalogue is older than the configured
+freshness window.
+
+Recovery — re-run `dbc cache refresh --provider <name>`.
+
+### `DBC_MESSAGE_NOT_FOUND`
+
+Symptom — `dbc inspect --message <name>` or `encode <name> …` referenced
+a message that does not exist in the active DBC.
+
+Recovery — list messages with `dbc inspect path/to/file.dbc --json` and
+match the name exactly (case-sensitive).
+
+### `DBC_PROVIDER_NOT_FOUND`
+
+Symptom — `--provider <name>` referred to a provider that is not
+registered.
+
+Recovery — list providers:
+
+```bash
+canarchy dbc provider list --json
+```
+
+### `DBC_SIGNAL_INVALID`
+
+Symptom — `encode --dbc <ref> <message> sig=val …` was given a value
+outside the signal range or for a signal that does not exist.
+
+Recovery — inspect the signal definition for the message:
+
+```bash
+canarchy dbc inspect path/to/file.dbc --message <name> --signals-only --json
+```
+
+Check the `min`, `max`, and choice set before retrying.
+
+---
+
+## Dataset workflow errors
+
+### `DATASET_NOT_FOUND`
+
+Symptom — `datasets fetch`, `datasets inspect`, or `datasets replay` was
+called with a ref that is not in the active provider catalogue.
+
+Recovery —
+
+```bash
+canarchy datasets search --json
+```
+
+### `DATASET_PROVIDER_NOT_FOUND`
+
+Symptom — `--provider <name>` does not match a registered dataset
+provider.
+
+Recovery — `canarchy datasets provider list --json`.
+
+### `DATASET_REPLAY_UNAVAILABLE`
+
+Symptom — the dataset entry is not replayable (for example it is a
+curated index rather than a CAN log).
+
+Recovery — switch to a replayable entry. Use `datasets search` to find
+entries with `is_replayable: true` and `default_replay_file` set.
+
+### `DATASET_INDEX_NOT_REPLAYABLE`
+
+Symptom — the ref is an index entry (`is_index: true`). Index entries
+point at external sources and have no inline replay stream.
+
+Recovery — follow the linked source pages from the inspect output:
+
+```bash
+canarchy datasets inspect <ref> --json
+```
+
+### `DATASET_REPLAY_FETCH_FAILED`
+
+Symptom — the remote replay stream could not be opened.
+
+Causes — network outage, transient HTTP failure, or the upstream URL
+moved.
+
+Recovery — retry the command, or run with `--dry-run` first to confirm
+the resolved URL before opening the stream.
+
+### `DATASET_REPLAY_FILE_NOT_FOUND`
+
+Symptom — `--file <id-or-name>` did not match an entry in the dataset
+replay manifest.
+
+Recovery —
+
+```bash
+canarchy datasets replay <ref> --list-files --json
+```
+
+---
+
+## Frame and argument validation errors
+
+### `INVALID_ARGUMENTS`
+
+Symptom — the parser accepted the command but the values failed a deeper
+validation step.
+
+Recovery — re-read the message and hint; they name the failing argument
+and constraint.
+
+### `INVALID_MAX_FRAMES`
+
+Symptom — `--max-frames` value was zero, negative, or non-numeric.
+
+Recovery — pass a positive integer such as `--max-frames 1000`.
+
+### `INVALID_ANALYSIS_SECONDS`
+
+Symptom — `--seconds` value was zero, negative, or non-numeric.
+
+Recovery — pass a positive float such as `--seconds 60.0`.
+
+### `INVALID_MAX_SECONDS`
+
+Symptom — `--max-seconds` value was zero, negative, or non-numeric.
+Used by `datasets replay`.
+
+Recovery — pass a positive float such as `--max-seconds 10.0`.
+
+### `ANALYSIS_WINDOW_REQUIRES_FILE`
+
+Symptom — `--max-frames` or `--seconds` was used together with `--stdin`.
+These bounds only apply when reading from a file.
+
+Recovery — either drop the bound, or write the stream to a temporary
+file first:
+
+```bash
+your-producer | canarchy filter --file - 'id==0x123'
+```
+
+### `INVALID_FRAME_ID`
+
+Symptom — a frame identifier passed to `send`, `generate`, or `filter`
+was not a valid hex value or fell outside the 11-bit or 29-bit range.
+
+Recovery — use hex form, prefixed or unprefixed (`0x123` or `123`),
+within the valid range for the frame type.
+
+### `INVALID_FRAME_DATA`
+
+Symptom — the payload could not be parsed as hex bytes, or its length
+exceeded the allowed DLC.
+
+Recovery — pass an even number of hex characters with no separators,
+for example `11223344`.
+
+### `INVALID_DLC` / `INVALID_COUNT` / `INVALID_GAP` / `INVALID_RATE`
+
+Symptom — one of the `generate` flags was given a non-numeric value or
+fell outside the allowed range.
+
+Recovery — pass a positive integer (`--count`, `--dlc`, `--gap`) or
+positive float (`--rate`).
+
+### `INVALID_PGN` / `INVALID_SPN` / `INVALID_SOURCE_ADDRESS`
+
+Symptom — a J1939 selector was outside the valid range.
+
+Recovery — PGNs are 18-bit integers, SPNs are positive integers, and
+J1939 source addresses are 0–253 (0xFE and 0xFF are reserved).
+
+### `INVALID_CHUNK_SIZE`
+
+Symptom — `datasets stream --chunk-size` was zero, negative, or
+non-numeric.
+
+Recovery — pass a positive integer such as `--chunk-size 1000`.
+
+### `INVALID_SIGNAL_ASSIGNMENT`
+
+Symptom — `encode --dbc <ref> <message> sig=val …` could not parse a
+`key=value` argument.
+
+Recovery — confirm there are no shell-splitting issues and that the
+value matches the signal's declared type.
+
+---
+
+## Capture, stdin, and input errors
+
+### `CAPTURE_EMPTY`
+
+Symptom — the capture file parsed cleanly but contained no valid
+frames.
+
+Recovery — confirm the source produced output, and re-check the file
+suffix and format. Stdin sources may need `--file -` rather than
+`--stdin` for candump text.
+
+### `CAPTURE_FILE_REQUIRED`
+
+Symptom — a file-only command was called without `--file`.
+
+Recovery — pass a path or `-` for stdin candump input.
+
+### `MISSING_INPUT`
+
+Symptom — a command that requires either a file or stdin received
+neither.
+
+Recovery — pass `--file <path>` or pipe candump text into the command
+with `--file -`.
+
+### `STDIN_AND_FILE_SPECIFIED`
+
+Symptom — both `--file` and `--stdin` were given.
+
+Recovery — choose one input source.
+
+### `NO_STREAM_EVENTS` / `INVALID_STREAM_EVENT`
+
+Symptom — `filter --stdin`, `decode --stdin`, or `j1939 decode --stdin`
+received zero events, or an event that did not match the FrameEvent
+schema.
+
+Recovery — verify the upstream stream emits one JSON object per line
+that conforms to the [Event Schema](event-schema.md).
+
+---
+
+## Reverse-engineering errors
+
+### `RE_REFERENCE_REQUIRED`
+
+Symptom — `re correlate` was called without `--reference`.
+
+Recovery — supply a JSON or JSONL file containing a numeric series.
+
+### `INVALID_REFERENCE_FILE`
+
+Symptom — `--reference <path>` exists but failed to parse.
+
+Recovery — the file must be a JSON array, a JSON object with `name`
+plus `samples`, or JSONL with one numeric sample per line. NaN entries
+must be omitted, not encoded as the string `"NaN"`.
+
+### `INSUFFICIENT_OVERLAP`
+
+Symptom — the capture and the reference series do not share enough
+timestamp overlap to compute correlation.
+
+Recovery — re-capture or re-export the reference so both cover the same
+time window.
+
+---
+
+## Session and skill errors
+
+### `SESSION_NOT_FOUND`
+
+Symptom — `session load <name>` referred to a session that does not
+exist.
+
+Recovery — `canarchy session show --json` to list known sessions.
+
+### `INVALID_SESSION_NAME`
+
+Symptom — the session name contained reserved characters or was empty.
+
+Recovery — use letters, digits, dashes, and underscores.
+
+### `SKILL_CACHE_MISS`
+
+Symptom — a skill ref was requested but the cache is cold.
+
+Recovery —
+
+```bash
+canarchy skills cache refresh
+```
+
+### `SKILL_FETCH_FAILED`
+
+Symptom — the skill manifest could not be downloaded.
+
+Recovery — retry, or inspect the provider list with
+`canarchy skills provider list --json`.
+
+### `SKILL_MANIFEST_INVALID`
+
+Symptom — the downloaded manifest did not pass schema validation.
+
+Recovery — file an issue against the upstream skills repository, then
+retry once the manifest is fixed.
+
+### `SKILL_NOT_FOUND` / `SKILL_PROVIDER_NOT_FOUND`
+
+Symptom — the ref or provider name does not match a known entry.
+
+Recovery — use `canarchy skills search` or
+`canarchy skills provider list --json` to discover valid names.
+
+---
+
+## Export and format errors
+
+### `EXPORT_SOURCE_UNSUPPORTED`
+
+Symptom — `export <source> <destination>` was called with a source the
+exporter does not handle.
+
+Recovery — see `docs/command_spec.md` for the supported source list.
+
+### `EXPORT_FORMAT_UNSUPPORTED` / `UNSUPPORTED_OUTPUT_FORMAT`
+
+Symptom — the requested output format is not implemented for the chosen
+command.
+
+Recovery — choose one of `--json`, `--jsonl`, `--text`, or a
+command-specific frame-line mode such as `--candump` where supported.
+
+### `EXPORT_WRITE_FAILED`
+
+Symptom — the destination path could not be opened for writing.
+
+Recovery — confirm the parent directory exists and that the process can
+write to it.
+
+### `EXPORT_EVENTS_UNAVAILABLE`
+
+Symptom — the export source produced no events.
+
+Recovery — verify the upstream command produced output; an empty stdin
+or zero-frame capture is the most common cause.
+
+### `UNSUPPORTED_SOURCE_FORMAT`
+
+Symptom — `datasets stream --source-format <name>` was given a format
+that is not implemented.
+
+Recovery — current options are documented under
+`canarchy datasets stream --help`.
+
+---
+
+## Active-bus operations
+
+### `ACTIVE_ACK_REQUIRED`
+
+Symptom — an active command (`send`, `generate`, `gateway`, `uds scan`)
+was started without `--ack-active` in a non-interactive context.
+
+Recovery — re-run with `--ack-active`, after confirming the target.
+
+### `ACTIVE_CONFIRMATION_DECLINED`
+
+Symptom — the operator declined the interactive confirmation prompt.
+
+Recovery — re-run when you are ready to confirm, or pass `--ack-active`
+to skip the prompt explicitly.
+
+### `ACTIVE_TRANSMIT`
+
+Symptom — a transmission failed at the transport layer.
+
+Recovery — confirm the interface is up (`ip link show can0` on Linux)
+and that the configured backend supports transmission. The hint should
+include the underlying transport error.
+
+### `COMMAND_PLANNED`
+
+Symptom — informational structured response from `--dry-run` on
+`datasets replay` and similar planning modes.
+
+Recovery — no action needed. The payload describes what the command
+would have done.
+
+---
+
+## Plugin errors
+
+### `PLUGIN_NOT_FOUND`
+
+Symptom — a plugin name referenced in `~/.canarchy/config.toml` is not
+registered.
+
+Recovery — `canarchy plugins list --json` (once the CLI surface lands;
+see the project roadmap).
+
+### `PLUGIN_DUPLICATE`
+
+Symptom — two plugins registered under the same entry-point name.
+
+Recovery — remove the duplicate distribution from the environment.
+
+### `PLUGIN_INVALID` / `PLUGIN_INCOMPATIBLE`
+
+Symptom — the plugin failed to load or did not implement the required
+protocol.
+
+Recovery — file an issue against the plugin distribution. CANarchy will
+continue to load without the failing plugin.
+
+---
+
+## TUI errors
+
+### `TUI_COMMAND_UNSUPPORTED`
+
+Symptom — a command typed into the TUI input area is not exposed to the
+TUI front end.
+
+Recovery — drop back to the shell or run the command directly from the
+CLI.
+
+---
+
+## Reporting unknown codes
+
+If you encounter a code that is not on this page, please open a
+[bug report](https://github.com/hexsecs/canarchy/issues/new/choose).
+Include the full structured envelope and the command you ran.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,12 +73,23 @@ nav:
       - Event Schema: event-schema.md
       - CAN Tool Feature Matrix: feature-matrix.md
       - Security Use Cases With Agents: security-use-cases.md
+      - Troubleshooting: troubleshooting.md
   - Tutorials:
       - Overview: tutorials/index.md
       - Stream CAN Data from CANdid: tutorials/stream_candid_dataset.md
       - Discover and Use Provider-Backed DBC Files: tutorials/dbc_provider_workflow.md
       - J1939 Heavy Vehicle Analysis: tutorials/j1939_heavy_vehicle.md
       - Generate and Capture: tutorials/generate_and_capture.md
+  - Cookbook:
+      - Overview: cookbook/index.md
+      - Filter for a single arbitration ID or PGN: cookbook/filter-pgn.md
+      - Decode SPN 110 (engine coolant temperature): cookbook/decode-spn-110.md
+      - Find counter signals in a capture: cookbook/find-counter-signals.md
+      - Match an unknown capture against opendbc: cookbook/match-dbc-against-capture.md
+      - Stream the CANdid dataset into stats: cookbook/stream-candid-into-stats.md
+      - Wire CANarchy into Claude Desktop or Claude Code: cookbook/mcp-claude-integration.md
+      - Build a virtual CAN loop for offline testing: cookbook/virtual-can-loop.md
+      - Compare two captures for DM1 fault diffs: cookbook/compare-dm1-faults.md
   - Developers:
       - Architecture: architecture.md
       - Docs Workflow: docs_site.md


### PR DESCRIPTION
## Summary

Horizon 1 docs/community bundle from the improvement plan (#295). Adds
the missing community/governance files, structured issue and PR
templates, a comprehensive error-code troubleshooting page, a new
top-level Cookbook section, and a fully commented sample config.

Closes #296, #297, #298, #299, #301.

## Changes

- **Governance** (#296): `CONTRIBUTING.md` (human-facing version of the AGENTS.md flow), `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1 by reference), and `SECURITY.md` covering private security reports and active-bus operation guidance. README now has a Community section linking all three.
- **Templates** (#297): `.github/ISSUE_TEMPLATE/{bug_report,feature_request,config}.yml` matching the existing `## Summary` / `## Acceptance Criteria` issue shape, plus `.github/PULL_REQUEST_TEMPLATE.md` with the PR acceptance gates from AGENTS.md as checkboxes.
- **Troubleshooting** (#298): `docs/troubleshooting.md` catalogues ~60 structured error codes across DBC, dataset, frame-validation, capture/stdin, reverse-engineering, session, skill, export/format, active-bus, plugin, and TUI workflows with copy-pasteable recovery commands. Wired into the User Guide nav.
- **Cookbook** (#299): new `docs/cookbook/` top-level section with eight recipes — filter by ID/PGN, decode SPN 110, find counter signals, match an unknown capture against opendbc, stream CANdid into stats, MCP integration with Claude Desktop and Claude Code, build a virtual CAN loop, and compare DM1 faults across captures.
- **Sample config** (#301): `docs/examples/config.toml` documents every key under `[transport]`, `[dbc.providers.opendbc]`, `[j1939]`, and the planned `[plugins]` table; referenced from `docs/getting_started.md`.
- `CHANGELOG.md` `[Unreleased]` carries one Documentation entry per closed issue.

## Test plan

- [x] `uv run python -m unittest discover -s tests` — 599 passed, 1 skipped
- [x] `uv run --group docs mkdocs build --strict` — exit 0
- [x] Cookbook commands spot-checked against in-tree fixtures:
  - `j1939 spn 110 --file tests/fixtures/j1939_heavy_vehicle.candump` ✓
  - `j1939 compare …shifted.candump …heavy_vehicle.candump` ✓
  - `re counters tests/fixtures/re_counter_nibble.candump` ✓ (initial draft used `--file`; fixed to positional)
  - `filter 'id==0x18FEEE31' --file …`, `j1939 pgn 65262`, `j1939 dm1 …` ✓

## Documentation

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `docs/command_spec.md` — unchanged (no command surface change)
- [ ] `docs/event-schema.md` — unchanged (no output schema change)
- [ ] `docs/design/` — unchanged (no behavioural change)
- [ ] `docs/tests/` — unchanged
- [ ] `AGENTS.md` / `docs/agents.md` — unchanged
- [x] `mkdocs.yml` nav updated (Troubleshooting, Cookbook section)

## Safety

Not applicable — docs and templates only. No active-transmit behaviour
touched. `SECURITY.md` formalises the existing `--ack-active` posture but
does not change any command.

## Related

This is the first deliverable from #295. Remaining Horizon 1 items
(#300, #302, #303, #304, #305, #306, #307, #308) are scoped separately
and ready to pick up.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EyAemaqJWAVv7wFuNs6djg)_