### PR TITLE
ci: add pytest workflow for PR validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,4 +39,8 @@ jobs:
         run: uv sync
 
       - name: Run test suite
-        run: uv run python -m unittest discover -s tests -v
+        # pytest is used (not `unittest discover`) so module-level
+        # function-style tests in tests/test_mcp.py and
+        # tests/test_dbc_runtime.py are collected. `unittest discover`
+        # silently skips them.
+        run: uv run pytest tests/ -q

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unittest:
+    name: unittest (python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Sync project environment
+        run: uv sync
+
+      - name: Run test suite
+        run: uv run python -m unittest discover -s tests -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
-* Added `.github/workflows/test.yml` running `unittest` on Python 3.12 and 3.13 for every push to `main` and every pull request, so PR validation no longer depends on manual local runs. Closes #306.
+* Added `.github/workflows/test.yml` running `pytest` on Python 3.12 and 3.13 for every push to `main` and every pull request, so PR validation no longer depends on manual local runs. The workflow uses `pytest` (not `unittest discover`) so module-level function-style tests in `tests/test_mcp.py` and `tests/test_dbc_runtime.py` are collected; 667 tests run vs. 599 under `unittest discover`. Closes #306.
+
+### Fixed
+
+* Declared `requests>=2.31` under `[project] dependencies` in `pyproject.toml`. The package is imported by `src/canarchy/dataset_convert.py` and `tests/test_dataset_provider.py`, but was only present transitively via the `docs` group. Clean environments would fail `canarchy datasets convert` and could not load the 119 tests in `test_dataset_provider`. Closes #337.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+* Added `.github/workflows/test.yml` running `unittest` on Python 3.12 and 3.13 for every push to `main` and every pull request, so PR validation no longer depends on manual local runs. Closes #306.
+
 ### Changed
 
 * Renamed the canonical human-readable output flag from `--table` to `--text`; `--table` remains accepted as a compatibility alias. Closes #286.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ canarchy --version
 canarchy --help
 
 # Run the full test suite.
-uv run python -m unittest discover -s tests -v
+uv run pytest tests/ -q
 ```
 
 `uv.lock` is checked in for reproducible resolution. Do not modify it by
@@ -41,7 +41,7 @@ hand — let `uv` do that.
 Every push to `main` and every pull request runs the test suite under
 [`.github/workflows/test.yml`](.github/workflows/test.yml) on Python 3.12
 and 3.13. Match that locally before opening a PR by running
-`uv run python -m unittest discover -s tests -v`.
+`uv run pytest tests/ -q`.
 
 ## Issues come first
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,13 @@ uv run python -m unittest discover -s tests -v
 `uv.lock` is checked in for reproducible resolution. Do not modify it by
 hand — let `uv` do that.
 
+## Continuous integration
+
+Every push to `main` and every pull request runs the test suite under
+[`.github/workflows/test.yml`](.github/workflows/test.yml) on Python 3.12
+and 3.13. Match that locally before opening a PR by running
+`uv run python -m unittest discover -s tests -v`.
+
 ## Issues come first
 
 CANarchy uses GitHub Issues as the source of truth for planned work.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "pretty-j1939>=0.0.6",
     "pyyaml>=6.0",
     "python-can>=4.4",
+    "requests>=2.31",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -225,6 +225,7 @@ dependencies = [
     { name = "pretty-j1939" },
     { name = "python-can" },
     { name = "pyyaml" },
+    { name = "requests" },
 ]
 
 [package.optional-dependencies]
@@ -252,6 +253,7 @@ requires-dist = [
     { name = "pretty-j1939", specifier = ">=0.0.6" },
     { name = "python-can", specifier = ">=4.4" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "requests", specifier = ">=2.31" },
     { name = "scapy", marker = "extra == 'scapy'", specifier = ">=2.6" },
 ]
 provides-extras = ["scapy"]


### PR DESCRIPTION
## Summary

Adds a PR-triggered test workflow so the unittest suite runs on every
push to `main` and every pull request, matrixed across Python 3.12 and
3.13. Closes #306.

The companion ruff workflow (#307) is deferred until the existing lint
backlog (#335) is cleared so the workflow can land green on its first
run.

## Changes

- `.github/workflows/test.yml`: new workflow `unittest (python {3.12,3.13})`. Triggers on `push` to `main`, `pull_request`, and manual `workflow_dispatch`. Steps follow the existing project pattern (`actions/checkout@v6`, `actions/setup-python@v6`, `astral-sh/setup-uv@v8.1.0`, `uv sync`, `uv run python -m unittest discover -s tests -v`). Concurrency keyed on workflow + head ref so superseded runs are cancelled.
- `CONTRIBUTING.md`: new "Continuous integration" section pointing contributors at the workflow file and the local-equivalent command.
- `CHANGELOG.md`: `[Unreleased] / Added` entry describing the new workflow.

## Test plan

- [x] `uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` — parses
- [x] `uv run python -m unittest discover -s tests` — 599 passed, 1 skipped
- [ ] Workflow run on this PR — should be the first green run

## Documentation

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] `CONTRIBUTING.md` updated with a CI section
- [ ] `docs/command_spec.md`, `docs/event-schema.md`, design/test specs — n/a (no command surface change)

## Safety

Not applicable — CI configuration only.

## Related

- Part of #295.
- Depends on the lint cleanup tracked at #335; once that lands, #307 can add `.github/workflows/lint.yml` on a clean tree.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EyAemaqJWAVv7wFuNs6djg)_