### PR TITLE
docs: canonical MCP install reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * Added `canarchy doctor`, a fast offline health-check command returning the canonical envelope with eight structured checks: Python version, `python-can` import, configured transport backend, `~/.canarchy/config.toml` parseability, DBC / dataset / skills cache writability, opendbc cache population, MCP stdio server constructability, and package/source version consistency. Mirrored as the `doctor` MCP tool. Closes #303.
 * Added `canarchy completion {bash,zsh,fish}` emitting a shell completion script to stdout. Scripts complete the top-level subcommands and the common flags (`--json`, `--jsonl`, `--text`, `--file`, `--dbc`, `--max-frames`, `--seconds`, `--offset`, `--ack-active`, `--log-level`, `--quiet`). Source the output directly or save it to the shell's completion directory; install snippets are documented in `docs/getting_started.md`. Unsupported shells return the standard `INVALID_ARGUMENTS` structured error. Closes #304.
 
+### Documentation
+
+* Added `docs/mcp_install.md` as the canonical install reference for wiring `canarchy mcp serve` into MCP-capable agent clients (Claude Desktop, Claude Code, and any generic stdio client). Covers OS-specific config paths, a verification recipe, configuration tips, and a troubleshooting table. Cookbook recipe `mcp-claude-integration.md` updated to point at the new canonical page. Closes #308.
+
 ### Fixed
 
 * Declared `requests>=2.31` under `[project] dependencies` in `pyproject.toml`. The package is imported by `src/canarchy/dataset_convert.py` and `tests/test_dataset_provider.py`, but was only present transitively via the `docs` group. Clean environments would fail `canarchy datasets convert` and could not load the 119 tests in `test_dataset_provider`. Closes #337.

--- a/docs/cookbook/mcp-claude-integration.md
+++ b/docs/cookbook/mcp-claude-integration.md
@@ -3,7 +3,9 @@
 ## Goal
 
 Run `canarchy` as an MCP server so an agent can call CANarchy commands
-directly.
+directly. This is the quick-start; see [MCP Install](../mcp_install.md)
+for the canonical reference with OS-specific paths, generic-client
+configuration, and troubleshooting.
 
 ## Prerequisites
 
@@ -69,5 +71,6 @@ The agent should invoke the MCP tool and return the canonical envelope.
 
 ## Where to go next
 
+* [MCP Install](../mcp_install.md) — full install reference (other clients, troubleshooting)
 * [Agent Guide](../agents.md)
 * [Command Spec — mcp serve](../command_spec.md)

--- a/docs/mcp_install.md
+++ b/docs/mcp_install.md
@@ -1,0 +1,154 @@
+# Install the CANarchy MCP server in an agent client
+
+`canarchy mcp serve` exposes the CLI as an [MCP](https://modelcontextprotocol.io/)
+stdio server. Any MCP-capable client can call CANarchy tools the same
+way it calls its own built-in tools. This page covers the canonical
+install paths.
+
+For the agent-side workflows themselves (which tools to call, the
+event-stream contract, security guidance), see the
+[Agent Guide](agents.md) and the [Command Spec](command_spec.md).
+
+## Prerequisites
+
+Confirm `canarchy` is on your `PATH` and the MCP server starts cleanly:
+
+```bash
+canarchy --version
+canarchy mcp serve --help
+```
+
+If either fails, follow the
+[Getting Started](getting_started.md#install-and-sync) install steps
+first. A clean `canarchy doctor --text` run is a fast way to verify the
+local environment before wiring it into a client.
+
+## Claude Desktop
+
+Edit Claude Desktop's MCP config file:
+
+| Platform | Config path |
+|----------|-------------|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Linux | `~/.config/Claude/claude_desktop_config.json` |
+
+Add a `canarchy` entry under `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "canarchy": {
+      "command": "canarchy",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+If `canarchy` is installed inside a project venv rather than on the
+system `PATH`, give the absolute path to the binary:
+
+```json
+{
+  "mcpServers": {
+    "canarchy": {
+      "command": "/path/to/.venv/bin/canarchy",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The CANarchy tools will appear in the tool
+picker.
+
+## Claude Code
+
+Claude Code reads MCP server entries from project-scoped or user-scoped
+configuration. The block shape is the same as Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "canarchy": {
+      "command": "canarchy",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+Drop the block into the appropriate Claude Code config file. The CLI
+also accepts MCP servers via:
+
+```bash
+claude mcp add canarchy canarchy mcp serve
+```
+
+(Refer to the Claude Code documentation for the current command surface
+of your installed version.)
+
+## Other MCP clients
+
+Any client that speaks MCP over stdio can run CANarchy with the same
+command. A generic configuration looks like:
+
+```yaml
+mcp_servers:
+  canarchy:
+    command: canarchy
+    args:
+      - mcp
+      - serve
+```
+
+Cursor, Continue, Cline, and similar editor integrations follow the
+same pattern. The only requirement is that the client launches
+`canarchy mcp serve` as a subprocess and speaks JSON-RPC on stdio.
+
+## Verify the integration
+
+Ask the agent to call CANarchy against one of the in-repo fixtures:
+
+> Run `canarchy capture-info` on
+> `tests/fixtures/j1939_heavy_vehicle.candump` and summarise the result.
+
+A correctly wired-up client invokes the `capture_info` MCP tool and
+returns the canonical envelope. The `doctor` tool is the fastest
+end-to-end smoke check because it requires no fixture:
+
+> Run `canarchy doctor` and report any warnings.
+
+## Configuration tips
+
+* **Per-project canarchy with uv.** If the agent should always pick up a
+  specific project's editable install, point `command` at `uv` and pass
+  `["run", "canarchy", "mcp", "serve"]` as `args`, with `cwd` set to
+  the project root. Some clients support `cwd` directly; otherwise wrap
+  in a small launcher script.
+* **Active-transmit safety.** Active commands such as `send` and
+  `gateway` already require `--ack-active`. Agents must surface the
+  confirmation explicitly. See
+  [`SECURITY.md`](https://github.com/hexsecs/canarchy/blob/main/SECURITY.md).
+* **Logging.** The MCP server logs to stderr. The agent client typically
+  surfaces stderr in its diagnostics pane; check there first when a
+  tool call misbehaves.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Tools never appear in the client | Wrong `command` path | Run `which canarchy` and use the absolute path in the config. |
+| `INVALID_ARGUMENTS` for known-good calls | Client passes wrong argv shape | Compare against the MCP tool inputSchema; `canarchy mcp serve --help` documents the bridging contract. |
+| Tools error with `DBC_CACHE_MISS` | opendbc cache empty | Run `canarchy dbc cache refresh --provider opendbc` once locally; the agent then has cached data to read. |
+| `python-can` import errors at startup | Missing optional dependency | Re-run `uv sync` in the project, or `pipx install canarchy` for a global install. |
+
+`canarchy doctor` is the canonical first stop for environment problems;
+each non-ok check ships a copy-pasteable remediation hint.
+
+## Where to go next
+
+* [Agent Guide](agents.md) — agent-side workflows and policies.
+* [Command Spec](command_spec.md) — every CLI command, mirrored as MCP tools where applicable.
+* [Cookbook: Wire CANarchy into Claude Desktop or Claude Code](cookbook/mcp-claude-integration.md) — the short version of this page.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,5 +149,6 @@ nav:
           - Composition: tests/composition.md
   - Agents:
       - Agent Guide: agents.md
+      - MCP Install: mcp_install.md
 
 strict: true


### PR DESCRIPTION
## Summary

Adds the canonical install reference for wiring `canarchy mcp serve`
into MCP-capable agent clients. The cookbook recipe shipped earlier
was a quick-start; this is the long-form reference.

Closes #308.

## Changes

- `docs/mcp_install.md` — Claude Desktop (with macOS / Windows / Linux config paths), Claude Code (config block plus `claude mcp add` snippet), and a generic stdio block usable by Cursor, Continue, Cline, and other MCP clients. Verification recipe runs against the in-tree fixture and against `doctor`. Configuration tips cover per-project uv launchers, active-transmit safety, and stderr logging. Troubleshooting table maps the four most common failure modes to concrete fixes.
- `mkdocs.yml` — new nav entry under Agents → MCP Install.
- `docs/cookbook/mcp-claude-integration.md` — points at the new canonical reference instead of being the only source of install instructions.
- `CHANGELOG.md` — `[Unreleased] / Documentation` entry.

## Test plan

- [x] `uv run --group docs mkdocs build --strict` — exit 0
- [x] `uv run pytest tests/ -q` — 688 passed, 1 skipped, 43 subtests passed (unchanged)
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] Manual: visited every config snippet, links to `agents.md`, `command_spec.md`, the cookbook recipe, and the GitHub `SECURITY.md` (root file, linked by URL so strict-mode mkdocs is happy).

## Documentation

- [x] `CHANGELOG.md` updated
- [x] `mkdocs.yml` nav updated
- [ ] `docs/command_spec.md`, design / test specs — n/a (no command surface change)
- [ ] `docs/agents.md` — referenced by the new page; unchanged content

## Safety

Not applicable — docs only.

## Related

Part of #295. Remaining Horizon 1: #300 (PyPI publish + quickstart), #305 (error-hint audit).


---
_Generated by [Claude Code](https://claude.ai/code/session_01EyAemaqJWAVv7wFuNs6djg)_