### PR TITLE
chore(release): prepare 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-29
+
 ### Changed
 
 * **Audited MCP coverage against the full CLI surface (#323):** Refreshed the authoritative CLI-to-MCP coverage matrix in `docs/design/mcp-server.md` so every implemented command is classified as exposed, intentionally excluded (with rationale), or deferred (not yet implemented). The audit confirms the active surface is complete: all 63 exposable commands have MCP mirrors (64 tools, since `datasets replay` splits into `datasets_replay_plan` / `datasets_replay_files`), with `shell`, `tui`, `mcp serve`, `mcp install`, `completion`, and `datasets stream` intentionally excluded, and `plugins list/info` (#317) and `re anomalies` (#321) deferred until those commands land. Corrected stale docs that still listed fuzzing as "deferred"/"not exposed" (the `fuzz_*` tools shipped in #312/#346–#348) and added the newer `dbc_signals`, `doctor`, `sequence_replay`, and `fuzz_signal` / `fuzz_spn` tools to the naming table. Added two guard tests in `tests/test_mcp.py` — `test_every_cli_command_is_exposed_or_documented` and `test_no_orphan_mcp_tools` — that fail the build if a new command drifts out of coverage or a tool loses its CLI counterpart (`REQ-MCP-16`). `docs/agents.md` and `AGENTS.md` updated to reflect the final surface and point at the matrix.

--- a/src/canarchy/__init__.py
+++ b/src/canarchy/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.7.1.dev0"
+__version__ = "0.8.0"


### PR DESCRIPTION
## Summary

Cuts the **0.8.0** release (the first since 0.7.0 on 2026-05-09).

- Bumps `src/canarchy/__init__.py` `0.7.1.dev0` → `0.8.0`.
- Finalizes `CHANGELOG.md`: the `Unreleased` entries (42 bullets accumulated since 0.7.0) become the `## [0.8.0] - 2026-05-29` section, with a fresh empty `## [Unreleased]` at the top.

Highlights in 0.8.0 (full notes in the changelog section): DBC-aware `send`/`fuzz signal`, J1939 `fuzz spn`, AFL-style mutators (havoc/splice/interesting), `sequence replay`, `dbc inspect --search`, atheris parser self-fuzz + `fuzz` CI, `canarchy mcp install`, the MCP coverage audit, live replay to interface, comma.ai segment replay, and more.

## Local release verification (per `docs/release.md`)

- [x] `uv build` → `canarchy-0.8.0` sdist + wheel
- [x] `uvx twine check dist/*` → PASSED
- [x] wheel installs into a clean venv and `canarchy --version` → `canarchy 0.8.0`
- [x] `uv run pytest` → 977 passed, 1 skipped
- [x] `uv run --group docs mkdocs build --strict` → exit 0

## Remaining release steps (after merge)

These are the outward-facing steps from `docs/release.md` — I'll do the git ones on your go-ahead and leave the irreversible PyPI publish to you:

1. Tag `v0.8.0` on the merge commit and push the tag.
2. Create the GitHub release using the full `[0.8.0]` changelog section verbatim.
3. Publish to PyPI via the manual `publish` workflow (TestPyPI first if desired) — needs the environment/OIDC approval.
4. Follow-up commit on `main` advancing the version to `0.8.1.dev0`.

https://claude.ai/code/session_01ReM26dJHAQwqcABgoxVdFA

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReM26dJHAQwqcABgoxVdFA)_