### PR TITLE
chore: reopen development at 0.8.1.dev0

### DIFF
--- a/src/canarchy/__init__.py
+++ b/src/canarchy/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.8.0"
+__version__ = "0.8.1.dev0"


### PR DESCRIPTION
## Summary

Post-0.8.0 release housekeeping: advance `src/canarchy/__init__.py` from `0.8.0` → `0.8.1.dev0` to reopen development on `main`, per `docs/release.md` step 9 and the Development Version Naming policy (after `X.Y.Z`, `main` advances to `X.Y.(Z+1).dev0`).

0.8.0 has been tagged and published to PyPI.

## Verification

- [x] `import canarchy` reports `0.8.1.dev0`

https://claude.ai/code/session_01ReM26dJHAQwqcABgoxVdFA

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReM26dJHAQwqcABgoxVdFA)_