### PR TITLE
chore(deps): bump cantools 41.3.1 -> 41.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Changed
+
+* Bumped the locked `cantools` dependency from 41.3.1 to 41.4.0 (latest release). The update also drops the now-unused transitive `diskcache` dependency, slightly reducing the install footprint. The `cantools` APIs CANarchy relies on (DBC/KCD/ARXML/SYM loading, message encode/decode, database serialization) are unchanged; the `pyproject.toml` floor constraint remains `cantools>=39.4`.
+
 ## [0.8.0] - 2026-05-29
 
 ### Changed

--- a/uv.lock
+++ b/uv.lock
@@ -299,19 +299,18 @@ wheels = [
 
 [[package]]
 name = "cantools"
-version = "41.3.1"
+version = "41.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argparse-addons" },
     { name = "bitstruct" },
     { name = "crccheck" },
-    { name = "diskcache" },
     { name = "python-can" },
     { name = "textparser" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/0f/133594a941073b5651ce7a068206cbc642ea012a13381d5f8d0528d932a6/cantools-41.3.1.tar.gz", hash = "sha256:63965b028ac02ab1b4c867aa207ed99f90f55b38ae107abe287d7d66d5435d9f", size = 1042445, upload-time = "2026-04-18T16:56:39.537Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/a2/327b37dd956a7e7a959c80f60746d0902c35b0d3f26a1b64c0f3915091b9/cantools-41.4.0.tar.gz", hash = "sha256:c1266a599b594d78c17ee97da5e583633f7ad19ab97dcb3aa19b6f62dc17ffec", size = 1043179, upload-time = "2026-05-20T22:03:26.402Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/30/fe8d22e5f52acd2c654d336210ae45a1130c8aa077fbb8582c2e286bf071/cantools-41.3.1-py3-none-any.whl", hash = "sha256:74a269964cc825b1d1427d8e2a4051401c33b983d14a03dcf6c21d67b4c3657a", size = 160378, upload-time = "2026-04-18T16:56:37.599Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/1a/dd384d1baedf71d1effdfe0c45671d4160cd6d04107b2b752e2c9444e854/cantools-41.4.0-py3-none-any.whl", hash = "sha256:3f530bf37f7ec52543855d215a1f73bb274bbc41996ba9754cab0d289f7b4f89", size = 161292, upload-time = "2026-05-20T22:03:23.589Z" },
 ]
 
 [[package]]
@@ -543,15 +542,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
-]
-
-[[package]]
-name = "diskcache"
-version = "5.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Re-locks cantools to the latest release: **41.3.1 → 41.4.0** (published 2026-05-20). The bump also drops the now-unused transitive **`diskcache`** dependency.

- Only `uv.lock` changes — no source changes.
- canarchy does not import `diskcache` directly (it was a cantools transitive dep), so dropping it is safe.
- The cantools APIs we rely on are unchanged on 41.4.0 — verified `load_file`, message encode/decode, `as_dbc_string`, and the `dump` formatting helpers (`layout_string`) against `tests/fixtures/sample.dbc`.
- The `pyproject.toml` floor constraint stays at `cantools>=39.4` (conservative minimum; uv resolves to the newest compatible).

## Verification

- [x] `uv lock --upgrade-package cantools` → 41.4.0; `uv sync` clean
- [x] Full suite: **977 passed, 1 skipped**
- [x] cantools helper smoke check on 41.4.0 passes

https://claude.ai/code/session_01ReM26dJHAQwqcABgoxVdFA

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReM26dJHAQwqcABgoxVdFA)_