### PR TITLE
Add Windows-first quickstart

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,3 +44,25 @@ jobs:
         # tests/test_dbc_runtime.py are collected. `unittest discover`
         # silently skips them.
         run: uv run pytest tests/ -q
+
+  windows-unittest:
+    name: windows unittest (python 3.12)
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Sync project environment
+        run: uv sync
+
+      - name: Run network-independent test suite
+        run: uv run pytest tests/ -q

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,8 +45,8 @@ jobs:
         # silently skips them.
         run: uv run pytest tests/ -q
 
-  windows-unittest:
-    name: windows unittest (python 3.12)
+  windows-smoke:
+    name: windows smoke (python 3.12)
     runs-on: windows-latest
 
     steps:
@@ -64,5 +64,14 @@ jobs:
       - name: Sync project environment
         run: uv sync
 
-      - name: Run network-independent test suite
-        run: uv run pytest tests/ -q
+      - name: Run Windows install smoke
+        shell: pwsh
+        run: |
+          uv run canarchy doctor --text
+          $env:CANARCHY_TRANSPORT_BACKEND = "scaffold"
+          uv run canarchy capture can0 --jsonl
+          uv run canarchy config show --json
+
+      - name: Run Windows-safe CLI tests
+        shell: pwsh
+        run: uv run pytest tests/test_cli.py::DoctorCommandTests tests/test_cli.py::CliTests::test_capture_json_output_streams_one_event_per_line -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 * Closed the MCP active-transmit safety gap for `send`, `generate`, and `gateway` (#380): these tools now require `ack_active=true`, default to `dry_run=true`, and are enforced by the same MCP gate as replay, sequence replay, and fuzzing. CLI `generate` and `gateway` also gain `--dry-run` planning modes so agents can inspect intended traffic without opening transports.
 * Bumped the locked `cantools` dependency from 41.3.1 to 41.4.0 (latest release). The update also drops the now-unused transitive `diskcache` dependency, slightly reducing the install footprint. The `cantools` APIs CANarchy relies on (DBC/KCD/ARXML/SYM loading, message encode/decode, database serialization) are unchanged; the `pyproject.toml` floor constraint remains `cantools>=39.4`.
 
+### Documentation
+
+* Added a Windows-first install and quickstart path covering PowerShell/CMD syntax, `pipx install canarchy`, `canarchy doctor`, no-hardware scaffold validation, Vector/PCAN driver pointers, and current Windows limitations. Added Windows CI coverage for the network-independent test suite and updated the feature matrix Windows usability row. Closes #330.
+
 ## [0.8.0] - 2026-05-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Documentation
 
-* Added a Windows-first install and quickstart path covering PowerShell/CMD syntax, `pipx install canarchy`, `canarchy doctor`, no-hardware scaffold validation, Vector/PCAN driver pointers, and current Windows limitations. Added Windows CI coverage for the network-independent test suite and updated the feature matrix Windows usability row. Closes #330.
+* Added a Windows-first install and quickstart path covering PowerShell/CMD syntax, `pipx install canarchy`, `canarchy doctor`, no-hardware scaffold validation, Vector/PCAN driver pointers, and current Windows limitations. Added Windows CI smoke coverage for the install and core CLI path, and updated the feature matrix Windows usability row. Closes #330.
 
 ## [0.8.0] - 2026-05-29
 

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -181,6 +181,33 @@ interface = "virtual"
 
 The `virtual` interface only delivers frames within the same Python process. Use `udp_multicast` if you need cross-process visibility.
 
+### Windows hardware adapters
+
+On Windows, install the vendor driver before opening a live CAN channel. CANarchy delegates live bus access to `python-can`, so the configured `interface` value must match the vendor backend and the command argument must match the vendor channel name.
+
+| Adapter family | Driver pointer | Interface type | Typical channel |
+|---|---|---|---|
+| Vector VN/VX | [Vector Driver Setup](https://www.vector.com/int/en/products/products-a-z/libraries-drivers/vector-driver-setup/) | `vector` | `0` |
+| PEAK PCAN-USB/PCIe | [PEAK-System drivers](https://www.peak-system.com/Drivers.523.0.html?&L=1) | `pcan` | `PCAN_USBBUS1` |
+
+PowerShell example for PCAN-USB:
+
+```powershell
+$env:CANARCHY_PYTHON_CAN_INTERFACE = "pcan"
+canarchy config show
+canarchy capture PCAN_USBBUS1 --candump
+```
+
+PowerShell example for Vector:
+
+```powershell
+$env:CANARCHY_PYTHON_CAN_INTERFACE = "vector"
+canarchy config show
+canarchy capture 0 --candump
+```
+
+SocketCAN and `vcan` are Linux-only. For Windows no-hardware tests across terminals, prefer `udp_multicast`; for deterministic offline smoke tests and CI, prefer `CANARCHY_TRANSPORT_BACKEND=scaffold`.
+
 ---
 
 ## Verifying Your Configuration

--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -55,7 +55,7 @@ The workflow matrix above is useful for operator-facing comparison, but several 
 | Protocol breadth beyond raw CAN | Partial | Yes | Partial | Partial | Partial | Yes | Partial | Yes | Yes | No |
 | Session / bookmark / saved analysis workflow | Partial | No | Partial | No | Partial | Partial | Partial | Yes | Yes | No |
 | Embedded-library ergonomics | No | No | Yes | Yes | No | No | No | Partial | No | Yes |
-| Windows-first usability | Partial | No | Yes | Yes | Partial | Partial | Partial | Partial | Yes | Yes |
+| Windows-first usability | Yes | No | Yes | Yes | Partial | Partial | Partial | Partial | Yes | Yes |
 
 ## Documentation Quality
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -6,6 +6,80 @@ This guide walks through the fastest way to see CANarchy produce familiar `candu
 
 CANarchy targets Python 3.12 or newer. Pick the install path that matches your use case.
 
+### Windows 11 quickstart
+
+Use **Windows Terminal with PowerShell 7** when possible. The commands below also work in Windows PowerShell 5.1 unless noted. `cmd.exe` is usable for CANarchy commands, but PowerShell is clearer for environment variables and JSON output.
+
+1. Install Python 3.12 or newer from [python.org](https://www.python.org/downloads/windows/) or with `winget`:
+
+   ```powershell
+   winget install Python.Python.3.12
+   py -3.12 --version
+   ```
+
+2. Install `pipx`, then make sure its script directory is on `PATH`:
+
+   ```powershell
+   py -3.12 -m pip install --user pipx
+   py -3.12 -m pipx ensurepath
+   ```
+
+   Open a new terminal after `ensurepath` if `pipx` is not found immediately.
+
+3. Install CANarchy from PyPI and run the offline health check:
+
+   ```powershell
+   pipx install canarchy
+   canarchy --version
+   canarchy doctor --text
+   ```
+
+   `canarchy doctor` should print a normal health-check table on Windows. Warnings about missing hardware-specific drivers or an unpopulated DBC cache are expected until you configure those workflows.
+
+4. Run the deterministic no-hardware smoke test:
+
+   ```powershell
+   $env:CANARCHY_TRANSPORT_BACKEND = "scaffold"
+   canarchy capture can0 --jsonl
+   ```
+
+   In `cmd.exe`, use this environment-variable syntax instead:
+
+   ```bat
+   set CANARCHY_TRANSPORT_BACKEND=scaffold
+   canarchy capture can0 --jsonl
+   ```
+
+5. For live CAN hardware, install the vendor driver first, then select the matching `python-can` interface type. Common Windows paths are:
+
+   | Adapter family | Driver pointer | CANarchy interface type | Example channel |
+   |---|---|---|---|
+   | Vector VN/VX | [Vector Driver Setup](https://www.vector.com/int/en/products/products-a-z/libraries-drivers/vector-driver-setup/) | `vector` | `0` |
+   | PEAK PCAN-USB/PCIe | [PEAK-System drivers](https://www.peak-system.com/Drivers.523.0.html?&L=1) | `pcan` | `PCAN_USBBUS1` |
+
+   Example PCAN session configuration:
+
+   ```powershell
+   $env:CANARCHY_PYTHON_CAN_INTERFACE = "pcan"
+   canarchy config show
+   canarchy capture PCAN_USBBUS1 --candump
+   ```
+
+   Example Vector session configuration:
+
+   ```powershell
+   $env:CANARCHY_PYTHON_CAN_INTERFACE = "vector"
+   canarchy config show
+   canarchy capture 0 --candump
+   ```
+
+Known Windows limitations:
+
+* SocketCAN and `vcan` are Linux-only; use vendor hardware backends, `udp_multicast`, or `scaffold` on Windows.
+* `canarchy completion` currently emits `bash`, `zsh`, and `fish` scripts, not PowerShell completion.
+* The `virtual` python-can interface is same-process only. Use `udp_multicast` for no-hardware tests that need separate terminals.
+* Live capture/transmit depends on vendor drivers, adapter firmware, and channel names exposed by the driver package.
+
 ### From PyPI (recommended for users)
 
 ```bash


### PR DESCRIPTION
Closes #330

Summary:
- Add Windows 11 quickstart and validated install path guidance.
- Document Windows hardware adapter notes and scaffold smoke checks.
- Add a Windows CI unit-test job.

Verification:
- 
- command: doctor
summary: 8 ok, 0 warning(s), 0 failed
checks:
- [OK]    python_version: Python 3.12.13
- [OK]    python_can: python-can 4.6.1 importable
- [OK]    transport_backend: python-can interface=<unset>
- [OK]    config_file: /Users/phil/.canarchy/config.toml parses cleanly
- [OK]    cache_dirs: all caches writable
- [OK]    opendbc_cache: 15 cached DBC files at /Users/phil/.canarchy/cache/dbc/providers/opendbc (commit a5276670833f)
- [OK]    mcp_server: stdio server constructable
- [OK]    version_consistency: package and source agree on 0.8.1.dev0
- {"event_type": "frame", "payload": {"frame": {"arbitration_id": 419360305, "bitrate_switch": false, "data": "11223344", "dlc": 4, "error_state_indicator": false, "frame_format": "can", "interface": "can0", "is_error_frame": false, "is_extended_id": true, "is_remote_frame": false, "timestamp": 0.0}}, "source": "transport.capture", "timestamp": 0.0}
{"event_type": "frame", "payload": {"frame": {"arbitration_id": 418382897, "bitrate_switch": false, "data": "aabbccdd", "dlc": 4, "error_state_indicator": false, "frame_format": "can", "interface": "can0", "is_error_frame": false, "is_extended_id": true, "is_remote_frame": false, "timestamp": 0.1}}, "source": "transport.capture", "timestamp": 0.1}
- ........................................................................ [  6%]
........................................................................ [ 13%]
........................................................................ [ 20%]
........................................................................ [ 27%]
........................................................................ [ 34%]
.............................................................................................................. [ 44%]
.............................................................................................................................................. [ 58%]
........................................................................ [ 64%]
........................................................................ [ 71%]
........................................................................ [ 78%]
............................................................ [ 84%]
........................................................................ [ 90%]
..................s..................................................... [ 97%]
.......................                                                  [100%]
1054 passed, 1 skipped, 48 subtests passed in 17.89s