### PR TITLE
docs: flesh out plugin-guide.md with two complete walkthroughs (#318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Documentation
 
+* Rewrote `docs/plugin-guide.md` into two end-to-end walkthroughs (#318): (1) a custom `ProcessorPlugin` (`RepeatingIDDetector`) covering project layout, plugin code, `pyproject.toml` entry-point declaration, install, verification via `canarchy plugins list/info/enable/disable`, and a 4-test pytest suite; (2) a custom `SinkPlugin` walking through the reference `contrib/plugins/sqlite_sink/` implementation with the same structure, including a test that asserts frame events land in a temporary SQLite file. Added `plugin-guide.md` to the MkDocs nav so it appears in the rendered User Guide. Closes #318.
 * Added a Windows-first install and quickstart path covering PowerShell/CMD syntax, `pipx install canarchy`, `canarchy doctor`, no-hardware scaffold validation, Vector/PCAN driver pointers, and current Windows limitations. Added Windows CI smoke coverage for the install and core CLI path, and updated the feature matrix Windows usability row. Closes #330.
 
 ## [0.8.0] - 2026-05-29

--- a/docs/plugin-guide.md
+++ b/docs/plugin-guide.md
@@ -1,24 +1,43 @@
 # Plugin Author Guide
 
 CANarchy supports third-party plugins that extend the analysis engine without requiring a fork.
-This guide shows how to build, package, and register a custom processor plugin.
+This guide contains two complete walkthroughs followed by reference material for all extension
+points.
 
 ## Extension Points
 
-| Extension point | Use case |
-|----------------|----------|
-| `ProcessorPlugin` | Frame analysis: counters, entropy, anomaly detection, custom classifiers |
-| `SinkPlugin` | Output routing: databases, SIEM, cloud telemetry, custom file formats |
-| `InputAdapterPlugin` | Input parsing: proprietary capture formats, hardware-specific log files |
+| Extension point | Entry-point group | Use case |
+|----------------|-------------------|----------|
+| `ProcessorPlugin` | `canarchy.processors` | Frame analysis: counters, entropy, anomaly detection, custom classifiers |
+| `SinkPlugin` | `canarchy.sinks` | Output routing: databases, SIEM, cloud telemetry, custom file formats |
+| `InputAdapterPlugin` | `canarchy.input_adapters` | Input parsing: proprietary capture formats, hardware-specific log files |
 
 ## API Version
 
 Every plugin must declare `api_version = "1"`. If the version does not match the installed
 CANarchy build, the plugin is rejected at registration time with a clear error message.
 
-## Writing a Processor Plugin
+---
 
-A processor receives a list of `CanFrame` objects and returns a `ProcessorResult`.
+## Walkthrough 1 — Custom Decoder Plugin
+
+This walkthrough builds a `ProcessorPlugin` that flags arbitration IDs whose frame count
+exceeds a configurable fraction of the total traffic — useful for quickly identifying dominant
+talkers in a capture.
+
+### Project layout
+
+```
+canarchy-repeating-id/
+├── pyproject.toml
+├── my_package/
+│   ├── __init__.py
+│   └── plugin.py
+└── tests/
+    └── test_repeating_id.py
+```
+
+### Plugin code
 
 ```python
 # my_package/plugin.py
@@ -65,7 +84,7 @@ class RepeatingIDDetector:
         )
 ```
 
-### Rules
+### Processor plugin rules
 
 - `name` must be a unique string across all registered processors.
 - `api_version` must equal `canarchy.plugins.CANARCHY_API_VERSION`.
@@ -73,97 +92,304 @@ class RepeatingIDDetector:
 - `**kwargs` lets callers pass optional parameters; always provide safe defaults.
 - Do not import front-end modules (`cli`, `tui`, `mcp_server`) from within a plugin.
 
-## Packaging and Registration
+### Package and register
 
 Declare the plugin via a Python entry point in your `pyproject.toml`:
 
 ```toml
 [project]
 name = "canarchy-repeating-id"
-dependencies = ["canarchy>=0.6"]
+version = "0.1.0"
+dependencies = ["canarchy>=0.8"]
 
 [project.entry-points."canarchy.processors"]
 repeating-id-detector = "my_package.plugin:RepeatingIDDetector"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 ```
 
 Install the package into the same environment as CANarchy:
 
-```
+```bash
 pip install -e .
 # or
 uv pip install -e .
 ```
 
+### Verify the registration
+
 CANarchy discovers and registers the plugin the next time `get_registry()` is called (on first
-command execution). Operators can inspect and toggle discovered plugins from the CLI:
-
-```bash
-canarchy plugins list --json
-canarchy plugins info repeating-id-detector --json
-canarchy plugins disable repeating-id-detector --json
-canarchy plugins enable repeating-id-detector --json
-```
-
-## Entry Point Groups
-
-| Group | Extension point |
-|-------|----------------|
-| `canarchy.processors` | `ProcessorPlugin` |
-| `canarchy.sinks` | `SinkPlugin` |
-| `canarchy.input_adapters` | `InputAdapterPlugin` |
-
-## Local Verification
-
-To confirm your plugin is registered before distributing it, prefer the CLI:
+command execution):
 
 ```bash
 canarchy plugins list --json
 canarchy plugins info repeating-id-detector --json
 ```
 
-For direct registry tests, use Python:
+### Write a test
 
 ```python
+# tests/test_repeating_id.py
+import pytest
+from canarchy.models import CanFrame
 from canarchy.plugins import get_registry, reset_registry
+from my_package.plugin import RepeatingIDDetector
 
-reset_registry()  # force a fresh build
-registry = get_registry()
-proc = registry.get_processor("repeating-id-detector")
-assert proc is not None, "plugin not found — check entry point group and class name"
-print(registry.list_processors())
+
+@pytest.fixture(autouse=True)
+def fresh_registry():
+    reset_registry()
+    yield
+    reset_registry()
+
+
+def _frame(arb_id: int) -> CanFrame:
+    return CanFrame(arbitration_id=arb_id, data=b"\x00")
+
+
+def test_dominant_id_detected():
+    plugin = RepeatingIDDetector()
+    frames = [_frame(0x100)] * 8 + [_frame(0x200)] * 2
+    result = plugin.process(frames)
+    assert result.candidates[0]["arbitration_id"] == 0x100
+    assert result.candidates[0]["fraction"] == 0.8
+
+
+def test_no_dominant_id_emits_warning():
+    plugin = RepeatingIDDetector()
+    frames = [_frame(i) for i in range(10)]
+    result = plugin.process(frames, threshold=0.5)
+    assert result.warnings
+
+
+def test_empty_input_does_not_raise():
+    plugin = RepeatingIDDetector()
+    result = plugin.process([])
+    assert result.candidates == []
+
+
+def test_registered_via_entry_point():
+    # After `pip install -e .`, the plugin appears in the registry.
+    registry = get_registry()
+    proc = registry.get_processor("repeating-id-detector")
+    assert proc is not None
 ```
 
-## Error Isolation
+### Enable and disable via CLI
 
-CANarchy wraps third-party entry point loading in a `try/except`. If your plugin raises an
-unexpected exception during loading, CANarchy emits a `warnings.warn` and continues starting.
-A `PluginError` (version mismatch, duplicate name, invalid interface) propagates immediately
-so you can diagnose it during development.
+```bash
+# Disable the plugin (persisted in ~/.canarchy/config.toml)
+canarchy plugins disable repeating-id-detector --json
 
-## Writing a Sink Plugin
+# Re-enable it
+canarchy plugins enable repeating-id-detector --json
 
-A sink writes a serialized command payload to a custom destination.
+# Confirm status
+canarchy plugins info repeating-id-detector --json
+```
+
+---
+
+## Walkthrough 2 — Custom Sink Plugin
+
+This walkthrough builds a `SinkPlugin` that persists command payloads to a SQLite database.
+The completed implementation is the reference plugin shipped under
+`contrib/plugins/sqlite_sink/` in the CANarchy repository.
+
+### Project layout
+
+```
+canarchy-sqlite-sink/
+├── pyproject.toml
+├── sqlite_sink/
+│   ├── __init__.py
+│   └── plugin.py
+└── tests/
+    └── test_sqlite_sink.py
+```
+
+### Plugin code
 
 ```python
+# sqlite_sink/plugin.py
+from __future__ import annotations
+
 import json
+import sqlite3
+import time
 from typing import Any
+
 from canarchy.plugins import CANARCHY_API_VERSION
 
 
-class JsonFileSink:
-    name = "json-file"
+class SqliteSinkPlugin:
+    """Write CANarchy command payloads to a SQLite database."""
+
+    name = "sqlite-sink"
     api_version = CANARCHY_API_VERSION
     supported_formats = ["json"]
 
     def write(
-        self, payload: dict[str, Any], destination: str, *, output_format: str = "json"
+        self,
+        payload: dict[str, Any],
+        destination: str,
+        *,
+        output_format: str = "json",
     ) -> dict[str, Any]:
-        with open(destination, "w") as f:
-            json.dump(payload, f, indent=2)
-        return {"destination": destination, "bytes_written": f.tell()}
+        """Insert frame events from *payload* into a SQLite DB at *destination*.
+
+        Creates the database and ``frames`` table if they do not exist.
+        Returns a dict with ``destination`` and ``rows_written``.
+        """
+        con = sqlite3.connect(destination)
+        try:
+            con.execute(
+                """
+                CREATE TABLE IF NOT EXISTS frames (
+                    id      INTEGER PRIMARY KEY,
+                    ts      REAL,
+                    command TEXT,
+                    payload TEXT
+                )
+                """
+            )
+            con.commit()
+
+            command = payload.get("command", "")
+            events = payload.get("data", {}).get("events", [])
+
+            rows_written = 0
+            if events:
+                for event in events:
+                    ts = event.get("ts", time.time())
+                    con.execute(
+                        "INSERT INTO frames (ts, command, payload) VALUES (?, ?, ?)",
+                        (ts, command, json.dumps(event)),
+                    )
+                    rows_written += 1
+            else:
+                ts = time.time()
+                con.execute(
+                    "INSERT INTO frames (ts, command, payload) VALUES (?, ?, ?)",
+                    (ts, command, json.dumps(payload)),
+                )
+                rows_written = 1
+
+            con.commit()
+        finally:
+            con.close()
+
+        return {"destination": destination, "rows_written": rows_written}
 ```
 
-Entry point group: `canarchy.sinks`.
+### Sink plugin rules
+
+- `name` must be a unique string across all registered sinks.
+- `api_version` must equal `canarchy.plugins.CANARCHY_API_VERSION`.
+- `supported_formats` lists the envelope formats the sink understands (currently `"json"`).
+- `write()` must return a dict; it must not raise on an empty `"events"` list.
+- `destination` is a string the caller controls — it may be a file path, a connection URL, or
+  a topic name depending on your sink's semantics.
+
+### Package and register
+
+```toml
+[project]
+name = "canarchy-sqlite-sink"
+version = "0.1.0"
+dependencies = ["canarchy>=0.8"]
+
+[project.entry-points."canarchy.sinks"]
+sqlite-sink = "sqlite_sink.plugin:SqliteSinkPlugin"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+```
+
+```bash
+pip install -e .
+```
+
+### Verify the registration
+
+```bash
+canarchy plugins list --json
+canarchy plugins info sqlite-sink --json
+```
+
+### Write a test
+
+```python
+# tests/test_sqlite_sink.py
+import os
+import sqlite3
+import tempfile
+import unittest
+
+from canarchy.plugins import SinkPlugin
+from sqlite_sink.plugin import SqliteSinkPlugin
+
+
+class SqliteSinkTests(unittest.TestCase):
+    def setUp(self):
+        self.plugin = SqliteSinkPlugin()
+
+    def test_events_land_in_db(self):
+        with tempfile.TemporaryDirectory() as td:
+            db_path = os.path.join(td, "out.db")
+            payload = {
+                "command": "capture",
+                "data": {
+                    "events": [
+                        {"type": "frame", "ts": 1.0, "arbitration_id": "0x100"},
+                        {"type": "frame", "ts": 2.0, "arbitration_id": "0x200"},
+                    ]
+                },
+            }
+            result = self.plugin.write(payload, db_path)
+
+            # Return contract
+            assert result["rows_written"] == 2
+            assert result["destination"] == db_path
+
+            # Rows actually landed in the database
+            con = sqlite3.connect(db_path)
+            rows = con.execute("SELECT COUNT(*) FROM frames").fetchone()[0]
+            con.close()
+            assert rows == 2
+
+    def test_db_created_if_missing(self):
+        with tempfile.TemporaryDirectory() as td:
+            db_path = os.path.join(td, "new.db")
+            self.plugin.write({"command": "test", "data": {}}, db_path)
+            assert os.path.exists(db_path)
+
+    def test_implements_sink_protocol(self):
+        assert isinstance(self.plugin, SinkPlugin)
+```
+
+### Enable and disable via CLI
+
+```bash
+canarchy plugins disable sqlite-sink --json
+canarchy plugins enable sqlite-sink --json
+canarchy plugins info sqlite-sink --json
+```
+
+### Reference implementation
+
+The completed plugin is available under `contrib/plugins/sqlite_sink/` in the CANarchy
+repository. Clone the repo and run its tests directly:
+
+```bash
+# From the repo root
+python -m pytest tests/test_contrib_sqlite_sink.py -v
+```
+
+---
 
 ## Writing an Input Adapter Plugin
 
@@ -191,6 +417,23 @@ class MyFormatAdapter:
 ```
 
 Entry point group: `canarchy.input_adapters`.
+
+---
+
+## Entry Point Groups Reference
+
+| Group | Extension point |
+|-------|----------------|
+| `canarchy.processors` | `ProcessorPlugin` |
+| `canarchy.sinks` | `SinkPlugin` |
+| `canarchy.input_adapters` | `InputAdapterPlugin` |
+
+## Error Isolation
+
+CANarchy wraps third-party entry point loading in a `try/except`. If your plugin raises an
+unexpected exception during loading, CANarchy emits a `warnings.warn` and continues starting.
+A `PluginError` (version mismatch, duplicate name, invalid interface) propagates immediately
+so you can diagnose it during development.
 
 ## Compatibility Policy
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
       - CAN Tool Feature Matrix: feature-matrix.md
       - Security Use Cases With Agents: security-use-cases.md
       - Troubleshooting: troubleshooting.md
+      - Plugin Author Guide: plugin-guide.md
   - Tutorials:
       - Overview: tutorials/index.md
       - Stream CAN Data from CANdid: tutorials/stream_candid_dataset.md


### PR DESCRIPTION
## Summary

- Rewrites `docs/plugin-guide.md` from a reference-style page into two end-to-end walkthroughs, closing the last open Horizon 2 item (#318)
- Adds `plugin-guide.md` to `mkdocs.yml` nav so the strict MkDocs build includes it

## Walkthroughs

**Walkthrough 1 — Custom Decoder (Processor) Plugin**
Builds a `RepeatingIDDetector` from scratch: project layout, plugin code, `pyproject.toml` entry-point declaration, install + verify via `canarchy plugins list/info`, a 4-test pytest suite, and `canarchy plugins enable/disable` examples.

**Walkthrough 2 — Custom Sink Plugin**
Walks through the reference `SqliteSinkPlugin` in `contrib/plugins/sqlite_sink/`, covering the same structure: plugin code, packaging, registration, and a test suite that asserts frame events land in a temporary SQLite file.

## Test plan

- [ ] `uv run pytest tests/test_contrib_sqlite_sink.py tests/test_plugins.py -v` — all 35 tests pass
- [ ] `uv run --with mkdocs-material mkdocs build --strict` — builds cleanly with no errors
- [ ] `plugin-guide.md` appears in the User Guide section of the rendered nav

Closes #318.

https://claude.ai/code/session_014opWW14ac6ojQYduAbdttx

---
_Generated by [Claude Code](https://claude.ai/code/session_014opWW14ac6ojQYduAbdttx)_