### PR TITLE
docs: position UTHP/TCAT as companion hardware (#419)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Documentation
 
+* Documented UTHP (SystemsCyber) and NMFTA TCAT as companion hardware platforms (#419): `docs/feature-matrix.md` gains a "Companion Hardware: UTHP And TCAT" section positioning CANarchy as the structured analysis layer over captures from a TCAT-style BeagleBone appliance, and a new cookbook recipe (`docs/cookbook/analyze-tcat-capture.md`) walks the capture-on-appliance → `capture-info` → `j1939 summary`/`inventory`/`faults` → `re` tools workflow, with MIT attribution and the note that bundled third-party tools carry their own licenses. Closes #419.
+
 * Rewrote `docs/plugin-guide.md` into two end-to-end walkthroughs (#318): (1) a custom `ProcessorPlugin` (`RepeatingIDDetector`) covering project layout, plugin code, `pyproject.toml` entry-point declaration, install, verification via `canarchy plugins list/info/enable/disable`, and a 4-test pytest suite; (2) a custom `SinkPlugin` walking through the reference `contrib/plugins/sqlite_sink/` implementation with the same structure, including a test that asserts frame events land in a temporary SQLite file. Added `plugin-guide.md` to the MkDocs nav so it appears in the rendered User Guide. Closes #318.
 * Added a Windows-first install and quickstart path covering PowerShell/CMD syntax, `pipx install canarchy`, `canarchy doctor`, no-hardware scaffold validation, Vector/PCAN driver pointers, and current Windows limitations. Added Windows CI smoke coverage for the install and core CLI path, and updated the feature matrix Windows usability row. Closes #330.
 

--- a/docs/cookbook/analyze-tcat-capture.md
+++ b/docs/cookbook/analyze-tcat-capture.md
@@ -1,0 +1,109 @@
+# Analyze a capture from a UTHP / TCAT appliance
+
+## Goal
+
+Use CANarchy as the analysis layer for captures taken on a heavy-vehicle
+assessment appliance such as the SystemsCyber **UTHP** (Universal Truck
+Hacking Platform) or the NMFTA **TCAT** (Truck Cybersecurity Assessment
+Tool). Both are BeagleBone-class devices with four CAN channels
+(`can0`–`can3`) that expose standard SocketCAN interfaces, so everything
+CANarchy does with candump files and SocketCAN applies directly.
+
+This recipe is passive end to end: it captures on the appliance and
+analyzes the file offline. No frames are transmitted.
+
+## Prerequisites
+
+* A UTHP or TCAT appliance connected to a truck network (J1939 backbone
+  or diagnostic connector) with at least one CAN channel active.
+* SSH access to the appliance, or any way to copy files off it.
+* CANarchy installed where the analysis runs (the appliance itself can run
+  it, but copying captures to a workstation is the more comfortable path).
+
+## Capture on the appliance
+
+The appliances ship `can-utils`, so the simplest capture is candump's
+timestamped log format, which CANarchy reads natively:
+
+```bash
+# on the appliance — capture 60 seconds of traffic from can0
+timeout 60 candump -L can0 > drive.candump
+```
+
+CANarchy itself also runs on the appliance if installed there:
+
+```bash
+canarchy capture can0 --candump > drive.candump
+```
+
+Copy the file to the analysis machine:
+
+```bash
+scp tcat:/home/debian/drive.candump .
+```
+
+## Triage the capture
+
+Size up the file before deeper analysis and note the suggested
+`max_frames` / `seconds` bounds for large captures:
+
+```bash
+canarchy capture-info --file drive.candump --json
+```
+
+Get the J1939 picture — PGN distribution, source addresses, transport
+sessions, and any printable identifiers (VIN, component IDs) broadcast
+over TP:
+
+```bash
+canarchy j1939 summary --file drive.candump --json
+canarchy j1939 inventory --file drive.candump --json
+```
+
+Pull the fault story — DM1 DTCs grouped per ECU with SPN names, FMI
+descriptions, and lamp status from the bundled SAE catalogs:
+
+```bash
+canarchy j1939 faults --file drive.candump --json
+```
+
+## Dig deeper with the RE tools
+
+The reverse-engineering commands annotate J1939 frames with PGN labels and
+source-address names automatically, and skip J1939 transport-protocol
+framing so TP sequence numbers do not masquerade as signals:
+
+```bash
+canarchy re entropy --file drive.candump --json
+canarchy re counters --file drive.candump --json
+canarchy re anomalies --file drive.candump --baseline known_good.candump --json
+```
+
+For multi-channel work, capture each appliance channel (`can0`–`can3`) to
+its own file and diff them:
+
+```bash
+canarchy j1939 compare --file can0.candump --file can1.candump --json
+canarchy re corpus --file can0.candump --file can1.candump --json
+```
+
+## About UTHP and TCAT
+
+* [UTHP](https://github.com/SystemsCyber/UTHP) is the Universal Truck
+  Hacking Platform from the Colorado State University Systems Cyber group:
+  a BeagleBone-based appliance image bundling truck-protocol tooling
+  (python-can, pretty-j1939, pretty-j1587, PLC4TRUCKSduck, TruckDevil,
+  CanCat, cannelloni, and more).
+* [TCAT](https://github.com/nmfta-repo/TCAT) is the NMFTA Truck
+  Cybersecurity Assessment Tool — the productized, hardened release of the
+  same platform, distributed as a flashable image.
+* Both projects are MIT licensed. The third-party tools they bundle carry
+  their own licenses. CANarchy complements rather than replaces them: the
+  appliance provides the bus access and channel breadth; CANarchy provides
+  the structured, scriptable analysis layer over the captures.
+
+## See also
+
+* [Compare two captures for DM1 fault diffs](compare-dm1-faults.md)
+* [Find counter signals in a capture](find-counter-signals.md)
+* [Filter for a single arbitration ID or PGN](filter-pgn.md)

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -10,6 +10,7 @@ For longer walkthroughs, see the [Tutorials](../tutorials/index.md) page.
 ## Capture and triage
 
 * [Filter for a single arbitration ID or PGN](filter-pgn.md)
+* [Analyze a capture from a UTHP / TCAT appliance](analyze-tcat-capture.md)
 * [Compare two captures for DM1 fault diffs](compare-dm1-faults.md)
 * [Build a virtual CAN loop for offline testing](virtual-can-loop.md)
 * [Verify a PCAN interface in 30 seconds](verify-pcan-interface.md)

--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -178,6 +178,24 @@ In practice, many users will still pair CANarchy with other tools:
 * BUSMASTER for desktop-centric CAN analysis on Windows
 * `udsoncan` for Python-native UDS client workflows
 
+## Companion Hardware: UTHP And TCAT
+
+For heavy-vehicle field work, CANarchy pairs naturally with the
+[UTHP](https://github.com/SystemsCyber/UTHP) (Universal Truck Hacking
+Platform, Colorado State University Systems Cyber) and its productized
+descendant, the NMFTA [TCAT](https://github.com/nmfta-repo/TCAT) (Truck
+Cybersecurity Assessment Tool). Both are BeagleBone-class appliances with
+four SocketCAN channels (`can0`–`can3`), J1708/PLC bus hardware, and a
+bundled truck-protocol tool image (both MIT licensed; their bundled
+third-party tools carry their own licenses).
+
+The division of labor: the appliance provides bus access, channel breadth,
+and truck-specific physical layers; CANarchy provides the structured,
+scriptable analysis layer over the captures — candump files from the
+appliance feed directly into `capture-info`, the `j1939 *` family, and the
+`re *` tools. See the cookbook recipe
+[Analyze a capture from a UTHP / TCAT appliance](cookbook/analyze-tcat-capture.md).
+
 ## Notes And Caveats
 
 * This matrix is intentionally high-level and not exhaustive.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
       - Verify a Vector interface in 30 seconds: cookbook/verify-vector-interface.md
       - Verify a Kvaser interface in 30 seconds: cookbook/verify-kvaser-interface.md
       - Compare two captures for DM1 fault diffs: cookbook/compare-dm1-faults.md
+      - Analyze a capture from a UTHP / TCAT appliance: cookbook/analyze-tcat-capture.md
   - Developers:
       - Architecture: architecture.md
       - Docs Workflow: docs_site.md


### PR DESCRIPTION
Closes #419 — the documentation follow-up from the UTHP/TCAT review (#221).

## docs: position UTHP/TCAT as companion hardware

* **Feature matrix:** new "Companion Hardware: UTHP And TCAT" section — the [UTHP](https://github.com/SystemsCyber/UTHP) / NMFTA [TCAT](https://github.com/nmfta-repo/TCAT) appliance provides bus access, four SocketCAN channels, and truck-specific physical layers (J1708/PLC); CANarchy is the structured, scriptable analysis layer over its captures. MIT attribution for both repos, with the note that their bundled third-party tools carry their own licenses.
* **Cookbook recipe** (`docs/cookbook/analyze-tcat-capture.md`): capture on the appliance (`candump -L can0` or `canarchy capture --candump`), copy off, then triage with `capture-info` → `j1939 summary`/`inventory`/`faults` → the `re` tools, plus multi-channel `j1939 compare` / `re corpus` across `can0`–`can3`. Passive end to end; registered in the cookbook index and MkDocs nav.
* CHANGELOG entry under Documentation.

Docs-only change — no code paths touched.

https://claude.ai/code/session_01Y5vC7jT4k3dQWFL3Vcd5xY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5vC7jT4k3dQWFL3Vcd5xY)_